### PR TITLE
feat: integrate catalogs service

### DIFF
--- a/api/config/custom-environment-variables.cjs
+++ b/api/config/custom-environment-variables.cjs
@@ -10,6 +10,7 @@ module.exports = {
   openapiViewerUrl: 'OPENAPI_VIEWER_URL',
   captureUrl: 'CAPTURE_URL',
   privateCaptureUrl: 'PRIVATE_CAPTURE_URL',
+  privateCatalogsUrl: 'PRIVATE_CATALOGS_URL',
   notifyUrl: 'NOTIFY_URL',
   privateNotifyUrl: 'PRIVATE_NOTIFY_URL',
   notifyWSUrl: 'NOTIFY_WS_URL',
@@ -92,6 +93,7 @@ module.exports = {
   secretKeys: {
     identities: 'SECRET_IDENTITIES',
     limits: 'SECRET_LIMITS',
+    catalogs: 'SECRET_CATALOGS',
     notifications: 'SECRET_NOTIFICATIONS',
     masterData: 'SECRET_MASTER_DATA',
     ignoreRateLimiting: 'SECRET_IGNORE_RATE_LIMITING'

--- a/api/config/default.cjs
+++ b/api/config/default.cjs
@@ -13,6 +13,7 @@ module.exports = {
   openapiViewerUrl: 'https://koumoul.com/openapi-viewer/',
   captureUrl: 'http://capture:8080',
   privateCaptureUrl: null,
+  privateCatalogsUrl: null,
   notifyUrl: null,
   privateNotifyUrl: null,
   notifyWSUrl: null,
@@ -154,6 +155,7 @@ module.exports = {
   secretKeys: {
     identities: null,
     limits: null,
+    catalogs: null,
     notifications: null,
     ignoreRateLimiting: null
   },

--- a/api/config/development.cjs
+++ b/api/config/development.cjs
@@ -14,6 +14,7 @@ module.exports = {
   openapiViewerUrl: `http://${host}:5600/openapi-viewer/`,
   captureUrl: `http://${host}:5600/capture`,
   privateCaptureUrl: 'http://localhost:8087',
+  privateCatalogsUrl: `http://${host}:5600/catalogs`,
   notifyUrl: `http://${host}:5600/notify`,
   privateNotifyUrl: 'http://localhost:8088',
   notifyWSUrl: 'ws://localhost:8088',
@@ -35,7 +36,8 @@ module.exports = {
   */
   secretKeys: {
     identities: 'dev_secret',
-    notifications: 'secret-notifications'
+    notifications: 'secret-notifications',
+    catalogs: 'secret-catalogs'
   },
   cache: {
     disabled: true

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -10,6 +10,7 @@ import * as wsServer from '@data-fair/lib-express/ws-server.js'
 import * as wsEmitter from '@data-fair/lib-node/ws-emitter.js'
 import locks from '@data-fair/lib-node/locks.js'
 import * as observe from './misc/utils/observe.js'
+import catalogsPublicationQueue from './misc/utils/catalogs-publication-queue.ts'
 import debug from 'debug'
 import EventEmitter from 'node:events'
 import eventPromise from '@data-fair/lib-utils/event-promise.js'
@@ -34,6 +35,10 @@ export const run = async () => {
 
   // a middleware for performance analysis
   app.use(observe.observeReqMiddleware)
+
+  if (config.privateCatalogsUrl) {
+    await catalogsPublicationQueue.start({ catalogsUrl: config.privateCatalogsUrl, catalogsSecret: config.secretKeys.catalogs })
+  }
 
   if (config.mode.includes('server')) {
     const limits = await import('./misc/utils/limits.js')

--- a/api/src/datasets/service.js
+++ b/api/src/datasets/service.js
@@ -12,6 +12,7 @@ import * as datasetUtils from './utils/index.js'
 import * as restDatasetsUtils from './utils/rest.js'
 import * as esUtils from './es/index.ts'
 import * as webhooks from '../misc/utils/webhooks.js'
+import catalogsPublicationQueue from '../misc/utils/catalogs-publication-queue.ts'
 import { updateStorage } from './utils/storage.js'
 import { dir, filePath, fullFilePath, originalFilePath, attachmentsDir, exportedFilePath, fsyncFile, metadataAttachmentsDir } from './utils/files.ts'
 import { getSchemaBreakingChanges } from './utils/data-schema.js'
@@ -351,6 +352,9 @@ export const deleteDataset = async (app, dataset) => {
 
   await db.collection('datasets').deleteOne({ id: dataset.id })
   await db.collection('journals').deleteOne({ type: 'dataset', id: dataset.id })
+
+  // notify catalogs that the dataset has been deleted
+  catalogsPublicationQueue.deletePublication(dataset.id)
 
   if (!dataset.isVirtual) {
     try {

--- a/api/src/datasets/utils/patch.js
+++ b/api/src/datasets/utils/patch.js
@@ -12,6 +12,7 @@ import * as extensions from './extensions.js'
 import * as schemaUtils from './data-schema.js'
 import * as virtualDatasetsUtils from './virtual.js'
 import * as wsEmitter from '@data-fair/lib-node/ws-emitter.js'
+import catalogsPublicationQueue from '../../misc/utils/catalogs-publication-queue.ts'
 
 /**
  * @param {any} app
@@ -126,13 +127,16 @@ export const preparePatch = async (app, patch, dataset, user, locale, draftValid
     removedRestProps.push({ key: '_updatedByName' })
   }
 
-  // Re-publish publications
+  // Re-publish publications (for catalogs in datafair)
   if (!patch.publications && dataset.publications && dataset.publications.length) {
     for (const p of dataset.publications) {
       if (p.status !== 'deleted') p.status = 'waiting'
     }
     patch.publications = dataset.publications
   }
+
+  // Re-publish publications (with catalogs service)
+  catalogsPublicationQueue.updatePublication(dataset.id)
 
   if (patch.rest) {
     // be extra sure that primaryKeyMode is preserved

--- a/api/src/misc/utils/catalogs-publication-queue.ts
+++ b/api/src/misc/utils/catalogs-publication-queue.ts
@@ -1,0 +1,80 @@
+import { internalError } from '@data-fair/lib-node/observer.js'
+import axios from './axios.js'
+import Debug from 'debug'
+
+const debug = Debug('catalogs-publication-queue')
+
+type CatalogsPublicationQueueOptions = {
+  catalogsUrl: string
+  catalogsSecret: string
+}
+
+type Queue = {
+  update: string[]
+  delete: string[]
+}
+
+export class CatalogsPublicationQueue {
+  _options: CatalogsPublicationQueueOptions | undefined
+  catalogsPublicationQueue: Queue = { update: [], delete: [] }
+  stopped = false
+  currentDrainPromise: Promise<void> | undefined
+
+  options () {
+    if (!this._options) throw new Error('catalogs queue was not initialized')
+    return this._options
+  }
+
+  start = async (options: CatalogsPublicationQueueOptions) => {
+    if (this._options) throw new Error('catalogs queue was already initialized')
+    this._options = options
+    this.loop()
+  }
+
+  stop = async () => {
+    this.stopped = true
+    if (this.currentDrainPromise) await this.currentDrainPromise
+    await this.drain()
+  }
+
+  async loop () {
+    while (!this.stopped) {
+      await new Promise(resolve => setTimeout(resolve, 3000))
+      this.currentDrainPromise = this.drain()
+      await this.currentDrainPromise
+      this.currentDrainPromise = undefined
+    }
+  }
+
+  async drain () {
+    if (this.catalogsPublicationQueue.update.length > 0 || this.catalogsPublicationQueue.delete.length > 0) {
+      const queue = { ...this.catalogsPublicationQueue }
+      this.catalogsPublicationQueue = { update: [], delete: [] }
+      debug('drain', queue.update.length + queue.delete.length, 'publications')
+      try {
+        await axios.post(this.options().catalogsUrl + '/api/datasets', queue, { headers: { 'x-secret-key': this.options().catalogsSecret } })
+      } catch (err: any) {
+        internalError('catalogs-publication-queue', err)
+        // retry later
+        if (err.status >= 500 && (queue.update.length + queue.delete.length < 100)) {
+          this.catalogsPublicationQueue.update = queue.update.concat(this.catalogsPublicationQueue.update)
+          this.catalogsPublicationQueue.delete = queue.delete.concat(this.catalogsPublicationQueue.delete)
+        }
+      }
+    }
+  }
+
+  updatePublication (dataset: string) {
+    if (this.stopped) throw new Error('catalogs queue has been stopped')
+    this.catalogsPublicationQueue.update.push(dataset)
+  }
+
+  deletePublication (dataset: string) {
+    if (this.stopped) throw new Error('catalogs queue has been stopped')
+    this.catalogsPublicationQueue.delete.push(dataset)
+  }
+}
+
+const catalogsPublicationQueue = new CatalogsPublicationQueue()
+
+export default catalogsPublicationQueue

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,21 @@ services:
       - SECRET_SENDMAILS=secret-sendmails
       - PROMETHEUS_ACTIVE=false
 
+  catalogs:
+    profiles:
+      - dev
+    image: ghcr.io/data-fair/catalogs:master
+    network_mode: host
+    depends_on:
+      - mongodb
+    environment:
+      - PORT=8089
+      - OBSERVER_ACTIVE=false
+      - PRIVATE_DIRECTORY_URL=http://localhost:5600/simple-directory
+      - PRIVATE_EVENTS_URL=http://localhost:5600/notify
+      - SECRET_EVENTS=secret-notifications
+      - SECRET_CATALOGS=secret-catalogs
+
   clamav:
     image: clamav/clamav:1.1
     profiles:

--- a/test/resources/nginx.conf
+++ b/test/resources/nginx.conf
@@ -90,6 +90,10 @@ server {
     proxy_pass http://localhost:8088/;
   }
 
+  location /catalogs {
+    proxy_pass http://localhost:8089;
+  }
+
   location /thumbor {
     rewrite  ^/thumbor/(.*) /$1 break;
     proxy_pass http://localhost:8000/;

--- a/ui/nuxt.config.js
+++ b/ui/nuxt.config.js
@@ -118,6 +118,7 @@ const nuxtConfig = {
     captureUrl: config.captureUrl,
     notifyUrl: config.notifyUrl,
     notifyWSUrl: config.notifyWSUrl,
+    catalogsIntegration: !!config.privateCatalogsUrl,
     subscriptionUrl: config.subscriptionUrl,
     theme: config.theme,
     baseAppsCategories: config.baseAppsCategories,

--- a/ui/public/pages/dataset/_id/index.vue
+++ b/ui/public/pages/dataset/_id/index.vue
@@ -290,6 +290,13 @@
                 </v-tab>
 
                 <v-tab
+                  v-if="user.adminMode && env.catalogsIntegration"
+                  href="#share-publications-next"
+                >
+                  <v-icon>mdi-transit-connection</v-icon>&nbsp;&nbsp;{{ $t('catalogs') }}
+                </v-tab>
+
+                <v-tab
                   v-if="dataset.isRest"
                   href="#share-exports"
                 >
@@ -339,6 +346,13 @@
 
                 <v-tab-item value="share-publications">
                   <dataset-catalog-publications />
+                </v-tab-item>
+
+                <v-tab-item value="share-publications-next">
+                  <d-frame
+                    :src="publicationUrl"
+                    sync-params
+                  />
                 </v-tab-item>
 
                 <v-tab-item value="share-exports">
@@ -501,6 +515,7 @@ en:
 
 <script>
 import { mapState, mapActions, mapGetters } from 'vuex'
+import '@data-fair/frame/lib/d-frame.js'
 
 export default {
   middleware: ['auth-required'],
@@ -537,6 +552,9 @@ export default {
     publicationSites () {
       if (!this.dataset || this.env.disablePublicationSites) return []
       return this.$store.getters.ownerPublicationSites(this.dataset.owner)
+    },
+    publicationUrl () {
+      return window.location.origin + '/catalogs/dataset-publications?dataset-id=' + this.dataset.slug
     },
     fileProperty () {
       if (!this.dataset) return

--- a/ui/public/plugins/session.js
+++ b/ui/public/plugins/session.js
@@ -1,6 +1,30 @@
 export default async ({ store, app, env, $vuetify, route, i18n }) => {
   let publicUrl = window.location.origin + env.basePath
   if (publicUrl.endsWith('/')) publicUrl = publicUrl.substr(0, publicUrl.length - 1)
+
+  env.extraNavigationItems = env.extraNavigationItems ?? []
+  env.extraAdminNavigationItems = env.extraAdminNavigationItems ?? []
+
+  if (env.catalogsIntegration) {
+    // env.extraNavigationItems.push({
+    env.extraAdminNavigationItems.push({
+      id: 'catalogs',
+      title: 'Catalogues',
+      can: 'contrib',
+      iframe: '/catalogs/catalogs',
+      basePath: '/catalogs',
+      icon: 'mdi-transit-connection'
+    })
+
+    env.extraAdminNavigationItems.push({
+      id: 'catalogs-plugins',
+      title: 'Plugins - Catalogues',
+      iframe: '/catalogs/admin/plugins',
+      basePath: '/catalogs',
+      icon: 'mdi-transit-connection'
+    })
+  }
+
   store.commit('setAny', {
     env: {
       ...env,


### PR DESCRIPTION
- L'intégration "s'active" si une privateCatalogsUrl est passée en variable d'environnement
- Envoie de webhooks au service catalogs lors de modification et suppression de dataset
- Intègre la page de téléchargement de plugin et la liste des catalogues pour les super admins
- Sur la page d'un jeu de données, pour les super admins, ajout d'un nouvel onglet "catalogues" pour lister les publications du jeu de données et en de nouvelles.