### PR TITLE
fix(api): allow master-data datasets on secondary-domain back-office

### DIFF
--- a/api/src/datasets/service.js
+++ b/api/src/datasets/service.js
@@ -98,7 +98,15 @@ export const findDatasets = async (db, locale, publicationSite, publicBaseUrl, r
     if (options.catalogMode) {
       extraFilters.push({ publicationSites: `${publicationSite.type}:${publicationSite.id}` })
     } else {
-      extraFilters.push({ 'owner.type': publicationSite.owner.type, 'owner.id': publicationSite.owner.id })
+      // master-data datasets are cross-domain reference data and must remain reachable
+      // from a per-domain back-office (e.g. as virtual-dataset children, or initFrom source)
+      extraFilters.push({
+        $or: [
+          { 'owner.type': publicationSite.owner.type, 'owner.id': publicationSite.owner.id },
+          { 'masterData.virtualDatasets.active': true },
+          { 'masterData.standardSchema.active': true }
+        ]
+      })
     }
   }
 

--- a/api/src/datasets/service.js
+++ b/api/src/datasets/service.js
@@ -100,6 +100,8 @@ export const findDatasets = async (db, locale, publicationSite, publicBaseUrl, r
     } else {
       // master-data datasets are cross-domain reference data and must remain reachable
       // from a per-domain back-office (e.g. as virtual-dataset children, or initFrom source)
+      // TODO: when remote-services are deprecated and master-data visibility is managed
+      // directly on the datasets make these filters more complete to better reflect account permissions.
       extraFilters.push({
         $or: [
           { 'owner.type': publicationSite.owner.type, 'owner.id': publicationSite.owner.id },


### PR DESCRIPTION
The dataset listing on a per-domain back-office added a hard `owner = publicationSite.owner` filter, which prevented users from seeing master-data datasets owned by other accounts and broke the virtual-dataset / initFrom flows in `dataset-select.vue` (the master-data parent IDs returned by the remote-services lookup were silently filtered out by `/api/v1/datasets?id=...`).

Extend the secondary-domain filter to also accept datasets flagged with `masterData.virtualDatasets.active` or
`masterData.standardSchema.active`, which are the cross-domain reference datasets `syncDataset` itself uses to (re)create their remote-service projection. The catalog mode is unchanged.