### PR TITLE
fix: inverted WS permission check

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -264,7 +264,7 @@ export const run = async () => {
         if (!resource) throw httpError(404, `Ressource ${type}/${id} inconnue.`)
         let user = sessionState.user
         if (message.apiKey) user = await readApiKey(db, message.apiKey, type, message.account)
-        return !permissions.can(type, resource, `realtime-${subject}`, user)
+        return permissions.can(type, resource, `realtime-${subject}`, user)
       })
     ])
     // At this stage the server is ready to respond to API requests


### PR DESCRIPTION
This pull request addresses an issue with the WebSocket (WS) permission check logic in the wsServer.start function. The current implementation incorrectly inverts the result of the `permissions.can(...)` check, leading to incorrect permission evaluations.

## Problem:
The `canSubscribe`function, which is the third parameter of `wsServer.start`, is supposed to return true if the user has the necessary permissions. However, the current logic uses a negation operator (!) on the result of `permissions.can(...)`, effectively inverting the permission check. This means that users who should have access are denied, and vice versa.

## Fix:
The fix involves removing the negation operator (!) from the `permissions.can(...)` check within the `canSubscribe` function. This ensures that the function returns true only when the user has the required permissions, aligning with the intended logic.


The bug was discovered during the processing tasks that utilize the waitForJournal function. An error message indicating "Missing Permission" was observed, even though the owner of the processing task was the same as the owner of the dataset.
![image](https://github.com/user-attachments/assets/dc98b46b-a9c4-4b42-b55b-faa6dbccc2a8)

After applying the fix, the permission error was resolved, and the processing tasks completed without any permission-related issues.
![image](https://github.com/user-attachments/assets/ae904295-c0d3-46cf-8957-c985e2f0e886)



