### PR TITLE
fix: old _i management in rest datasets could produce conflicts

### DIFF
--- a/api/src/datasets/service.js
+++ b/api/src/datasets/service.js
@@ -290,6 +290,7 @@ export const createDataset = async (db, es, locale, sessionState, owner, body, f
     if (attachmentsFile) throw httpError(400, 'Un jeu de données éditable ne peut pas être créé avec des pièces jointes')
     dataset.rest = dataset.rest || {}
     dataset.rest.primaryKeyMode = dataset.rest.primaryKeyMode || 'sha256'
+    dataset.rest.indiceMode = dataset.rest.indiceMode || 'timestamp2'
     dataset.schema = dataset.schema || []
     if (dataset.initFrom) {
       // case where we go through the full workers sequence

--- a/api/types/dataset/schema.js
+++ b/api/types/dataset/schema.js
@@ -735,6 +735,10 @@ const datasetProperties = {
       primaryKeyMode: {
         type: 'string',
         enum: ['base64', 'sha256']
+      },
+      indiceMode: {
+        type: 'string',
+        enum: ['timestamp1', 'timestamp2']
       }
     }
   },

--- a/test/rest-datasets.js
+++ b/test/rest-datasets.js
@@ -1215,6 +1215,25 @@ test3,test3`, { headers: { 'content-type': 'text/csv' } })
     return true
   })
 
+  it.skip('Send multiple lines in parallel', async function () {
+    // activate temporarily to check that we manage correctly parallel insertions
+    // it is also necessary to change defaultLimits.apiRate.user.nb to support this number of requests
+
+    const ax = global.ax.dmeadus
+    await ax.post('/api/v1/datasets/restparallel', {
+      isRest: true,
+      // rest: { indiceMode: 'timestamp1' },
+      title: 'restparallel',
+      schema: [{ key: 'attr1', type: 'string' }, { key: 'attr2', type: 'string' }]
+    })
+    const promises = []
+    for (let i = 0; i < 900; i++) {
+      promises.push(ax.post('/api/v1/datasets/restparallel/lines', { attr1: 'val1', attr2: 'val2' }))
+    }
+    const responses = await Promise.all(promises)
+    console.log(responses.map(r => r.status).filter(s => s !== 201))
+  })
+
   it('Send bulk actions as a gzipped CSV', async function () {
     const ax = global.ax.dmeadus
     const res = await ax.post('/api/v1/datasets/restgzcsv', {

--- a/ui/public/pages/admin/info.vue
+++ b/ui/public/pages/admin/info.vue
@@ -63,7 +63,7 @@
       data-fair/openapi-viewer: Documentation des API
       data-fair/events: Gestion des événements/notifications
       data-fair/catalogs: Gestion des catalogues
-
+      data-fair/portals: Portails
   en:
     installed: installed
     available: available
@@ -73,6 +73,7 @@
       data-fair/openapi-viewer: API documentation
       data-fair/events: Events/notifications management
       data-fair/catalogs: Catalogs management
+      data-fair/portals: Portals
   </i18n>
 
 <script>


### PR DESCRIPTION
This was due to the unicity constraint applied to the _i column that was based on a timestamp.

If 2 queries were processed at the same millisecond an error occured that was erroneously returned as a 304 http response.

The fix is to append a random part to the _i value so that it is still ordered and unique (the 2 important properties that must be preserved) but much less likely to result in a conflict in case of parallel insertions. If a conflit still occurs randomly it should now be returned as a 500 error.