### PR TITLE
fix(ui): use bulk dataset listing to fill virtual schema from children

### DIFF
--- a/api/src/misc/utils/find.js
+++ b/api/src/misc/utils/find.js
@@ -543,22 +543,7 @@ export const getByUniqueRef = async (publicationSite, mainPublicationSite, reqPa
   /** @type {any} */
   let filter = { id: paramId }
   if (publicationSite) {
-    if (resourceType === 'dataset') {
-      // master-data datasets are cross-domain reference data and must remain reachable
-      // from a per-domain back-office (e.g. as virtual-dataset children, or initFrom source)
-      // TODO: when remote-services are deprecated and master-data visibility is managed
-      // directly on the datasets make these filters more complete to better reflect account permissions.
-      filter = {
-        _uniqueRefs: paramId,
-        $or: [
-          { 'owner.type': publicationSite.owner.type, 'owner.id': publicationSite.owner.id },
-          { 'masterData.virtualDatasets.active': true },
-          { 'masterData.standardSchema.active': true }
-        ]
-      }
-    } else {
-      filter = { _uniqueRefs: paramId, 'owner.type': publicationSite.owner.type, 'owner.id': publicationSite.owner.id }
-    }
+    filter = { _uniqueRefs: paramId, 'owner.type': publicationSite.owner.type, 'owner.id': publicationSite.owner.id }
   } else if (mainPublicationSite) {
     filter = {
       $or: [

--- a/api/src/misc/utils/find.js
+++ b/api/src/misc/utils/find.js
@@ -543,7 +543,22 @@ export const getByUniqueRef = async (publicationSite, mainPublicationSite, reqPa
   /** @type {any} */
   let filter = { id: paramId }
   if (publicationSite) {
-    filter = { _uniqueRefs: paramId, 'owner.type': publicationSite.owner.type, 'owner.id': publicationSite.owner.id }
+    if (resourceType === 'dataset') {
+      // master-data datasets are cross-domain reference data and must remain reachable
+      // from a per-domain back-office (e.g. as virtual-dataset children, or initFrom source)
+      // TODO: when remote-services are deprecated and master-data visibility is managed
+      // directly on the datasets make these filters more complete to better reflect account permissions.
+      filter = {
+        _uniqueRefs: paramId,
+        $or: [
+          { 'owner.type': publicationSite.owner.type, 'owner.id': publicationSite.owner.id },
+          { 'masterData.virtualDatasets.active': true },
+          { 'masterData.standardSchema.active': true }
+        ]
+      }
+    } else {
+      filter = { _uniqueRefs: paramId, 'owner.type': publicationSite.owner.type, 'owner.id': publicationSite.owner.id }
+    }
   } else if (mainPublicationSite) {
     filter = {
       $or: [

--- a/dev/resources/nginx.conf.template
+++ b/dev/resources/nginx.conf.template
@@ -161,8 +161,7 @@ server {
   }
 
   location /simple-directory {
-    rewrite  ^/simple-directory/(.*) /$1 break;
-    proxy_pass http://localhost:${SD_PORT}/;
+    proxy_pass http://localhost:${SD_PORT};
   }
 
   location /api-doc {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -89,6 +89,7 @@ services:
       - MANAGE_DEPARTMENTS=true
       - MANAGE_PARTNERS=true
       - MANAGE_SITES=true
+      - ACCEPT_UNKNOWN_SITE=true
       - LIST_USERS_MODE=admin
       - LIST_ORGANIZATIONS_MODE=authenticated
       - OBSERVER_ACTIVE=false

--- a/tests/features/ui/new-dataset-master-data-secondary-domain.e2e.spec.ts
+++ b/tests/features/ui/new-dataset-master-data-secondary-domain.e2e.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '@playwright/test'
+import { axiosAuth, clean } from '../../support/axios.ts'
+import { clearPublicationSitesCache, waitForFinalize } from '../../support/workers.ts'
+
+const DEV_HOST = process.env.DEV_HOST!
+const NGINX_PORT1 = process.env.NGINX_PORT1!
+const NGINX_PORT2 = process.env.NGINX_PORT2!
+const baseUrl1 = `http://${DEV_HOST}:${NGINX_PORT1}`
+const baseUrl2 = `http://${DEV_HOST}:${NGINX_PORT2}`
+
+test.describe('new-dataset wizard — virtual dataset from master-data on a secondary-domain back-office', () => {
+  test.beforeEach(async () => {
+    await clean()
+  })
+
+  test('initializes virtual dataset schema from a master-data child of the main domain', async ({ page, context }) => {
+    // 1) main-domain master-data dataset, owned by another org (test_org3) but
+    //    explicitly shared with test_org1 so the corresponding remote-service is
+    //    surfaced by /api/v1/remote-services?privateAccess=organization:test_org1.
+    //    This mirrors the production scenario: a master-data published as a
+    //    cross-domain reference for another organization.
+    const axOtherOrg = await axiosAuth('test_user2@test.com', 'test_org3')
+    await axOtherOrg.put('/api/v1/datasets/master-products', {
+      isRest: true,
+      title: 'Master products',
+      schema: [
+        { key: 'product_code', type: 'string' },
+        { key: 'product_label', type: 'string' }
+      ],
+      masterData: {
+        virtualDatasets: { active: true },
+        shareOrgs: [{ id: 'test_org1', name: 'Test Org 1' }]
+      }
+    })
+    // grant public read+list so test_org1 can find it via the bulk listing
+    // used by the new-dataset wizard's "fill schema from children" flow
+    await axOtherOrg.put('/api/v1/datasets/master-products/permissions', [{ classes: ['read', 'list'] }])
+    // populate the master-data with at least one row so it gets finalized
+    // (queryable=true filters on finalizedAt, used by dataset-select.vue)
+    await axOtherOrg.post('/api/v1/datasets/master-products/_bulk_lines', [
+      { product_code: 'P001', product_label: 'Product 1' }
+    ])
+    await waitForFinalize(axOtherOrg, 'master-products')
+
+    // 2) test_org1 registers a publication site bound to NGINX_PORT2
+    const axOrg = await axiosAuth('test_user1@test.com', 'test_org1')
+    await axOrg.post('/api/v1/settings/organization/test_org1/publication-sites', {
+      type: 'data-fair-portals',
+      id: 'portal1',
+      url: baseUrl2
+    })
+    await clearPublicationSitesCache()
+
+    // 3) cookies (i18n + cache bypass) — set per-port; session cookies will be
+    //    issued during login below
+    await context.addCookies([
+      { name: 'i18n_lang', value: 'fr', url: baseUrl1 },
+      { name: 'cache_bypass', value: '1', url: baseUrl1 },
+      { name: 'i18n_lang', value: 'fr', url: baseUrl2 },
+      { name: 'cache_bypass', value: '1', url: baseUrl2 }
+    ])
+
+    // 4) login through simple-directory on the main domain. The session
+    //    cookie is host-scoped (not port-scoped) so it also applies on
+    //    NGINX_PORT2.
+    const mainTarget = `${baseUrl1}/data-fair/`
+    const loginUrl = `${baseUrl1}/simple-directory/login?redirect=${encodeURIComponent(mainTarget)}`
+    await page.goto(loginUrl)
+    await page.getByLabel('Adresse mail').fill('test_user1@test.com')
+    await page.getByLabel('Mot de passe').fill('passwd')
+    await page.getByRole('button', { name: 'Se connecter' }).click()
+    await page.waitForURL(/\/data-fair\/(\?|$|#)/, { timeout: 10000 })
+
+    // 5) switch from personal account to test_org1 context (org context is
+    //    stored in the session cookie too, so it carries over to NGINX_PORT2)
+    await page.getByRole('button', { name: /Ouvrez le menu personnel/ }).click()
+    await page.getByRole('listitem').filter({ hasText: 'Test Org 1' }).click()
+    await page.waitForURL(/\/data-fair\/(\?|$|#)/, { timeout: 10000 })
+
+    // 6) navigate to the new-dataset wizard on the secondary domain
+    await page.goto(`${baseUrl2}/data-fair/new-dataset`)
+
+    const virtualCard = page.locator('.v-card-title', { hasText: 'Virtuel' })
+    await expect(virtualCard).toBeVisible({ timeout: 10000 })
+    await virtualCard.click()
+
+    const titleInput = page.getByLabel(/Titre du jeu de données/)
+    await expect(titleInput).toBeVisible({ timeout: 5000 })
+    await titleInput.fill('Virtual master-data secondary E2E')
+
+    // pick the master-data child via the dataset-select autocomplete
+    const childrenInput = page.getByRole('combobox', { name: 'Jeux enfants' })
+    await childrenInput.click()
+    await childrenInput.pressSequentially('Master', { delay: 50 })
+
+    const dropdown = page.locator('.v-overlay__content .v-list')
+    await expect(dropdown.getByText('Données de référence')).toBeVisible({ timeout: 10000 })
+    await dropdown.locator('.v-list-item', { hasText: 'Master products' }).click()
+    await expect(page.locator('.v-chip', { hasText: 'Master products' })).toBeVisible({ timeout: 5000 })
+    // close the dropdown so the subheader doesn't intercept clicks on the next checkbox
+    await page.keyboard.press('Escape')
+
+    // enable "fill schema from children" — this is the path the PR fix changed
+    await page.getByLabel(/Initialiser le schéma avec toutes les colonnes des jeux enfants/).check()
+
+    await page.getByRole('button', { name: /Continuer/ }).click()
+    const createBtn = page.getByRole('button', { name: /Créer le jeu de données/ })
+    await expect(createBtn).toBeVisible({ timeout: 5000 })
+    await expect(createBtn).toBeEnabled({ timeout: 5000 })
+    await createBtn.click()
+
+    // 7) redirect to the new dataset page
+    await expect(page).toHaveURL(/\/dataset\/[^/]+/, { timeout: 30000 })
+    const match = page.url().match(/\/dataset\/([^/?#]+)/)
+    expect(match).not.toBeNull()
+    const datasetId = match![1]
+
+    // 8) regression check: the new virtual dataset's schema must contain the
+    //    master-data columns. Pre-fix, the wizard fetched each child via
+    //    GET /api/v1/datasets/:id which 404'd through getByUniqueRef on a
+    //    secondary-domain back-office, so this assertion fails on master.
+    const created = (await axOrg.get(`/api/v1/datasets/${datasetId}`)).data
+    expect(created.isVirtual).toBe(true)
+    expect(created.virtual.children).toContain('master-products')
+    const schemaKeys = (created.schema || []).map((p: any) => p.key)
+    expect(schemaKeys).toContain('product_code')
+    expect(schemaKeys).toContain('product_label')
+  })
+})

--- a/ui/src/pages/new-dataset.vue
+++ b/ui/src/pages/new-dataset.vue
@@ -801,12 +801,19 @@ async function createVirtualDataset () {
   }
 
   // Fill schema from children if requested
-  if (virtualFillSchema.value) {
-    let allChildrenHaveAttachmentsAsImage = virtualChildren.value.length > 0
+  if (virtualFillSchema.value && virtualChildren.value.length) {
+    const { results: childDatasets } = await $fetch<{ results: any[] }>(`${$apiPath}/datasets`, {
+      query: {
+        id: virtualChildren.value.map(c => c.id).join(','),
+        select: 'id,schema,attachmentsAsImage',
+        size: virtualChildren.value.length
+      }
+    })
+    let allChildrenHaveAttachmentsAsImage = true
     for (const child of virtualChildren.value) {
-      const childDataset = await $fetch<any>(`${$apiPath}/datasets/${child.id}`)
-      if (!childDataset.attachmentsAsImage) allChildrenHaveAttachmentsAsImage = false
-      const schema = childDataset.schema || []
+      const childDataset = childDatasets.find(d => d.id === child.id)
+      if (!childDataset?.attachmentsAsImage) allChildrenHaveAttachmentsAsImage = false
+      const schema = childDataset?.schema || []
       for (const property of schema) {
         if (!body.schema.find((p: any) => p.key === property.key)) {
           body.schema.push(property)

--- a/ui/src/pages/new-dataset.vue
+++ b/ui/src/pages/new-dataset.vue
@@ -805,8 +805,7 @@ async function createVirtualDataset () {
     const { results: childDatasets } = await $fetch<{ results: any[] }>(`${$apiPath}/datasets`, {
       query: {
         id: virtualChildren.value.map(c => c.id).join(','),
-        select: 'id,schema,attachmentsAsImage',
-        size: virtualChildren.value.length
+        select: 'id,schema,attachmentsAsImage'
       }
     })
     let allChildrenHaveAttachmentsAsImage = true


### PR DESCRIPTION
## Summary

Follow-up to #346. The "fill schema from children" flow in `new-dataset.vue` was fetching each selected child via `GET /api/v1/datasets/:id`, which goes through the `readDataset` middleware and its strict `owner = publicationSite.owner` filter. On a secondary-domain back-office this returned 404 for any master-data child (whose owner is a different account), breaking virtual-dataset creation as soon as the "fill schema from children" option was checked.

The first attempt (commit 8f3ddaa78) relaxed `getByUniqueRef` server-side to also accept master-data datasets. That works but it broadens read access to master-data datasets across all per-id reads — wider than what the bug actually required.

Instead, replace the per-child loop with a single `GET /api/v1/datasets?id=id1,id2,...&select=schema,attachmentsAsImage` call. This goes through `findDatasets`, whose master-data tolerance was already added in #346, so:
- the API-side relaxation in `getByUniqueRef` is no longer needed and is reverted;
- N round-trips become 1
