### PR TITLE
fix(applications): stabilize config form and modernize base-app import

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -62,7 +62,6 @@
     "fs-extra": "^11.3.0",
     "geojson-vt": "^4.0.2",
     "geolib": "^3.3.4",
-    "html-extractor": "^0.2.2",
     "http-link-header": "^1.1.3",
     "http-terminator": "^3.2.0",
     "i18n": "^0.15.1",

--- a/api/src/applications/router.js
+++ b/api/src/applications/router.js
@@ -498,11 +498,11 @@ router.put('/:applicationId/configuration', readApplication, permissions.middlew
 
 // Configuration draft management
 router.get('/:applicationId/configuration-draft', readApplication, permissions.middleware('writeConfig', 'read'), cacheHeaders.resourceBased(), async (req, res) => {
-  // enrichment skipped: the only consumer is the config editor (vjsf), which strips fields
-  // not in the app schema. Enriching here caused phantom drafts on mount (diff between
-  // server-enriched configDraft and vjsf-normalized editConfig). Preview iframes go
-  // through proxy.js which handles its own refresh for cache-busting.
-  // await refreshConfigDatasetsRefs(req, req.application, true, true)
+  // schemaOnly: the consumer is the config editor (vjsf), which strips fields not in the
+  // app schema. Full enrichment caused phantom drafts on mount (diff between server-enriched
+  // configDraft and vjsf-normalized editConfig). We keep the refresh for schema-declared keys
+  // (e.g. dataset title) but skip extras like slug and non-schema select fields.
+  await refreshConfigDatasetsRefs(req, req.application, true, true, true)
   res.status(200).send(req.application.configurationDraft || req.application.configuration || {})
 })
 router.put('/:applicationId/configuration-draft', readApplication, permissions.middleware('writeConfig', 'write'), async (req, res, next) => {

--- a/api/src/applications/router.js
+++ b/api/src/applications/router.js
@@ -472,7 +472,9 @@ const writeConfig = async (req, res) => {
     { id: req.params.applicationId },
     {
       $unset: {
-        errorMessage: ''
+        errorMessage: '',
+        configurationDraft: '',
+        errorMessageDraft: ''
       },
       $set: {
         configuration: appConfig,
@@ -496,7 +498,11 @@ router.put('/:applicationId/configuration', readApplication, permissions.middlew
 
 // Configuration draft management
 router.get('/:applicationId/configuration-draft', readApplication, permissions.middleware('writeConfig', 'read'), cacheHeaders.resourceBased(), async (req, res) => {
-  await refreshConfigDatasetsRefs(req, req.application, true, true)
+  // enrichment skipped: the only consumer is the config editor (vjsf), which strips fields
+  // not in the app schema. Enriching here caused phantom drafts on mount (diff between
+  // server-enriched configDraft and vjsf-normalized editConfig). Preview iframes go
+  // through proxy.js which handles its own refresh for cache-busting.
+  // await refreshConfigDatasetsRefs(req, req.application, true, true)
   res.status(200).send(req.application.configurationDraft || req.application.configuration || {})
 })
 router.put('/:applicationId/configuration-draft', readApplication, permissions.middleware('writeConfig', 'write'), async (req, res, next) => {

--- a/api/src/applications/utils.ts
+++ b/api/src/applications/utils.ts
@@ -60,7 +60,7 @@ const memoizedGetFreshDataset = memoize(async (id) => {
   maxAge: 1000 * 60, // 1 minute
 })
 
-export const refreshConfigDatasetsRefs = async (req: Request, application: Application, draft: boolean, checkWithPersonalSession = false) => {
+export const refreshConfigDatasetsRefs = async (req: Request, application: Application, draft: boolean, checkWithPersonalSession = false, schemaOnly = false) => {
   const publicBaseUrl = req.publicBaseUrl
 
   const configuration = (draft ? (application.configurationDraft || application.configuration) : application.configuration) || {}
@@ -80,11 +80,16 @@ export const refreshConfigDatasetsRefs = async (req: Request, application: Appli
         continue
       }
       let refreshKeys = Object.keys(dataset)
-      refreshKeys.push('finalizedAt')
-      refreshKeys.push('slug')
-
       const datasetFilters = application.baseApp?.datasetsFilters?.[i] ?? {}
-      if (datasetFilters.select) refreshKeys = refreshKeys.concat(datasetFilters.select)
+      if (schemaOnly) {
+        // only refresh keys declared by the app config schema, so the payload matches
+        // what vjsf-normalized editConfig will contain and doesn't trigger phantom drafts
+        if (datasetFilters.properties) refreshKeys = refreshKeys.concat(Object.keys(datasetFilters.properties))
+      } else {
+        refreshKeys.push('finalizedAt')
+        refreshKeys.push('slug')
+        if (datasetFilters.select) refreshKeys = refreshKeys.concat(datasetFilters.select)
+      }
 
       const freshDataset = tolerateStale
         ? clone(await memoizedGetFreshDataset(dataset.id))

--- a/api/src/base-applications/router.ts
+++ b/api/src/base-applications/router.ts
@@ -21,7 +21,7 @@ router.post('', async (req, res) => {
     return
   }
   const baseApp = config.applications.find(a => a.url === req.body.url) || req.body
-  const fullBaseApp = await initBaseApp(baseApp)
+  const fullBaseApp = await initBaseApp(baseApp, req.getLocale())
   await syncBaseApp(fullBaseApp)
   res.send(fullBaseApp)
 })

--- a/api/src/base-applications/service.ts
+++ b/api/src/base-applications/service.ts
@@ -3,13 +3,63 @@ import mongo from '#mongo'
 import axios from '../misc/utils/axios.js'
 import jsonRefs from 'json-refs'
 import i18n from 'i18n'
-import Extractor from 'html-extractor'
+import * as parse5 from 'parse5'
 import slug from 'slugify'
 import { internalError } from '@data-fair/lib-node/observer.js'
+import { httpError } from '@data-fair/lib-utils/http-errors.js'
 import { clean, prepareQuery, getFragmentFetchUrl } from './operations.ts'
 import type { BaseApp } from '#types'
 
-const htmlExtractor = new Extractor()
+// Meta field names that may appear multiple times with a lang attribute.
+// For these we pick the variant matching the requester's locale, with fallback.
+const langAwareMetaNames = ['description', 'keywords']
+
+// Extract a flat meta map from an application's index.html, respecting
+// `lang` attributes on <title> and lang-aware meta tags.
+// Selection order for lang-aware tags:
+//   1. tag with lang === locale
+//   2. tag with lang === defaultLocale
+//   3. first tag (with or without lang)
+function extractHeadMeta (html: string, locale: string, defaultLocale: string): Record<string, string> {
+  const meta: Record<string, string> = {}
+  const doc = parse5.parse(html) as any
+  const htmlNode = doc.childNodes?.find((c: any) => c.tagName === 'html')
+  const head = htmlNode?.childNodes?.find((c: any) => c.tagName === 'head')
+  if (!head) return meta
+
+  const attr = (node: any, name: string): string | undefined =>
+    node.attrs?.find((a: any) => a.name === name)?.value
+
+  const titles: { lang?: string, text: string }[] = []
+  const metasByName = new Map<string, { lang?: string, content?: string }[]>()
+
+  for (const node of head.childNodes as any[]) {
+    if (node.tagName === 'title') {
+      const text = node.childNodes?.find((c: any) => c.nodeName === '#text')?.value ?? ''
+      titles.push({ lang: attr(node, 'lang'), text })
+    } else if (node.tagName === 'meta') {
+      const name = attr(node, 'name')
+      if (!name) continue
+      if (!metasByName.has(name)) metasByName.set(name, [])
+      metasByName.get(name)!.push({ lang: attr(node, 'lang'), content: attr(node, 'content') })
+    }
+  }
+
+  const pick = <T extends { lang?: string }>(items: T[]): T | undefined =>
+    items.find(i => i.lang === locale) ??
+    items.find(i => i.lang === defaultLocale) ??
+    items[0]
+
+  const pickedTitle = pick(titles)
+  if (pickedTitle) meta.title = pickedTitle.text
+
+  for (const [name, tags] of metasByName) {
+    const picked = langAwareMetaNames.includes(name) ? pick(tags) : tags[0]
+    if (picked?.content != null) meta[name] = picked.content
+  }
+
+  return meta
+}
 
 // Fill the collection using the default base applications from config
 // and cleanup non-public apps that are not used anywhere
@@ -35,13 +85,23 @@ async function failSafeInitBaseApp (app) {
   }
 }
 
-// Attempts to init an application's description from a URL
-export async function initBaseApp (app) {
+// Attempts to init an application's description from a URL.
+// `locale` is the locale of the admin triggering the import — used to pick
+// the right variant when the app declares multiple <title>/<meta> tags with
+// a `lang` attribute. Falls back to the API's default locale when absent.
+export async function initBaseApp (app, locale?: string) {
   if (app.url[app.url.length - 1] !== '/') app.url += '/'
-  const html = (await axios.get(app.url + 'index.html')).data
-  const data: { meta: Record<string, string> } = await new Promise((resolve, reject) => htmlExtractor.extract(html, (err, data) => err ? reject(err) : resolve(data)))
+  const defaultLocale = config.i18n.defaultLocale
+  const effectiveLocale = locale || defaultLocale
+  let html: string
+  try {
+    html = (await axios.get(app.url + 'index.html')).data
+  } catch (err) {
+    throw httpError(400, i18n.__({ phrase: 'errors.noAppAtUrl', locale: effectiveLocale }, { url: app.url }))
+  }
+  const meta = extractHeadMeta(html, effectiveLocale, defaultLocale)
   const patch: Partial<BaseApp> = {
-    meta: data.meta,
+    meta,
     id: slug(app.url, { lower: true }),
     updatedAt: new Date().toISOString(),
     ...app
@@ -76,7 +136,7 @@ export async function initBaseApp (app) {
   }
 
   if (!patch.hasConfigSchema && !(patch.meta && patch.meta['application-name'])) {
-    throw new Error(i18n.__({ phrase: 'errors.noAppAtUrl', locale: config.i18n.defaultLocale }, { url: app.url }))
+    throw httpError(400, i18n.__({ phrase: 'errors.noAppAtUrl', locale: effectiveLocale }, { url: app.url }))
   }
 
   patch.datasetsFilters = patch.datasetsFilters || []

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,7 +111,6 @@
         "fs-extra": "^11.3.0",
         "geojson-vt": "^4.0.2",
         "geolib": "^3.3.4",
-        "html-extractor": "^0.2.2",
         "http-link-header": "^1.1.3",
         "http-terminator": "^3.2.0",
         "i18n": "^0.15.1",
@@ -14155,130 +14154,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/html-extractor": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/html-extractor/-/html-extractor-0.2.2.tgz",
-      "integrity": "sha512-SGxMJTfgJRcl8T2FFzSXfMc+sBXGIlJkzzOzJv/qmv0D7mJh5ObrR7ayIo8OM70avrjQZRFypq9LnvcIWQunjA==",
-      "dependencies": {
-        "htmlparser2": "3.9.x",
-        "lodash": "4.x"
-      },
-      "engines": {
-        "node": ">= 0.8.10"
-      }
-    },
-    "node_modules/html-extractor/node_modules/dom-serializer": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/html-extractor/node_modules/dom-serializer/node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/html-extractor/node_modules/dom-serializer/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/html-extractor/node_modules/domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/html-extractor/node_modules/domhandler": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/html-extractor/node_modules/domutils": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
-    },
-    "node_modules/html-extractor/node_modules/entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/html-extractor/node_modules/htmlparser2": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-      "integrity": "sha512-RSOwLNCnCLDRB9XpSfCzsLzzX8COezhJ3D4kRBNWh0NC/facp1hAMmM8zD7kC01My8vD6lGEbPMlbRW/EwGK5w==",
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^1.3.0",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/html-extractor/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
-    "node_modules/html-extractor/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/html-extractor/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/html-extractor/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/htmlparser2": {

--- a/tests/features/embed/settings.e2e.spec.ts
+++ b/tests/features/embed/settings.e2e.spec.ts
@@ -8,7 +8,7 @@ test.describe('embed settings pages', () => {
 
   test('displays api-keys settings page', async ({ page, goToWithAuth }) => {
     await goToWithAuth('/data-fair/embed/settings/user/test_user1/api-keys', 'test_user1')
-    await expect(page.locator('.bg-surface')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('button', { name: 'Ajouter une clé d\'API' })).toBeVisible({ timeout: 10000 })
   })
 
   test('displays settings with pre-seeded topics', async ({ page, goToWithAuth }) => {

--- a/tests/features/ui/application-pages.e2e.spec.ts
+++ b/tests/features/ui/application-pages.e2e.spec.ts
@@ -40,4 +40,21 @@ test.describe('application detail pages', () => {
     await goToWithAuth(`/data-fair/application/${applicationId}/api-doc`, 'test_user1')
     await expect(page.locator('d-frame').first()).toBeAttached({ timeout: 10000 })
   })
+
+  test('config page loads when returning without refresh', async ({ page, goToWithAuth }) => {
+    test.skip(!applicationId, 'No base application available')
+    // Navigate to config page
+    await goToWithAuth(`/data-fair/application/${applicationId}/config`, 'test_user1')
+    // Wait for d-frame to load
+    await expect(page.locator('d-frame').first()).toBeAttached({ timeout: 10000 })
+
+    // Navigate back to the main application page
+    await page.goto(`${page.url().split('/config')[0]}`)
+    await expect(page.locator('#metadata')).toBeVisible({ timeout: 10000 })
+
+    // Navigate back to config WITHOUT refresh - this is the key test
+    // The d-frame should still load properly (bug would cause form to disappear)
+    await page.goto(`/data-fair/application/${applicationId}/config`)
+    await expect(page.locator('d-frame').first()).toBeAttached({ timeout: 10000 })
+  })
 })

--- a/tests/support/workers.ts
+++ b/tests/support/workers.ts
@@ -30,7 +30,7 @@ export const closeSharedWs = () => {
 export const waitForFinalize = async (
   ax: AxiosInstance,
   datasetId: string,
-  timeout = 4000
+  timeout = 15000
 ): Promise<any> => {
   try {
     await getSharedWs().waitForJournal(datasetId, 'finalize-end', timeout)
@@ -54,7 +54,7 @@ export const doAndWaitForFinalize = async (
   ax: AxiosInstance,
   datasetId: string,
   action: () => Promise<any>,
-  timeout = 4000
+  timeout = 15000
 ): Promise<any> => {
   /* const sub = await subscribeJournal(datasetId)
   await action()
@@ -78,7 +78,7 @@ export const doAndWaitForFinalize = async (
 export const waitForJournalEvent = async (
   datasetId: string,
   eventType: string,
-  timeout = 4000
+  timeout = 15000
 ): Promise<any> => {
   return getSharedWs().waitForJournal(datasetId, eventType, timeout)
 }
@@ -92,7 +92,7 @@ export const waitForDatasetError = async (
   datasetId: string,
   opts?: { timeout?: number, draft?: boolean }
 ): Promise<any> => {
-  const timeout = opts?.timeout ?? 4000
+  const timeout = opts?.timeout ?? 15000
   const params = opts?.draft ? { draft: true } : undefined
   const ws = getSharedWs()
   await ws.waitFor(`datasets/${datasetId}/journal`, (e: any) => e.type === 'error', timeout)
@@ -116,7 +116,7 @@ export const sendDataset = async (
   const length = form.getLengthSync()
   const headers = { 'Content-Length': length, ...form.getHeaders() }
   const res = await ax.post('/api/v1/datasets', form, { ...opts, headers })
-  const timeout = length > 20000 ? 30000 : 4000
+  const timeout = length > 20000 ? 30000 : 15000
   return waitForFinalize(ax, res.data.id, timeout)
 }
 

--- a/ui/src/components/application/application-config.vue
+++ b/ui/src/components/application/application-config.vue
@@ -106,7 +106,7 @@
               />
               <v-btn
                 v-if="editConfig"
-                :disabled="hasModification || !hasDraft || !!application.errorMessageDraft"
+                :disabled="hasModification || !hasDraft || !!application?.errorMessageDraft"
                 color="accent"
                 @click="validateDraft.execute()"
               >
@@ -150,6 +150,7 @@ import { v2compat } from '@koumoul/vjsf/compat/v2'
 import { clone } from '@json-layout/core'
 import { type AppConfig } from '#api/types'
 import { setProperty } from 'dot-prop'
+import equal from 'fast-deep-equal'
 import Debug from 'debug'
 
 const debug = Debug('application-config')
@@ -163,7 +164,7 @@ const { roDataset } = defineProps({
   roDataset: { type: Boolean, default: false }
 })
 
-const { application, applicationLink, patch, canWriteConfig, configFetch, configDraftFetch, configDraft, writeConfig, writeConfigDraft, cancelConfigDraft, baseAppDraft } = useApplicationStore()
+const { application, applicationLink, patch, canWriteConfig, configFetch, configDraftFetch, configDraft, writeConfig, writeConfigDraft, cancelConfigDraft, baseAppDraft, schemaFetch } = useApplicationStore()
 const { availableVersions } = useApplicationVersions()
 useApplicationWatch('draft-error')
 
@@ -188,10 +189,10 @@ const editConfig = ref<AppConfig | null>(null)
 watch(configDraft, (config) => {
   debug('update editConfig from stored draft', toRaw(editConfig.value) === toRaw(config))
   editConfig.value = config
-})
+}, { immediate: true })
 // return true if some local changes were not yet synced with the server
 const hasModification = computed(() => {
-  if (toRaw(configDraft.value) !== toRaw(editConfig.value)) return true // shallow comparison is ok as vjsf returns immutable objects
+  if (!equal(toRaw(configDraft.value), toRaw(editConfig.value))) return true
   if (application.value?.urlDraft && editUrl.value !== application.value.urlDraft) return true
   return false
 })
@@ -199,18 +200,6 @@ const hasDraft = computed(() => application.value?.status === 'configured-draft'
 
 const showForm = ref(false)
 const draftSchema = ref<any>()
-const schemaUrl = computed(() => editUrl.value && (editUrl.value + 'config-schema.json'))
-const schemaFetch = useFetch<any>(schemaUrl)
-watch(schemaFetch.data, (schema) => {
-  if (schema) {
-    if (typeof schema !== 'object') {
-      sendUiNotif({ type: 'error', msg: 'Schema fetched is not a valid JSON' })
-    } else {
-      draftSchema.value = completeSchema(clone(schema))
-      showForm.value = true
-    }
-  }
-})
 
 const completeSchema = (schema: any) => {
   debug('complete schema for vjsf')
@@ -250,6 +239,18 @@ const completeSchema = (schema: any) => {
   }
 }
 
+if (!schemaFetch.initialized.value) schemaFetch.refresh()
+watch(schemaFetch.data, (schema) => {
+  if (schema) {
+    if (typeof schema !== 'object') {
+      sendUiNotif({ type: 'error', msg: 'Schema fetched is not a valid JSON' })
+    } else {
+      draftSchema.value = completeSchema(clone(schema))
+      showForm.value = true
+    }
+  }
+}, { immediate: true })
+
 const draftPreviewInc = ref(0)
 const formValid = ref(false)
 const showFullOrg = ref(false)
@@ -278,7 +279,7 @@ const vjsfOptions = computed<VjsfOptions | null>(() => {
 // TODO: editUrl is not saved yet as urlDraft ?
 const saveDraft = async () => {
   if (!canWriteConfig.value || !formValid.value || !editConfig.value) return
-  if (toRaw(configDraft.value) === toRaw(editConfig.value)) return
+  if (equal(toRaw(configDraft.value), toRaw(editConfig.value))) return
   const wasInError = !!application.value?.errorMessageDraft
   await writeConfigDraft(editConfig.value)
   if (baseAppDraft.value?.meta?.['df:sync-config'] === 'true') {

--- a/ui/src/components/application/application-facets.vue
+++ b/ui/src/components/application/application-facets.vue
@@ -186,7 +186,7 @@ const requestedPublicationSitesItems = facetToItems('requestedPublicationSites',
 fr:
   owner: Propriétaire
   noDepartment: Aucun département
-  baseApplication: Type d'application
+  baseApplication: Modèle d'application
   visibility: Visibilité
   topics: Thématiques
   publicationSites: Sites de publication
@@ -198,7 +198,7 @@ fr:
 en:
   owner: Owner
   noDepartment: No department
-  baseApplication: Application type
+  baseApplication: Base application
   visibility: Visibility
   topics: Topics
   publicationSites: Publication sites

--- a/ui/src/components/application/application-list-item.vue
+++ b/ui/src/components/application/application-list-item.vue
@@ -3,53 +3,103 @@
     :to="noLink ? undefined : `/application/${application.id}`"
     lines="two"
   >
+    <template
+      v-if="application.visibility"
+      #prepend
+    >
+      <resource-visibility
+        :visibility="application.visibility"
+        class="mr-2"
+        size="small"
+      />
+    </template>
     <v-list-item-title :title="application.title || application.id">
       {{ application.title || application.id }}
-      <v-chip
+      <v-tooltip
         v-if="application.status === 'error'"
-        size="x-small"
-        color="error"
-        variant="tonal"
-        class="ml-1"
+        :text="t('error')"
       >
-        {{ t('error') }}
-      </v-chip>
+        <template #activator="{ props: tooltipProps }">
+          <v-icon
+            v-bind="tooltipProps"
+            :icon="mdiAlert"
+            color="error"
+            size="small"
+            class="ml-1"
+          />
+        </template>
+      </v-tooltip>
     </v-list-item-title>
-    <v-list-item-subtitle>
-      <span v-if="(showAll || !!(application.owner?.department && !session.state.account?.department)) && application.owner">{{ ownerName }} · </span>
-      <span v-if="application.status">{{ t('status.' + application.status) }} · </span>
-      <span v-if="application.updatedAt">{{ formatDate(application.updatedAt) }}</span>
+    <v-list-item-subtitle v-if="subtitleParts.length">
+      <template
+        v-for="(part, i) in subtitleParts"
+        :key="i"
+      >
+        <span v-if="i > 0"> · </span>
+        <v-icon
+          v-if="part.icon"
+          :icon="part.icon"
+          size="small"
+          class="mr-1"
+        />
+        <span>{{ part.text }}</span>
+      </template>
     </v-list-item-subtitle>
     <template
-      v-if="showTopics && application.topics?.length"
+      v-if="showAppend"
       #append
     >
-      <topic-chips :topics="application.topics" />
+      <div class="d-flex align-center ga-2">
+        <topic-chips
+          v-if="showTopics && application.topics?.length"
+          :topics="application.topics"
+        />
+        <owner-avatar
+          v-if="showOwner && application.owner"
+          :owner="application.owner"
+          :omit-owner-name="!showAll"
+        />
+      </div>
     </template>
   </v-list-item>
 </template>
 
 <script setup lang="ts">
 import type { Application } from '#api/types'
+import { mdiAlert } from '@mdi/js'
+import ownerAvatar from '@data-fair/lib-vuetify/owner-avatar.vue'
+
+type ListedApplication = Partial<Application> & Pick<Application, 'id'> & {
+  title?: string
+  visibility?: 'public' | 'private' | 'protected'
+}
 
 const { t, locale } = useI18n()
-const session = useSession()
 const showAll = useBooleanSearchParam('showAll')
 
 const props = withDefaults(defineProps<{
-  application: Application
+  application: ListedApplication
   showTopics?: boolean
+  showOwner?: boolean
   noLink?: boolean
 }>(), {
   showTopics: true,
-  noLink: false,
+  showOwner: false,
 })
 
-const ownerName = computed(() => {
-  const o = props.application.owner
-  if (!o) return ''
-  return o.departmentName || o.name || o.id
+const subtitleParts = computed(() => {
+  const parts: { icon?: string, text: string }[] = []
+  if (props.application.status && props.application.status !== 'configured') {
+    parts.push({ text: t('status.' + props.application.status) })
+  }
+  if (props.application.updatedAt) parts.push({ text: formatDate(props.application.updatedAt) })
+  return parts
 })
+
+const showAppend = computed(() =>
+  (props.showTopics && !!props.application.topics?.length) ||
+  (props.showOwner && !!props.application.owner)
+)
 
 const formatDate = (dateStr: string) => {
   return new Date(dateStr).toLocaleDateString(locale.value)
@@ -58,17 +108,21 @@ const formatDate = (dateStr: string) => {
 
 <i18n lang="yaml">
 fr:
-  error: Erreur
+  error: En erreur
   status:
+    created: Créée
     running: En cours
     error: Erreur
     stopped: Arrêté
     configured: Configuré
+    configured-draft: Brouillon
 en:
-  error: Error
+  error: Error status
   status:
+    created: Created
     running: Running
     error: Error
     stopped: Stopped
     configured: Configured
+    configured-draft: Draft
 </i18n>

--- a/ui/src/composables/application/application-store.ts
+++ b/ui/src/composables/application/application-store.ts
@@ -47,7 +47,11 @@ const createApplicationStore = (id: string) => {
       }
     })
     config.value = newConfig
-    if (application.value) application.value.status = 'configured'
+    configDraft.value = newConfig
+    if (application.value) {
+      application.value.status = 'configured'
+      delete application.value.errorMessageDraft
+    }
   }
 
   const configDraftFetch = useFetch<AppConfig>($apiPath + `/applications/${id}/configuration-draft`, { immediate: false })
@@ -73,6 +77,12 @@ const createApplicationStore = (id: string) => {
     configDraft.value = config.value
     if (application.value) application.value.status = 'configured'
   }
+
+  const schemaUrl = computed(() => {
+    const url = application.value?.urlDraft || application.value?.url
+    return url ? (url + 'config-schema.json') : null
+  })
+  const schemaFetch = useFetch<any>(() => schemaUrl.value, { immediate: false })
 
   const baseAppFetch = useFetch<BaseApp>($apiPath + `/applications/${id}/base-application`, { immediate: false })
   const privateAccess = computed(() => application.value && `${application.value.owner.type}:${application.value.owner.id}`)
@@ -179,6 +189,7 @@ const createApplicationStore = (id: string) => {
     configDraft,
     writeConfigDraft,
     cancelConfigDraft,
+    schemaFetch,
     baseAppFetch,
     baseAppDraft,
     baseAppsFetch,

--- a/ui/src/layouts/embed.vue
+++ b/ui/src/layouts/embed.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-main>
+  <v-main scrollable>
     <slot />
   </v-main>
 </template>

--- a/ui/src/pages/admin/base-apps.vue
+++ b/ui/src/pages/admin/base-apps.vue
@@ -276,6 +276,7 @@ const applyPatch = useAsyncAction(async (baseApp: BaseApp, patch: BaseAppPatch) 
 const urlToAdd = ref('')
 const add = useAsyncAction(async () => {
   await $fetch('base-applications', { method: 'POST', body: { url: urlToAdd.value } })
+  urlToAdd.value = ''
   baseAppsFetch.refresh()
 })
 </script>

--- a/ui/src/pages/admin/base-apps.vue
+++ b/ui/src/pages/admin/base-apps.vue
@@ -7,32 +7,31 @@
       <v-col
         cols="12"
         sm="6"
-        md="4"
-      >
-        <v-text-field
-          v-model="q"
-          name="q"
-          :label="t('search')"
-          hide-details
-          variant="outlined"
-          density="compact"
-          :append-icon="mdiMagnify"
-          @keypress.enter="baseAppsFetch.refresh()"
-        />
-      </v-col>
-    </v-row>
-
-    <v-row>
-      <v-col
-        cols="12"
-        sm="6"
-        md="4"
       >
         <v-text-field
           v-model="urlToAdd"
           :label="t('add')"
           :placeholder="t('addPlaceholder')"
+          variant="outlined"
+          density="compact"
+          hide-details
           @keypress.enter="add.execute()"
+        />
+      </v-col>
+
+      <v-col
+        cols="12"
+        sm="6"
+      >
+        <v-text-field
+          v-model="q"
+          :append-inner-icon="mdiMagnify"
+          :label="t('search')"
+          variant="outlined"
+          density="compact"
+          hide-details
+          clearable
+          @keypress.enter="baseAppsFetch.refresh()"
         />
       </v-col>
     </v-row>

--- a/ui/src/pages/embed/settings/[type]/[id]/api-keys.vue
+++ b/ui/src/pages/embed/settings/[type]/[id]/api-keys.vue
@@ -1,8 +1,5 @@
 <template>
-  <v-container
-    data-iframe-height
-    class="bg-surface"
-  >
+  <v-container data-iframe-height>
     <settings-api-keys
       v-if="settings"
       v-model="settings.apiKeys"

--- a/ui/src/pages/embed/settings/[type]/[id]/datasets-metadata.vue
+++ b/ui/src/pages/embed/settings/[type]/[id]/datasets-metadata.vue
@@ -1,7 +1,5 @@
 <template>
-  <v-container
-    data-iframe-height
-  >
+  <v-container data-iframe-height>
     <settings-datasets-metadata
       v-if="settings"
       v-model="settings.datasetsMetadata"

--- a/ui/src/pages/embed/settings/[type]/[id]/licenses.vue
+++ b/ui/src/pages/embed/settings/[type]/[id]/licenses.vue
@@ -1,7 +1,5 @@
 <template>
-  <v-container
-    data-iframe-height
-  >
+  <v-container data-iframe-height>
     <settings-licenses
       v-if="settings"
       v-model="settings.licenses"

--- a/ui/src/pages/embed/settings/[type]/[id]/topics.vue
+++ b/ui/src/pages/embed/settings/[type]/[id]/topics.vue
@@ -1,7 +1,5 @@
 <template>
-  <v-container
-    data-iframe-height
-  >
+  <v-container data-iframe-height>
     <settings-topics
       v-if="settings"
       v-model="settings.topics"

--- a/ui/src/pages/embed/settings/[type]/[id]/webhooks.vue
+++ b/ui/src/pages/embed/settings/[type]/[id]/webhooks.vue
@@ -1,7 +1,5 @@
 <template>
-  <v-container
-    data-iframe-height
-  >
+  <v-container data-iframe-height>
     <settings-webhooks
       v-if="settings"
       v-model="settings.webhooks"

--- a/ui/src/pages/new-application.vue
+++ b/ui/src/pages/new-application.vue
@@ -90,7 +90,7 @@
             <v-autocomplete
               v-model="copyApp"
               v-model:search="copySearch"
-              :loading="appSearchLoading"
+              :loading="searchApps.loading.value"
               :label="t('searchApp')"
               :placeholder="t('search')"
               :items="appSearchResults"
@@ -105,7 +105,16 @@
               hide-details
               clearable
               @update:model-value="onCopyAppSelected"
-            />
+            >
+              <template #item="{ props: itemProps, item }">
+                <application-list-item
+                  v-bind="{ ...itemProps, title: undefined }"
+                  :application="(item as any)"
+                  :show-topics="true"
+                  :no-link="true"
+                />
+              </template>
+            </v-autocomplete>
           </template>
 
           <!-- Base app mode -->
@@ -255,6 +264,8 @@
 
 <script setup lang="ts">
 import { mdiApps, mdiContentCopy, mdiSecurity, mdiShape, mdiTextBox } from '@mdi/js'
+import { withQuery } from 'ufo'
+import { watchDebounced } from '@vueuse/core'
 import { $apiPath, $uiConfig } from '~/context'
 import { useBreadcrumbs } from '~/composables/layout/use-breadcrumbs'
 import { DfAgentChatAction } from '@data-fair/lib-vuetify-agents'
@@ -336,26 +347,33 @@ onMounted(async () => {
 const copyApp = ref<any>(null)
 const copySearch = ref('')
 const appSearchResults = ref<any[]>([])
-const appSearchLoading = ref(false)
-let searchTimeout: ReturnType<typeof setTimeout> | null = null
 
-watch(copySearch, (q) => {
-  if (searchTimeout) clearTimeout(searchTimeout)
-  if (!q || q.length < 2) { appSearchResults.value = []; return }
-  searchTimeout = setTimeout(() => {
-    searchApplications()
-  }, 300)
+const copyAppsUrl = computed(() => {
+  if (creationType.value !== 'copy') return null
+  const query: Record<string, any> = {
+    size: 20,
+    select: 'id,title,url,status,updatedAt,topics,-userPermissions,-links',
+    owner: ownerFilter.value
+  }
+  if (copySearch.value) query.q = copySearch.value
+  return withQuery(`${$apiPath}/applications`, query)
 })
 
-async function searchApplications () {
-  appSearchLoading.value = true
-  try {
-    const data = await $fetch<{ results: any[] }>(`${$apiPath}/applications?q=${encodeURIComponent(copySearch.value)}&size=20&select=id,title,url,-userPermissions,-links,-owner&owner=${ownerFilter.value}`)
-    appSearchResults.value = data.results
-  } finally {
-    appSearchLoading.value = false
+const searchApps = useAsyncAction(async () => {
+  if (!copyAppsUrl.value) {
+    appSearchResults.value = []
+    return
   }
-}
+  const items: any[] = []
+  if (copyApp.value) items.push(copyApp.value)
+  const data = await $fetch<{ results: any[] }>(copyAppsUrl.value)
+  for (const r of data.results) {
+    if (!items.find(i => i.id === r.id)) items.push(r)
+  }
+  appSearchResults.value = items
+})
+
+watchDebounced(copyAppsUrl, () => searchApps.execute(), { immediate: true, debounce: 250 })
 
 function onCopyAppSelected (app: any) {
   if (!app) return


### PR DESCRIPTION
## Summary
- Fix the application config form disappearing (or showing a phantom draft) when navigating back to `/config` without a full page refresh, and add an e2e test guarding the regression.
- Rewrite the base-application import with `parse5` (replaces the abandoned `html-extractor`), pick the right `<title>` / `<meta>` variant based on the caller locale, and return a proper 400 when the remote `index.html` is unreachable.
- Tidy the admin base-apps page: add + search fields on the same row with matching density/variant, and rename the "Application type" facet to "Modèle d'application" to match the rest of the UI.
- Restore the "copy from existing application" selector on the new-application page (the pre-selected app was lost after refactor) and enrich the application list item with visibility prepend, owner avatar, a cleaner error indicator, and a draft status.

## Details
The config form bug was a combination of three issues: `GET /configuration-draft` was enriching dataset refs server-side and diverging from the vjsf-normalized `editConfig` (spurious "has modification" state), the `config-schema` fetch was racing between the component and the store on every mount, and `writeConfig` left `configurationDraft` / `errorMessageDraft` dangling so the next mount restored stale state. Draft diffing now uses deep equality since vjsf no longer guarantees referential immutability.

The copy-application selector was rewritten to use `useAsyncAction` + `watchDebounced` + `withQuery` so the currently-selected app stays in the items list after a new search, and each entry now renders via `application-list-item.vue` for a richer display (title, status, date, topics).