### PR TITLE
fix(ui): back-office navigation on site domains

### DIFF
--- a/ui/src/components/layout/layout-navigation-left.vue
+++ b/ui/src/components/layout/layout-navigation-left.vue
@@ -10,12 +10,13 @@
       open-strategy="multiple"
       nav
     >
-      <!-- Portal home link (when not main site) -->
+      <!-- Portal home link (when the current site has a configured title) -->
       <v-list-item
-        v-if="site && site.main === false"
+        v-if="siteTitle"
         href="/"
         :prepend-icon="mdiHome"
         :title="t('homePortal')"
+        :subtitle="siteTitle"
       />
       <!-- Dashboard -->
       <v-list-item
@@ -86,9 +87,13 @@ import {
 const drawer = defineModel<boolean>({ required: true })
 const { t, locale } = useI18n()
 const route = useRoute()
-const { site } = useSessionAuthenticated()
+const { fullSite } = useSessionAuthenticated()
 const { canAdmin, missingSubscription } = usePermissions()
 const { navigationGroups } = useNavigationItems({ t, locale })
+
+// FullSiteInfo type in @data-fair/lib-vue/session.d.ts is incomplete — it omits
+// fields like `title` that are present at runtime on window.__PUBLIC_SITE_INFO.
+const siteTitle = computed(() => (fullSite.value as { title?: string } | null)?.title)
 
 // Auto-expand the group containing the current route
 const activeGroup = computed(() => {

--- a/ui/src/components/layout/layout-navigation-top.vue
+++ b/ui/src/components/layout/layout-navigation-top.vue
@@ -41,8 +41,9 @@
       <template #item="{ item }">
         <v-breadcrumbs-item
           :to="item.to"
-          :disabled="!item.to"
-          :class="item.to ? 'text-primary' : undefined"
+          :href="item.href"
+          :disabled="!item.to && !item.href"
+          :class="(item.to || item.href) ? 'text-primary' : undefined"
           style="opacity: 0.9;"
         >
           {{ item.title }}
@@ -83,7 +84,7 @@
 </template>
 
 <script lang="ts" setup>
-import type { createBreadcrumbs } from '~/composables/layout/use-breadcrumbs'
+import type { createBreadcrumbs, BreadcrumbItem } from '~/composables/layout/use-breadcrumbs'
 import DfNotificationQueue from '@data-fair/lib-vuetify-events/DfNotificationQueue.vue'
 import DfPersonalMenu from '@data-fair/lib-vuetify/personal-menu.vue'
 import DfThemeSwitcher from '@data-fair/lib-vuetify/theme-switcher.vue'
@@ -104,10 +105,14 @@ const props = defineProps<{
 
 const drawer = defineModel<boolean>('drawer', { required: true })
 const { t } = useI18n()
-const { user } = useSession()
+const { user, fullSite } = useSession()
 const { missingSubscription } = usePermissions()
 const { mdAndUp, lgAndUp } = useDisplay()
 const route = useRoute()
+
+// FullSiteInfo type in @data-fair/lib-vue/session.d.ts is incomplete — it omits
+// fields like `title` that are present at runtime on window.__PUBLIC_SITE_INFO.
+const siteTitle = computed(() => (fullSite.value as { title?: string } | null)?.title)
 
 const showBreadcrumbs = computed(() => {
   if (!user.value) return false
@@ -122,12 +127,23 @@ function truncate (str: string, maxLen: number): string {
   return str.length > maxLen ? str.slice(0, maxLen) + '…' : str
 }
 
-const breadcrumbItems = computed(() => {
+type BreadcrumbRenderItem = {
+  title: string
+  to?: BreadcrumbItem['to']
+  href?: string
+}
+
+const breadcrumbItems = computed<BreadcrumbRenderItem[]>(() => {
   if (!props.breadcrumbs) return []
-  return props.breadcrumbs.items.value.map(item => ({
+  const items: BreadcrumbRenderItem[] = props.breadcrumbs.items.value.map(item => ({
     title: truncate(item.text, 50),
     to: item.to
   }))
+  if (siteTitle.value) {
+    items.unshift({ title: 'Data Fair', to: '/' })
+    items.unshift({ title: truncate(siteTitle.value, 50), href: '/' })
+  }
+  return items
 })
 </script>
 

--- a/ui/src/pages/department.vue
+++ b/ui/src/pages/department.vue
@@ -21,11 +21,15 @@
 
 <script setup lang="ts">
 import { useDFramePage } from '~/composables/layout/use-d-frame-page'
+import { useBreadcrumbs } from '~/composables/layout/use-breadcrumbs'
 
 const { t } = useI18n()
 const { user, account } = useSessionAuthenticated()
 const { sendUiNotif } = useUiNotif()
 const { stateChangeAdapter, onMessage } = useDFramePage()
+
+const breadcrumbs = useBreadcrumbs()
+breadcrumbs.receive({ breadcrumbs: [{ text: t('department') }] })
 
 const authorized = computed(() => {
   if (!user.value) return false
@@ -40,7 +44,9 @@ const authorized = computed(() => {
 
 <i18n lang="yaml">
 fr:
+  department: Gestion du département
   notAuthorized: Vous n'êtes pas autorisé à accéder à cette page.
 en:
+  department: Manage department
   notAuthorized: You are not authorized to access this page.
 </i18n>

--- a/ui/src/pages/index.vue
+++ b/ui/src/pages/index.vue
@@ -164,6 +164,7 @@
 
 <i18n lang="yaml">
 fr:
+  dashboard: Tableau de bord
   subscriptionRequired: Un abonnement est requis. Rendez-vous sur la {subscriptionLink}.
   subscriptionPage: page d'abonnement
   organizationSpace: Espace de l'organisation {name}
@@ -181,6 +182,7 @@ fr:
   manageDatasets: Gérez les jeux de données
   manageApplications: Gérez les applications
 en:
+  dashboard: Dashboard
   subscriptionRequired: A subscription is required. Please visit the {subscriptionLink}.
   subscriptionPage: subscription page
   organizationSpace: Space of organization {name}
@@ -202,6 +204,7 @@ en:
 <script setup lang="ts">
 import { mdiAlert } from '@mdi/js'
 import { usePermissions } from '~/composables/use-permissions'
+import { useBreadcrumbs } from '~/composables/layout/use-breadcrumbs'
 import dataSvg from '~/assets/svg/Data Arranging_Two Color.svg?raw'
 import dataMaintenanceSvg from '~/assets/svg/Data maintenance_Two Color.svg?raw'
 import shareSvg from '~/assets/svg/Share_Two Color.svg?raw'
@@ -210,6 +213,9 @@ const { t } = useI18n()
 const session = useSession()
 const user = session.user
 const account = session.account
+
+const breadcrumbs = useBreadcrumbs()
+breadcrumbs.receive({ breadcrumbs: [{ text: t('dashboard') }] })
 
 // usePermissions uses useSession() internally, so it can be called unconditionally
 const { canContribDep, canAdminDep, missingSubscription } = usePermissions()

--- a/ui/src/pages/index.vue
+++ b/ui/src/pages/index.vue
@@ -164,7 +164,7 @@
 
 <i18n lang="yaml">
 fr:
-  subscriptionRequired: Votre abonnement est requis. Rendez-vous sur la {subscriptionLink}.
+  subscriptionRequired: Un abonnement est requis. Rendez-vous sur la {subscriptionLink}.
   subscriptionPage: page d'abonnement
   organizationSpace: Espace de l'organisation {name}
   departmentSpace: Espace de l'organisation {name} / {departmentName}
@@ -181,7 +181,7 @@ fr:
   manageDatasets: Gérez les jeux de données
   manageApplications: Gérez les applications
 en:
-  subscriptionRequired: Your subscription is required. Please visit the {subscriptionLink}.
+  subscriptionRequired: A subscription is required. Please visit the {subscriptionLink}.
   subscriptionPage: subscription page
   organizationSpace: Space of organization {name}
   departmentSpace: Space of organization {name} / {departmentName}

--- a/ui/src/pages/me.vue
+++ b/ui/src/pages/me.vue
@@ -15,8 +15,10 @@
 
 <script setup lang="ts">
 import { useDFramePage } from '~/composables/layout/use-d-frame-page'
+import { useBreadcrumbs } from '~/composables/layout/use-breadcrumbs'
 import { usePermissions } from '~/composables/use-permissions'
 
+const { t } = useI18n()
 const router = useRouter()
 const session = useSession()
 const { sendUiNotif } = useUiNotif()
@@ -24,9 +26,19 @@ const { stateChangeAdapter, onMessage } = useDFramePage()
 
 const { missingSubscription } = usePermissions()
 
+const breadcrumbs = useBreadcrumbs()
+breadcrumbs.receive({ breadcrumbs: [{ text: t('myAccount') }] })
+
 onMounted(() => {
   if (missingSubscription.value && session.state.account?.type === 'organization') {
     router.replace('/subscription')
   }
 })
 </script>
+
+<i18n lang="yaml">
+fr:
+  myAccount: Informations personnelles
+en:
+  myAccount: Personal info
+</i18n>

--- a/ui/src/pages/organization.vue
+++ b/ui/src/pages/organization.vue
@@ -21,11 +21,15 @@
 
 <script setup lang="ts">
 import { useDFramePage } from '~/composables/layout/use-d-frame-page'
+import { useBreadcrumbs } from '~/composables/layout/use-breadcrumbs'
 
 const { t } = useI18n()
 const { user, account } = useSessionAuthenticated()
 const { sendUiNotif } = useUiNotif()
 const { stateChangeAdapter, onMessage } = useDFramePage()
+
+const breadcrumbs = useBreadcrumbs()
+breadcrumbs.receive({ breadcrumbs: [{ text: t('organization') }] })
 
 const authorized = computed(() => {
   if (!user.value) return false
@@ -40,7 +44,9 @@ const authorized = computed(() => {
 
 <i18n lang="yaml">
 fr:
+  organization: Gestion de l'organisation
   notAuthorized: Vous n'êtes pas autorisé à accéder à cette page.
 en:
+  organization: Manage organization
   notAuthorized: You are not authorized to access this page.
 </i18n>

--- a/ui/src/pages/subscription.vue
+++ b/ui/src/pages/subscription.vue
@@ -17,7 +17,19 @@
 
 <script setup lang="ts">
 import { useDFramePage } from '~/composables/layout/use-d-frame-page'
+import { useBreadcrumbs } from '~/composables/layout/use-breadcrumbs'
 
+const { t } = useI18n()
 const { sendUiNotif } = useUiNotif()
 const { stateChangeAdapter, onMessage } = useDFramePage()
+
+const breadcrumbs = useBreadcrumbs()
+breadcrumbs.receive({ breadcrumbs: [{ text: t('subscription') }] })
 </script>
+
+<i18n lang="yaml">
+fr:
+  subscription: Abonnement
+en:
+  subscription: Subscription
+</i18n>


### PR DESCRIPTION
## Summary

Fixes back-office navigation when the admin UI is accessed from a secondary site domain (i.e. the site has a configured `title`).

- **Portal home link (left drawer)** — now shown whenever the current site has a configured title, with the site title rendered as a subtitle. Previously gated on `site.main === false`, which was unreliable.
- **Breadcrumb prefix (top bar)** — on sites with a title, breadcrumbs are now prefixed with `[Site title] > Data Fair > …`, and the site-title crumb links back to the portal (`href="/"`) while the "Data Fair" crumb routes to `/`. Required adding `href` support to the breadcrumbs renderer.
- **Default breadcrumbs on core pages** — added breadcrumb entries on dashboard (`index.vue`), personal info (`me.vue`), department, organization and subscription pages, so the breadcrumb is never empty on the main entry points.
- Minor copy fix on `index.vue`: *"Votre abonnement est requis"* → *"Un abonnement est requis"*.

Note: `FullSiteInfo` in `@data-fair/lib-vue/session.d.ts` is incomplete (missing `title`), so a small local cast is used in the two layout components — flagged with a comment.