### PR TITLE
feat(ui): expandable dataset schema field details

### DIFF
--- a/ui/src/components/dataset/dataset-property-transform.vue
+++ b/ui/src/components/dataset/dataset-property-transform.vue
@@ -44,7 +44,7 @@
         <v-select
           v-model="overwritePropertyType"
           :items="rawPropertyTypes"
-          :item-title="(item: any) => item.title"
+          :item-title="(item: any) => item.title[locale]"
           :item-value="(item: any) => `${item.type}${item.format || item['x-display'] || ''}`"
           return-object
           :label="t('overrideType')"
@@ -52,7 +52,7 @@
           density="compact"
           persistent-placeholder
           clearable
-          :placeholder="t('detectedType') + ': ' + (detectedPropertyType?.title?.toLowerCase() || '')"
+          :placeholder="t('detectedType') + ': ' + (detectedPropertyType?.title?.[locale]?.toLowerCase() || '')"
           :disabled="!editable"
         />
 
@@ -112,7 +112,7 @@ en:
 import { mdiClose, mdiDatabaseCog } from '@mdi/js'
 import { propertyTypes } from '~/utils/dataset'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 
 const props = defineProps<{
   property: any

--- a/ui/src/components/dataset/dataset-property-transform.vue
+++ b/ui/src/components/dataset/dataset-property-transform.vue
@@ -44,15 +44,15 @@
         <v-select
           v-model="overwritePropertyType"
           :items="rawPropertyTypes"
-          :item-title="(item: any) => item.title[locale]"
-          :item-value="(item: any) => `${item.type}${item.format || item['x-display'] || ''}`"
+          :item-title="propTypeTitle"
+          :item-value="(item) => `${item.type}${item.format || ''}`"
           return-object
           :label="t('overrideType')"
           variant="outlined"
           density="compact"
           persistent-placeholder
           clearable
-          :placeholder="t('detectedType') + ': ' + (detectedPropertyType?.title?.[locale]?.toLowerCase() || '')"
+          :placeholder="t('detectedType') + ': ' + (detectedTypeTitle?.toLowerCase() || '')"
           :disabled="!editable"
         />
 
@@ -92,7 +92,7 @@
 fr:
   transform: Transformation
   overrideType: Surcharger le type
-  detectedType: "type détecté"
+  detectedType: Type détecté
   expr: Expression
   typeOverrideHelp1: Vous pouvez surcharger le type de cette colonne. De cette manière vous pouvez définir un type différent de celui détecté automatiquement depuis l'analyse du fichier.
   typeOverrideHelp2: Si le type choisi ne peut pas être obtenu à partir des données brutes vous pouvez saisir une expression de transformation ci-dessous.
@@ -100,7 +100,7 @@ fr:
 en:
   transform: Transformation
   overrideType: Override type
-  detectedType: "detected type"
+  detectedType: Detected type
   expr: Expression
   typeOverrideHelp1: You can override the type of this column. This way you can define a type different from the one automatically detected from the file analysis.
   typeOverrideHelp2: If the chosen type cannot be obtained from the raw data you can enter a transformation expression below.
@@ -112,7 +112,8 @@ en:
 import { mdiClose, mdiDatabaseCog } from '@mdi/js'
 import { propertyTypes } from '~/utils/dataset'
 
-const { t, locale } = useI18n()
+const { t } = useI18n()
+const propTypeTitle = usePropTypeTitle()
 
 const props = defineProps<{
   property: any
@@ -128,10 +129,11 @@ const hasTransform = computed(() => {
   return !!(transform?.expr?.trim() || transform?.type)
 })
 
-const detectedPropertyType = computed(() => {
-  return rawPropertyTypes.find(
+const detectedTypeTitle = computed(() => {
+  const detected = rawPropertyTypes.find(
     p => p.type === props.property.type && (p.format || null) === (props.property.format || null)
   )
+  return detected && propTypeTitle(detected)
 })
 
 const overwritePropertyType = computed({

--- a/ui/src/components/dataset/dataset-virtual-child-compat.vue
+++ b/ui/src/components/dataset/dataset-virtual-child-compat.vue
@@ -34,7 +34,7 @@ const props = defineProps<{
   parentSchema: any[]
 }>()
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const { vocabulary } = useStore()
 
 const capabilitiesProperties = capabilitiesSchema.properties as Record<string, { type: string, default: boolean, layout: string, title: string, description: string }>
@@ -82,8 +82,8 @@ const messages = computed(() => {
     if (childType !== parentType) {
       messages.error.push(t('typeMismatch', {
         field: field.title || field['x-originalName'] || field.key,
-        childType: childType?.title ?? '?',
-        parentType: parentType?.title ?? '?'
+        childType: childType?.title?.[locale.value] ?? '?',
+        parentType: parentType?.title?.[locale.value] ?? '?'
       }))
     }
 

--- a/ui/src/components/dataset/dataset-virtual-child-compat.vue
+++ b/ui/src/components/dataset/dataset-virtual-child-compat.vue
@@ -34,7 +34,8 @@ const props = defineProps<{
   parentSchema: any[]
 }>()
 
-const { t, locale } = useI18n()
+const { t } = useI18n()
+const propTypeTitle = usePropTypeTitle()
 const { vocabulary } = useStore()
 
 const capabilitiesProperties = capabilitiesSchema.properties as Record<string, { type: string, default: boolean, layout: string, title: string, description: string }>
@@ -82,8 +83,8 @@ const messages = computed(() => {
     if (childType !== parentType) {
       messages.error.push(t('typeMismatch', {
         field: field.title || field['x-originalName'] || field.key,
-        childType: childType?.title?.[locale.value] ?? '?',
-        parentType: parentType?.title?.[locale.value] ?? '?'
+        childType: (childType && propTypeTitle(childType)) ?? '?',
+        parentType: (parentType && propTypeTitle(parentType)) ?? '?'
       }))
     }
 

--- a/ui/src/components/dataset/schema/dataset-add-column-dialog.vue
+++ b/ui/src/components/dataset/schema/dataset-add-column-dialog.vue
@@ -88,7 +88,7 @@ const emit = defineEmits<{
   add: [column: any]
 }>()
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 
 const isFormValid = ref(false)
 const newColumnKey = ref('')
@@ -96,7 +96,7 @@ const newColumnType = ref(propertyTypes[0])
 
 const typeItems = computed(() => propertyTypes.map(pt => ({
   ...pt,
-  title: pt.title
+  title: pt.title[locale.value]
 })))
 
 const validNewColumnKey = (name: string) => {

--- a/ui/src/components/dataset/schema/dataset-add-column-dialog.vue
+++ b/ui/src/components/dataset/schema/dataset-add-column-dialog.vue
@@ -30,7 +30,8 @@
             <v-select
               v-model="newColumnType"
               :label="t('columnType')"
-              :items="typeItems"
+              :items="propertyTypes"
+              :item-title="(item: any) => item.title[locale]"
               return-object
               hide-details
             />
@@ -93,11 +94,6 @@ const { t, locale } = useI18n()
 const isFormValid = ref(false)
 const newColumnKey = ref('')
 const newColumnType = ref(propertyTypes[0])
-
-const typeItems = computed(() => propertyTypes.map(pt => ({
-  ...pt,
-  title: pt.title[locale.value]
-})))
 
 const validNewColumnKey = (name: string) => {
   if (!name) return false

--- a/ui/src/components/dataset/schema/dataset-add-column-dialog.vue
+++ b/ui/src/components/dataset/schema/dataset-add-column-dialog.vue
@@ -31,7 +31,7 @@
               v-model="newColumnType"
               :label="t('columnType')"
               :items="propertyTypes"
-              :item-title="(item: any) => item.title[locale]"
+              :item-title="propTypeTitle"
               return-object
               hide-details
             />
@@ -89,7 +89,8 @@ const emit = defineEmits<{
   add: [column: any]
 }>()
 
-const { t, locale } = useI18n()
+const { t } = useI18n()
+const propTypeTitle = usePropTypeTitle()
 
 const isFormValid = ref(false)
 const newColumnKey = ref('')

--- a/ui/src/components/dataset/schema/dataset-column-editor.vue
+++ b/ui/src/components/dataset/schema/dataset-column-editor.vue
@@ -95,7 +95,7 @@
         </div>
         <div class="mb-1">
           <span class="text-medium-emphasis">{{ t('type') }}:</span>
-          {{ propTypeTitle(column) }}
+          {{ propTypeTitle(column, locale) }}
           <template v-if="currentFileColumn?.dateFormat">
             ({{ currentFileColumn.dateFormat }})
           </template>

--- a/ui/src/components/dataset/schema/dataset-column-editor.vue
+++ b/ui/src/components/dataset/schema/dataset-column-editor.vue
@@ -96,7 +96,7 @@
 
         <div class="mb-1">
           <span class="text-medium-emphasis">{{ t('type') }}:</span>
-          {{ propTypeTitle(column, locale) }}
+          {{ propTypeTitle(column) }}
           <template v-if="currentFileColumn?.dateFormat">
             ({{ currentFileColumn.dateFormat }})
           </template>
@@ -264,11 +264,11 @@ en:
 /* eslint-disable vue/no-mutating-props */
 import type { SchemaProperty } from '#api/types'
 import { MarkdownEditor } from '@koumoul/vjsf-markdown'
-import { propTypeTitle } from '~/utils/dataset'
 import { useDatasetStore } from '~/composables/dataset/dataset-store'
 import useStore from '~/composables/use-store'
 
 const { t, locale } = useI18n()
+const propTypeTitle = usePropTypeTitle()
 const { dataset } = useDatasetStore()
 const { vocabulary, vocabularyArray } = useStore()
 

--- a/ui/src/components/dataset/schema/dataset-schema-download.vue
+++ b/ui/src/components/dataset/schema/dataset-schema-download.vue
@@ -3,12 +3,12 @@
     <template #activator="{ props }">
       <v-btn
         v-bind="props"
-        :prepend-icon="mdiDownload"
+        :icon="mdiDownload"
+        :title="t('downloadSchema')"
         color="primary"
         variant="flat"
-      >
-        {{ t('downloadSchema') }}
-      </v-btn>
+        size="small"
+      />
     </template>
     <v-list>
       <v-list-item

--- a/ui/src/components/dataset/schema/dataset-schema-download.vue
+++ b/ui/src/components/dataset/schema/dataset-schema-download.vue
@@ -14,13 +14,13 @@
       <v-list-item
         :href="downloadUrls.tableSchema"
         :prepend-icon="mdiTable"
-        :title="t('tableSchema')"
+        :title="t('downloadAsTableSchema')"
         download
       />
       <v-list-item
         :href="downloadUrls.jsonSchema"
         :prepend-icon="mdiCodeJson"
-        :title="t('jsonSchema')"
+        :title="t('downloadAsJsonSchema')"
         download
       />
     </v-list>
@@ -30,12 +30,12 @@
 <i18n lang="yaml">
 fr:
   downloadSchema: Télécharger le schéma
-  jsonSchema: Schéma JSON
-  tableSchema: Schéma Table
+  downloadAsJsonSchema: Télécharger au format JSON Schema
+  downloadAsTableSchema: Télécharger au format Table Schema
 en:
   downloadSchema: Download the schema
-  jsonSchema: JSON Schema
-  tableSchema: Table Schema
+  downloadAsJsonSchema: Download as JSON Schema
+  downloadAsTableSchema: Download as Table Schema
 </i18n>
 
 <script setup lang="ts">

--- a/ui/src/components/dataset/schema/dataset-schema-field-details.vue
+++ b/ui/src/components/dataset/schema/dataset-schema-field-details.vue
@@ -1,164 +1,139 @@
 <template>
-  <v-dialog
-    :model-value="!!field"
-    max-width="720"
-    scrollable
-    @update:model-value="(v) => { if (!v) emit('close') }"
-  >
-    <v-card v-if="field">
-      <v-toolbar
-        density="compact"
-        flat
+  <v-container v-if="field">
+    <v-row density="compact">
+      <v-col
+        cols="12"
+        sm="6"
       >
-        <v-toolbar-title>
+        <div class="text-caption text-medium-emphasis">
+          {{ t('title') }}
+        </div>
+        <div class="text-body-2">
           {{ field.title || field['x-originalName'] || field.key }}
-        </v-toolbar-title>
-        <v-spacer />
-        <v-btn
-          :icon="mdiClose"
-          variant="text"
-          size="small"
-          @click="emit('close')"
+        </div>
+      </v-col>
+      <v-col
+        v-if="field['x-originalName'] && field['x-originalName'] !== field.key"
+        cols="12"
+        sm="6"
+      >
+        <div class="text-caption text-medium-emphasis">
+          {{ t('originalName') }}
+        </div>
+        <code class="text-body-2">{{ field['x-originalName'] }}</code>
+      </v-col>
+      <v-col
+        cols="12"
+        sm="6"
+      >
+        <div class="text-caption text-medium-emphasis">
+          {{ t('type') }}
+        </div>
+        <div class="text-body-2">
+          {{ propTypeTitle(field, locale) }}<span
+            v-if="field.format"
+            class="text-medium-emphasis"
+          > ({{ field.format }})</span>
+        </div>
+      </v-col>
+      <v-col
+        v-if="typeof field['x-cardinality'] === 'number'"
+        cols="12"
+        sm="6"
+      >
+        <div class="text-caption text-medium-emphasis">
+          {{ t('cardinality') }}
+        </div>
+        <div class="text-body-2">
+          {{ field['x-cardinality'].toLocaleString() }}
+        </div>
+      </v-col>
+      <v-col
+        v-if="conceptTitle"
+        cols="12"
+      >
+        <div class="text-caption text-medium-emphasis">
+          {{ t('concept') }}
+        </div>
+        <div class="text-body-2">
+          {{ conceptTitle }}
+          <span
+            v-if="field['x-refersTo']"
+            class="text-medium-emphasis text-caption ml-1"
+          >
+            {{ field['x-refersTo'] }}
+          </span>
+        </div>
+      </v-col>
+      <v-col
+        v-if="descriptionHtml"
+        cols="12"
+      >
+        <div class="text-caption text-medium-emphasis">
+          {{ t('description') }}
+        </div>
+        <p
+          v-safe-html="descriptionHtml"
+          class="text-body-2 mb-0"
         />
-      </v-toolbar>
-      <v-card-text class="pa-4">
-        <v-row density="compact">
-          <v-col
-            cols="12"
-            sm="6"
+      </v-col>
+      <v-col
+        v-if="field['x-display']"
+        cols="12"
+        sm="6"
+      >
+        <div class="text-caption text-medium-emphasis">
+          {{ t('display') }}
+        </div>
+        <div class="text-body-2">
+          {{ field['x-display'] }}
+        </div>
+      </v-col>
+      <v-col
+        v-if="capabilityFlags.length"
+        cols="12"
+      >
+        <div class="text-caption text-medium-emphasis mb-1">
+          {{ t('capabilities') }}
+        </div>
+        <v-chip
+          v-for="cap in capabilityFlags"
+          :key="cap.name"
+          :color="cap.enabled ? 'primary' : undefined"
+          :variant="cap.enabled ? 'tonal' : 'outlined'"
+          size="small"
+          class="mr-1 mb-1"
+        >
+          {{ cap.name }}
+        </v-chip>
+      </v-col>
+      <v-col
+        v-if="valueEntries.length"
+        cols="12"
+      >
+        <div class="text-caption text-medium-emphasis mb-1">
+          {{ t('values') }}
+        </div>
+        <div class="text-body-2">
+          <template
+            v-for="(entry, i) in valueEntries"
+            :key="entry.value"
           >
-            <div class="text-caption text-medium-emphasis">
-              {{ t('key') }}
-            </div>
-            <code class="text-body-2">{{ field.key }}</code>
-          </v-col>
-          <v-col
-            v-if="field['x-originalName'] && field['x-originalName'] !== field.key"
-            cols="12"
-            sm="6"
-          >
-            <div class="text-caption text-medium-emphasis">
-              {{ t('originalName') }}
-            </div>
-            <code class="text-body-2">{{ field['x-originalName'] }}</code>
-          </v-col>
-          <v-col
-            cols="12"
-            sm="6"
-          >
-            <div class="text-caption text-medium-emphasis">
-              {{ t('type') }}
-            </div>
-            <div class="text-body-2">
-              {{ propTypeTitle(field, locale) }}
-              <span
-                v-if="field.format"
-                class="text-medium-emphasis"
-              >
-                ({{ field.format }})
-              </span>
-            </div>
-          </v-col>
-          <v-col
-            v-if="typeof field['x-cardinality'] === 'number'"
-            cols="12"
-            sm="6"
-          >
-            <div class="text-caption text-medium-emphasis">
-              {{ t('cardinality') }}
-            </div>
-            <div class="text-body-2">
-              {{ field['x-cardinality'].toLocaleString() }}
-            </div>
-          </v-col>
-          <v-col
-            v-if="conceptTitle"
-            cols="12"
-          >
-            <div class="text-caption text-medium-emphasis">
-              {{ t('concept') }}
-            </div>
-            <div class="text-body-2">
-              {{ conceptTitle }}
-              <span
-                v-if="field['x-refersTo']"
-                class="text-medium-emphasis text-caption ml-1"
-              >
-                {{ field['x-refersTo'] }}
-              </span>
-            </div>
-          </v-col>
-          <v-col
-            v-if="descriptionHtml"
-            cols="12"
-          >
-            <div class="text-caption text-medium-emphasis">
-              {{ t('description') }}
-            </div>
-            <p
-              v-safe-html="descriptionHtml"
-              class="text-body-2 mb-0"
-            />
-          </v-col>
-          <v-col
-            v-if="field['x-display']"
-            cols="12"
-            sm="6"
-          >
-            <div class="text-caption text-medium-emphasis">
-              {{ t('display') }}
-            </div>
-            <div class="text-body-2">
-              {{ field['x-display'] }}
-            </div>
-          </v-col>
-          <v-col
-            v-if="capabilityFlags.length"
-            cols="12"
-          >
-            <div class="text-caption text-medium-emphasis mb-1">
-              {{ t('capabilities') }}
-            </div>
-            <v-chip
-              v-for="cap in capabilityFlags"
-              :key="cap.name"
-              :color="cap.enabled ? 'primary' : undefined"
-              :variant="cap.enabled ? 'tonal' : 'outlined'"
-              size="small"
-              class="mr-1 mb-1"
-            >
-              {{ cap.name }}
-            </v-chip>
-          </v-col>
-          <v-col
-            v-if="valueRows.length"
-            cols="12"
-          >
-            <div class="text-caption text-medium-emphasis mb-1">
-              {{ t('values') }}
-            </div>
-            <v-data-table
-              :headers="valueHeaders"
-              :items="valueRows"
-              :items-per-page="-1"
-              density="compact"
-              hide-default-footer
-              class="border-thin rounded"
-            >
-              <template #item.value="{ item }">
-                <code>{{ item.value }}</code>
-              </template>
-            </v-data-table>
-          </v-col>
-        </v-row>
-      </v-card-text>
-    </v-card>
-  </v-dialog>
+            <span v-if="i > 0">&nbsp;—&nbsp;</span>
+            <span>
+              <template v-if="entry.label">{{ entry.label }} (<code>{{ entry.value }}</code>)</template>
+              <code v-else>{{ entry.value }}</code>
+            </span>
+          </template>
+        </div>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <i18n lang="yaml">
 fr:
-  key: Clé
+  title: Libellé
   originalName: Identifiant d'origine
   type: Type
   cardinality: Cardinalité
@@ -167,10 +142,8 @@ fr:
   display: Affichage
   capabilities: Capacités
   values: Valeurs
-  value: Valeur
-  label: Libellé
 en:
-  key: Key
+  title: Title
   originalName: Original name
   type: Type
   cardinality: Cardinality
@@ -179,12 +152,9 @@ en:
   display: Display
   capabilities: Capabilities
   values: Values
-  value: Value
-  label: Label
 </i18n>
 
 <script setup lang="ts">
-import { mdiClose } from '@mdi/js'
 import { propTypeTitle } from '~/utils/dataset'
 import type { SchemaProperty } from '#api/types'
 
@@ -193,10 +163,6 @@ const { vocabulary } = useStore()
 
 const props = defineProps<{
   field: SchemaProperty | null
-}>()
-
-const emit = defineEmits<{
-  close: []
 }>()
 
 const conceptTitle = computed(() => {
@@ -218,12 +184,7 @@ const capabilityFlags = computed(() => {
   return Object.entries(caps).map(([name, value]) => ({ name, enabled: value !== false }))
 })
 
-const hasLabels = computed(() => {
-  const labels = props.field?.['x-labels']
-  return !!labels && Object.keys(labels).length > 0
-})
-
-const valueRows = computed(() => {
+const valueEntries = computed(() => {
   const field = props.field
   if (!field) return []
   const labels = (field['x-labels'] || {}) as Record<string, string>
@@ -232,9 +193,4 @@ const valueRows = computed(() => {
   const values = Array.from(new Set([...fromEnum, ...fromLabels]))
   return values.map(value => ({ value, label: labels[value] ?? '' }))
 })
-
-const valueHeaders = computed(() => [
-  { title: t('value'), key: 'value' },
-  ...(hasLabels.value ? [{ title: t('label'), key: 'label' }] : [])
-])
 </script>

--- a/ui/src/components/dataset/schema/dataset-schema-field-details.vue
+++ b/ui/src/components/dataset/schema/dataset-schema-field-details.vue
@@ -119,20 +119,19 @@
         cols="12"
       >
         <div class="text-caption text-medium-emphasis mb-1">
-          {{ t('values') }}
+          {{ hasLabels ? t('valuesWithLabels') : t('values') }}
         </div>
-        <div class="text-body-2">
-          <template
-            v-for="(entry, i) in valueEntries"
-            :key="entry.value"
-          >
-            <span v-if="i > 0">&nbsp;-&nbsp;</span>
-            <span>
-              <template v-if="entry.label">{{ entry.label }} (<code>{{ entry.value }}</code>)</template>
-              <code v-else>{{ entry.value }}</code>
-            </span>
+        <v-data-table
+          :headers="valueHeaders"
+          :items="valueEntries"
+          density="compact"
+          class="border rounded"
+          hide-default-footer
+        >
+          <template #item.value="{ item }">
+            <code>{{ item.value }}</code>
           </template>
-        </div>
+        </v-data-table>
       </v-col>
     </v-row>
   </v-container>
@@ -149,6 +148,9 @@ fr:
   display: Affichage
   capabilities: Capacités
   values: Valeurs
+  valuesWithLabels: Valeurs et libellés associés
+  value: Valeur
+  label: Libellé
 en:
   title: Title
   originalName: Original name
@@ -159,6 +161,9 @@ en:
   display: Display
   capabilities: Capabilities
   values: Values
+  valuesWithLabels: Values and associated labels
+  value: Value
+  label: Label
 </i18n>
 
 <script setup lang="ts">
@@ -199,5 +204,15 @@ const valueEntries = computed(() => {
   const fromLabels = Object.keys(labels)
   const values = Array.from(new Set([...fromEnum, ...fromLabels]))
   return values.map(value => ({ value, label: labels[value] ?? '' }))
+})
+
+const hasLabels = computed(() => valueEntries.value.some(e => e.label))
+
+const valueHeaders = computed(() => {
+  const cols: { key: string, title: string, sortable: boolean }[] = [
+    { key: 'value', title: t('value'), sortable: false }
+  ]
+  if (hasLabels.value) cols.push({ key: 'label', title: t('label'), sortable: false })
+  return cols
 })
 </script>

--- a/ui/src/components/dataset/schema/dataset-schema-field-details.vue
+++ b/ui/src/components/dataset/schema/dataset-schema-field-details.vue
@@ -51,6 +51,7 @@
       <v-col
         v-if="conceptTitle"
         cols="12"
+        sm="6"
       >
         <div class="text-caption text-medium-emphasis">
           {{ t('concept') }}
@@ -61,7 +62,13 @@
             v-if="field['x-refersTo']"
             class="text-medium-emphasis text-caption ml-1"
           >
-            {{ field['x-refersTo'] }}
+            <a
+              :href="field['x-refersTo']"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {{ field['x-refersTo'] }}
+            </a>
           </span>
         </div>
       </v-col>
@@ -119,7 +126,7 @@
             v-for="(entry, i) in valueEntries"
             :key="entry.value"
           >
-            <span v-if="i > 0">&nbsp;—&nbsp;</span>
+            <span v-if="i > 0">&nbsp;-&nbsp;</span>
             <span>
               <template v-if="entry.label">{{ entry.label }} (<code>{{ entry.value }}</code>)</template>
               <code v-else>{{ entry.value }}</code>

--- a/ui/src/components/dataset/schema/dataset-schema-field-details.vue
+++ b/ui/src/components/dataset/schema/dataset-schema-field-details.vue
@@ -124,6 +124,7 @@
         <v-data-table
           :headers="valueHeaders"
           :items="valueEntries"
+          :items-per-page="-1"
           density="compact"
           class="border rounded"
           hide-default-footer

--- a/ui/src/components/dataset/schema/dataset-schema-field-details.vue
+++ b/ui/src/components/dataset/schema/dataset-schema-field-details.vue
@@ -30,7 +30,7 @@
           {{ t('type') }}
         </div>
         <div class="text-body-2">
-          {{ propTypeTitle(field, locale) }}<span
+          {{ propTypeTitle(field) }}<span
             v-if="field.format"
             class="text-medium-emphasis"
           > ({{ field.format }})</span>
@@ -168,10 +168,10 @@ en:
 </i18n>
 
 <script setup lang="ts">
-import { propTypeTitle } from '~/utils/dataset'
 import type { SchemaProperty } from '#api/types'
 
-const { t, locale } = useI18n()
+const { t } = useI18n()
+const propTypeTitle = usePropTypeTitle()
 const { vocabulary } = useStore()
 
 const props = defineProps<{

--- a/ui/src/components/dataset/schema/dataset-schema-field-details.vue
+++ b/ui/src/components/dataset/schema/dataset-schema-field-details.vue
@@ -1,0 +1,240 @@
+<template>
+  <v-dialog
+    :model-value="!!field"
+    max-width="720"
+    scrollable
+    @update:model-value="(v) => { if (!v) emit('close') }"
+  >
+    <v-card v-if="field">
+      <v-toolbar
+        density="compact"
+        flat
+      >
+        <v-toolbar-title>
+          {{ field.title || field['x-originalName'] || field.key }}
+        </v-toolbar-title>
+        <v-spacer />
+        <v-btn
+          :icon="mdiClose"
+          variant="text"
+          size="small"
+          @click="emit('close')"
+        />
+      </v-toolbar>
+      <v-card-text class="pa-4">
+        <v-row density="compact">
+          <v-col
+            cols="12"
+            sm="6"
+          >
+            <div class="text-caption text-medium-emphasis">
+              {{ t('key') }}
+            </div>
+            <code class="text-body-2">{{ field.key }}</code>
+          </v-col>
+          <v-col
+            v-if="field['x-originalName'] && field['x-originalName'] !== field.key"
+            cols="12"
+            sm="6"
+          >
+            <div class="text-caption text-medium-emphasis">
+              {{ t('originalName') }}
+            </div>
+            <code class="text-body-2">{{ field['x-originalName'] }}</code>
+          </v-col>
+          <v-col
+            cols="12"
+            sm="6"
+          >
+            <div class="text-caption text-medium-emphasis">
+              {{ t('type') }}
+            </div>
+            <div class="text-body-2">
+              {{ propTypeTitle(field, locale) }}
+              <span
+                v-if="field.format"
+                class="text-medium-emphasis"
+              >
+                ({{ field.format }})
+              </span>
+            </div>
+          </v-col>
+          <v-col
+            v-if="typeof field['x-cardinality'] === 'number'"
+            cols="12"
+            sm="6"
+          >
+            <div class="text-caption text-medium-emphasis">
+              {{ t('cardinality') }}
+            </div>
+            <div class="text-body-2">
+              {{ field['x-cardinality'].toLocaleString() }}
+            </div>
+          </v-col>
+          <v-col
+            v-if="conceptTitle"
+            cols="12"
+          >
+            <div class="text-caption text-medium-emphasis">
+              {{ t('concept') }}
+            </div>
+            <div class="text-body-2">
+              {{ conceptTitle }}
+              <span
+                v-if="field['x-refersTo']"
+                class="text-medium-emphasis text-caption ml-1"
+              >
+                {{ field['x-refersTo'] }}
+              </span>
+            </div>
+          </v-col>
+          <v-col
+            v-if="descriptionHtml"
+            cols="12"
+          >
+            <div class="text-caption text-medium-emphasis">
+              {{ t('description') }}
+            </div>
+            <p
+              v-safe-html="descriptionHtml"
+              class="text-body-2 mb-0"
+            />
+          </v-col>
+          <v-col
+            v-if="field['x-display']"
+            cols="12"
+            sm="6"
+          >
+            <div class="text-caption text-medium-emphasis">
+              {{ t('display') }}
+            </div>
+            <div class="text-body-2">
+              {{ field['x-display'] }}
+            </div>
+          </v-col>
+          <v-col
+            v-if="capabilityFlags.length"
+            cols="12"
+          >
+            <div class="text-caption text-medium-emphasis mb-1">
+              {{ t('capabilities') }}
+            </div>
+            <v-chip
+              v-for="cap in capabilityFlags"
+              :key="cap.name"
+              :color="cap.enabled ? 'primary' : undefined"
+              :variant="cap.enabled ? 'tonal' : 'outlined'"
+              size="small"
+              class="mr-1 mb-1"
+            >
+              {{ cap.name }}
+            </v-chip>
+          </v-col>
+          <v-col
+            v-if="valueRows.length"
+            cols="12"
+          >
+            <div class="text-caption text-medium-emphasis mb-1">
+              {{ t('values') }}
+            </div>
+            <v-data-table
+              :headers="valueHeaders"
+              :items="valueRows"
+              :items-per-page="-1"
+              density="compact"
+              hide-default-footer
+              class="border-thin rounded"
+            >
+              <template #item.value="{ item }">
+                <code>{{ item.value }}</code>
+              </template>
+            </v-data-table>
+          </v-col>
+        </v-row>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<i18n lang="yaml">
+fr:
+  key: Clé
+  originalName: Identifiant d'origine
+  type: Type
+  cardinality: Cardinalité
+  concept: Concept
+  description: Description
+  display: Affichage
+  capabilities: Capacités
+  values: Valeurs
+  value: Valeur
+  label: Libellé
+en:
+  key: Key
+  originalName: Original name
+  type: Type
+  cardinality: Cardinality
+  concept: Concept
+  description: Description
+  display: Display
+  capabilities: Capabilities
+  values: Values
+  value: Value
+  label: Label
+</i18n>
+
+<script setup lang="ts">
+import { mdiClose } from '@mdi/js'
+import { propTypeTitle } from '~/utils/dataset'
+import type { SchemaProperty } from '#api/types'
+
+const { t, locale } = useI18n()
+const { vocabulary } = useStore()
+
+const props = defineProps<{
+  field: SchemaProperty | null
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const conceptTitle = computed(() => {
+  if (!props.field) return null
+  const refersTo = props.field['x-refersTo']
+  if (!refersTo) return null
+  return vocabulary.value[refersTo]?.title ?? null
+})
+
+const descriptionHtml = computed(() => {
+  if (!props.field) return null
+  const refersTo = props.field['x-refersTo']
+  return props.field.description || (refersTo && vocabulary.value[refersTo]?.description) || null
+})
+
+const capabilityFlags = computed(() => {
+  const caps = props.field?.['x-capabilities']
+  if (!caps) return []
+  return Object.entries(caps).map(([name, value]) => ({ name, enabled: value !== false }))
+})
+
+const hasLabels = computed(() => {
+  const labels = props.field?.['x-labels']
+  return !!labels && Object.keys(labels).length > 0
+})
+
+const valueRows = computed(() => {
+  const field = props.field
+  if (!field) return []
+  const labels = (field['x-labels'] || {}) as Record<string, string>
+  const fromEnum = Array.isArray(field.enum) ? field.enum.map(v => String(v)) : []
+  const fromLabels = Object.keys(labels)
+  const values = Array.from(new Set([...fromEnum, ...fromLabels]))
+  return values.map(value => ({ value, label: labels[value] ?? '' }))
+})
+
+const valueHeaders = computed(() => [
+  { title: t('value'), key: 'value' },
+  ...(hasLabels.value ? [{ title: t('label'), key: 'label' }] : [])
+])
+</script>

--- a/ui/src/components/dataset/schema/dataset-schema-view.vue
+++ b/ui/src/components/dataset/schema/dataset-schema-view.vue
@@ -60,7 +60,6 @@ fr:
   key: Clé
   title: Libellé
   type: Type
-  x-refersTo: Concept
   description: Description
   moreInfo: Plus d'infos
   collapse: Réduire
@@ -69,7 +68,6 @@ en:
   key: Key
   title: Title
   type: Type
-  x-refersTo: Concept
   description: Description
   moreInfo: More info
   collapse: Collapse
@@ -90,10 +88,9 @@ const truncateStyle = 'max-width: 0; overflow: hidden; text-overflow: ellipsis; 
 const headers = computed(() => [
   { key: 'key', title: t('key'), width: '160px' },
   { key: 'title', title: t('title'), width: '25%', cellProps: { style: truncateStyle } },
-  { key: 'type', title: t('type'), width: '120px' },
-  { key: 'x-refersTo', title: t('x-refersTo'), width: '140px' },
+  { key: 'type', title: t('type'), width: '125px' },
   { key: 'description', title: t('description'), width: '40%', cellProps: { style: truncateStyle } },
-  { key: 'data-table-expand', title: '', sortable: false, width: '56px', align: 'end' as const }
+  { key: 'data-table-expand', title: '', sortable: false, align: 'end' as const }
 ])
 
 const visibleFields = computed(() => dataset.value?.schema?.filter(f => !f['x-calculated']) ?? [])

--- a/ui/src/components/dataset/schema/dataset-schema-view.vue
+++ b/ui/src/components/dataset/schema/dataset-schema-view.vue
@@ -26,9 +26,6 @@
     <template #item.type="{ item }">
       {{ propTypeTitle(item, locale) }}
     </template>
-    <template #item.x-refersTo="{ item }">
-      {{ vocabulary && item['x-refersTo'] && vocabulary[item['x-refersTo']]?.title }}
-    </template>
     <template #item.description="{ item }">
       {{ descriptionFor(item) }}
     </template>

--- a/ui/src/components/dataset/schema/dataset-schema-view.vue
+++ b/ui/src/components/dataset/schema/dataset-schema-view.vue
@@ -1,71 +1,57 @@
 <template>
   <v-data-table-virtual
     v-if="dataset?.schema"
+    :expanded="expanded"
     :group-by="dataset.schema.some(f => 'x-group' in f) ? [{ key: 'x-group' }] : []"
     :headers="headers"
     :items="visibleFields"
-    :height="tableHeight"
+    :height="height"
+    item-value="key"
     density="comfortable"
     hide-default-footer
     fixed-header
+    show-expand
+    class="bg-background"
+    @update:expanded="onExpandedUpdate"
   >
-    <template #top>
-      <div
-        ref="topRef"
-        class="d-flex justify-end"
-      >
-        <dataset-schema-download />
-      </div>
-    </template>
     <template #header.data-table-group>
       {{ t('group') }}
+    </template>
+    <template #header.data-table-expand>
+      <dataset-schema-download />
     </template>
     <template #item.title="{ item }">
       {{ item.title || item['x-originalName'] || item.key }}
     </template>
     <template #item.type="{ item }">
-      <div>{{ propTypeTitle(item, locale) }}</div>
-      <div
-        v-if="item.format"
-        class="text-caption text-medium-emphasis"
-      >
-        {{ item.format }}
-      </div>
-    </template>
-    <template #item.values="{ item }">
-      <template v-if="hasValues(item)">
-        <v-chip
-          v-for="(chip, i) in chipsFor(item)"
-          :key="i"
-          :title="chip.tooltip"
-          size="x-small"
-          variant="tonal"
-          class="mr-1 my-1"
-        >
-          {{ chip.text }}
-        </v-chip>
-      </template>
+      {{ propTypeTitle(item, locale) }}
     </template>
     <template #item.x-refersTo="{ item }">
       {{ vocabulary && item['x-refersTo'] && vocabulary[item['x-refersTo']]?.title }}
     </template>
     <template #item.description="{ item }">
-      <div v-safe-html="item.description || (vocabulary && item['x-refersTo'] && vocabulary[item['x-refersTo']]?.description)" />
+      {{ descriptionFor(item) }}
     </template>
-    <template #item.actions="{ item }">
+    <template #item.data-table-expand="{ internalItem, isExpanded, toggleExpand }">
       <v-btn
-        :icon="mdiInformationOutline"
-        :title="t('details')"
-        size="small"
+        :icon="isExpanded(internalItem) ? mdiClose : mdiInformationOutline"
+        :title="isExpanded(internalItem) ? t('collapse') : t('moreInfo')"
         variant="text"
-        @click="selectedField = item"
+        size="small"
+        @click="toggleExpand(internalItem)"
       />
     </template>
+    <template #expanded-row="{ columns, item }">
+      <tr>
+        <td
+          :colspan="columns.length"
+          class="pa-0"
+        >
+          <dataset-schema-field-details :field="item" />
+        </td>
+      </tr>
+    </template>
   </v-data-table-virtual>
-  <dataset-schema-field-details
-    :field="selectedField"
-    @close="selectedField = null"
-  />
 </template>
 
 <i18n lang="yaml">
@@ -74,26 +60,23 @@ fr:
   key: Clé
   title: Libellé
   type: Type
-  values: Valeurs
   x-refersTo: Concept
   description: Description
-  details: Détails du champ
-  moreCount: "+{n} autres"
+  moreInfo: Plus d'infos
+  collapse: Réduire
 en:
   group: Group
   key: Key
   title: Title
   type: Type
-  values: Values
   x-refersTo: Concept
   description: Description
-  details: Field details
-  moreCount: "+{n} more"
+  moreInfo: More info
+  collapse: Collapse
 </i18n>
 
 <script setup lang="ts">
-import { mdiInformationOutline } from '@mdi/js'
-import { useElementSize } from '@vueuse/core'
+import { mdiClose, mdiInformationOutline } from '@mdi/js'
 import { propTypeTitle } from '~/utils/dataset'
 import type { SchemaProperty } from '#api/types'
 
@@ -101,52 +84,29 @@ const { t, locale } = useI18n()
 const { vocabulary } = useStore()
 const { dataset } = useDatasetStore()
 
-const props = defineProps<{ height?: number }>()
+defineProps<{ height?: number }>()
 
-const topRef = ref<HTMLElement | null>(null)
-const { height: topHeight } = useElementSize(topRef)
-const tableHeight = computed(() => props.height ? props.height - topHeight.value : undefined)
-
+const truncateStyle = 'max-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap'
 const headers = computed(() => [
-  { key: 'key', title: t('key'), minWidth: '160px' },
-  { key: 'title', title: t('title'), minWidth: '160px' },
-  { key: 'type', title: t('type'), minWidth: '120px' },
-  { key: 'values', title: t('values'), minWidth: '180px', sortable: false },
-  { key: 'x-refersTo', title: t('x-refersTo'), minWidth: '140px' },
-  { key: 'description', title: t('description'), minWidth: '240px' },
-  { key: 'actions', title: '', sortable: false, width: '56px', align: 'center' as const }
+  { key: 'key', title: t('key'), width: '160px' },
+  { key: 'title', title: t('title'), width: '25%', cellProps: { style: truncateStyle } },
+  { key: 'type', title: t('type'), width: '120px' },
+  { key: 'x-refersTo', title: t('x-refersTo'), width: '140px' },
+  { key: 'description', title: t('description'), width: '40%', cellProps: { style: truncateStyle } },
+  { key: 'data-table-expand', title: '', sortable: false, width: '56px', align: 'end' as const }
 ])
 
 const visibleFields = computed(() => dataset.value?.schema?.filter(f => !f['x-calculated']) ?? [])
 
-const selectedField = ref<SchemaProperty | null>(null)
-
-const MAX_INLINE_CHIPS = 4
-
-function hasValues (field: SchemaProperty) {
-  const enumLen = Array.isArray(field.enum) ? field.enum.length : 0
-  const labelsLen = field['x-labels'] ? Object.keys(field['x-labels']).length : 0
-  return enumLen + labelsLen > 0
+const expanded = ref<string[]>([])
+function onExpandedUpdate (next: string[]) {
+  const added = next.find(k => !expanded.value.includes(k))
+  expanded.value = added ? [added] : []
 }
 
-function chipsFor (field: SchemaProperty) {
-  const labels = (field['x-labels'] || {}) as Record<string, string>
-  const fromEnum = Array.isArray(field.enum) ? field.enum.map(v => String(v)) : []
-  const fromLabels = Object.keys(labels)
-  const values = Array.from(new Set([...fromEnum, ...fromLabels]))
-  const head = values.slice(0, MAX_INLINE_CHIPS).map(value => {
-    const label = labels[value]
-    return label
-      ? { text: label, tooltip: value }
-      : { text: value, tooltip: value }
-  })
-  if (values.length > MAX_INLINE_CHIPS) {
-    const rest = values.slice(MAX_INLINE_CHIPS)
-    head.push({
-      text: t('moreCount', { n: rest.length }),
-      tooltip: rest.map(v => labels[v] ? `${labels[v]} (${v})` : v).join(', ')
-    })
-  }
-  return head
+function descriptionFor (field: SchemaProperty) {
+  const refersTo = field['x-refersTo']
+  const raw = field.description || (vocabulary.value && refersTo && vocabulary.value[refersTo]?.description) || ''
+  return raw.replace(/<[^>]*>/g, '')
 }
 </script>

--- a/ui/src/components/dataset/schema/dataset-schema-view.vue
+++ b/ui/src/components/dataset/schema/dataset-schema-view.vue
@@ -3,11 +3,20 @@
     v-if="dataset?.schema"
     :group-by="dataset.schema.some(f => 'x-group' in f) ? [{ key: 'x-group' }] : []"
     :headers="headers"
-    :items="dataset.schema.filter(f => !f['x-calculated'])"
+    :items="visibleFields"
+    :height="tableHeight"
     density="comfortable"
     hide-default-footer
     fixed-header
   >
+    <template #top>
+      <div
+        ref="topRef"
+        class="d-flex justify-end"
+      >
+        <dataset-schema-download />
+      </div>
+    </template>
     <template #header.data-table-group>
       {{ t('group') }}
     </template>
@@ -15,15 +24,48 @@
       {{ item.title || item['x-originalName'] || item.key }}
     </template>
     <template #item.type="{ item }">
-      {{ propTypeTitle(item) }}
+      <div>{{ propTypeTitle(item, locale) }}</div>
+      <div
+        v-if="item.format"
+        class="text-caption text-medium-emphasis"
+      >
+        {{ item.format }}
+      </div>
+    </template>
+    <template #item.values="{ item }">
+      <template v-if="hasValues(item)">
+        <v-chip
+          v-for="(chip, i) in chipsFor(item)"
+          :key="i"
+          :title="chip.tooltip"
+          size="x-small"
+          variant="tonal"
+          class="mr-1 my-1"
+        >
+          {{ chip.text }}
+        </v-chip>
+      </template>
     </template>
     <template #item.x-refersTo="{ item }">
       {{ vocabulary && item['x-refersTo'] && vocabulary[item['x-refersTo']]?.title }}
     </template>
     <template #item.description="{ item }">
-      <p v-safe-html="item.description || (vocabulary && item['x-refersTo'] && vocabulary[item['x-refersTo']]?.description)" />
+      <div v-safe-html="item.description || (vocabulary && item['x-refersTo'] && vocabulary[item['x-refersTo']]?.description)" />
+    </template>
+    <template #item.actions="{ item }">
+      <v-btn
+        :icon="mdiInformationOutline"
+        :title="t('details')"
+        size="small"
+        variant="text"
+        @click="selectedField = item"
+      />
     </template>
   </v-data-table-virtual>
+  <dataset-schema-field-details
+    :field="selectedField"
+    @close="selectedField = null"
+  />
 </template>
 
 <i18n lang="yaml">
@@ -32,30 +74,79 @@ fr:
   key: Clé
   title: Libellé
   type: Type
+  values: Valeurs
   x-refersTo: Concept
   description: Description
+  details: Détails du champ
+  moreCount: "+{n} autres"
 en:
   group: Group
   key: Key
   title: Title
   type: Type
+  values: Values
   x-refersTo: Concept
   description: Description
+  details: Field details
+  moreCount: "+{n} more"
 </i18n>
 
 <script setup lang="ts">
+import { mdiInformationOutline } from '@mdi/js'
+import { useElementSize } from '@vueuse/core'
 import { propTypeTitle } from '~/utils/dataset'
+import type { SchemaProperty } from '#api/types'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const { vocabulary } = useStore()
 const { dataset } = useDatasetStore()
 
-const headers = [
-  { key: 'key', title: t('key') },
-  { key: 'title', title: t('title') },
-  { key: 'type', title: t('type') },
-  { key: 'x-refersTo', title: t('x-refersTo') },
-  { key: 'description', title: t('description') }
-]
+const props = defineProps<{ height?: number }>()
 
+const topRef = ref<HTMLElement | null>(null)
+const { height: topHeight } = useElementSize(topRef)
+const tableHeight = computed(() => props.height ? props.height - topHeight.value : undefined)
+
+const headers = computed(() => [
+  { key: 'key', title: t('key'), minWidth: '160px' },
+  { key: 'title', title: t('title'), minWidth: '160px' },
+  { key: 'type', title: t('type'), minWidth: '120px' },
+  { key: 'values', title: t('values'), minWidth: '180px', sortable: false },
+  { key: 'x-refersTo', title: t('x-refersTo'), minWidth: '140px' },
+  { key: 'description', title: t('description'), minWidth: '240px' },
+  { key: 'actions', title: '', sortable: false, width: '56px', align: 'center' as const }
+])
+
+const visibleFields = computed(() => dataset.value?.schema?.filter(f => !f['x-calculated']) ?? [])
+
+const selectedField = ref<SchemaProperty | null>(null)
+
+const MAX_INLINE_CHIPS = 4
+
+function hasValues (field: SchemaProperty) {
+  const enumLen = Array.isArray(field.enum) ? field.enum.length : 0
+  const labelsLen = field['x-labels'] ? Object.keys(field['x-labels']).length : 0
+  return enumLen + labelsLen > 0
+}
+
+function chipsFor (field: SchemaProperty) {
+  const labels = (field['x-labels'] || {}) as Record<string, string>
+  const fromEnum = Array.isArray(field.enum) ? field.enum.map(v => String(v)) : []
+  const fromLabels = Object.keys(labels)
+  const values = Array.from(new Set([...fromEnum, ...fromLabels]))
+  const head = values.slice(0, MAX_INLINE_CHIPS).map(value => {
+    const label = labels[value]
+    return label
+      ? { text: label, tooltip: value }
+      : { text: value, tooltip: value }
+  })
+  if (values.length > MAX_INLINE_CHIPS) {
+    const rest = values.slice(MAX_INLINE_CHIPS)
+    head.push({
+      text: t('moreCount', { n: rest.length }),
+      tooltip: rest.map(v => labels[v] ? `${labels[v]} (${v})` : v).join(', ')
+    })
+  }
+  return head
+}
 </script>

--- a/ui/src/components/dataset/schema/dataset-schema-view.vue
+++ b/ui/src/components/dataset/schema/dataset-schema-view.vue
@@ -24,7 +24,7 @@
       {{ item.title || item['x-originalName'] || item.key }}
     </template>
     <template #item.type="{ item }">
-      {{ propTypeTitle(item, locale) }}
+      {{ propTypeTitle(item) }}
     </template>
     <template #item.description="{ item }">
       {{ descriptionFor(item) }}
@@ -72,10 +72,10 @@ en:
 
 <script setup lang="ts">
 import { mdiClose, mdiInformationOutline } from '@mdi/js'
-import { propTypeTitle } from '~/utils/dataset'
 import type { SchemaProperty } from '#api/types'
 
-const { t, locale } = useI18n()
+const { t } = useI18n()
+const propTypeTitle = usePropTypeTitle()
 const { vocabulary } = useStore()
 const { dataset } = useDatasetStore()
 

--- a/ui/src/pages/embed/dataset/[id]/fields.vue
+++ b/ui/src/pages/embed/dataset/[id]/fields.vue
@@ -1,14 +1,18 @@
 <template>
-  <v-container data-iframe-height>
-    <div class="text-center">
-      <dataset-schema-download />
-    </div>
-    <dataset-schema-view />
+  <v-container
+    :style="`height: ${windowHeight}px`"
+    class="pa-0"
+    fluid
+  >
+    <dataset-schema-view :height="windowHeight" />
   </v-container>
 </template>
 
 <script setup lang="ts">
+import { useWindowSize } from '@vueuse/core'
 import { provideDatasetStore } from '~/composables/dataset/dataset-store'
+
+const { height: windowHeight } = useWindowSize()
 
 const route = useRoute<'/embed/dataset/[id]/fields'>()
 

--- a/ui/src/utils/dataset.ts
+++ b/ui/src/utils/dataset.ts
@@ -1,24 +1,27 @@
 import { mdiTextShort, mdiTextLong, mdiFormatText, mdiCalendar, mdiClockOutline, mdiNumeric, mdiCheckboxMarkedCircleOutline, mdiCodeBraces, mdiCodeArray } from '@mdi/js'
 
-export const propertyTypes = [
-  { type: 'string', title: 'Texte', icon: mdiTextShort, 'x-capabilities': { textAgg: false }, maxLength: 200 },
-  { type: 'string', 'x-display': 'textarea', title: 'Texte long', icon: mdiTextLong, 'x-capabilities': { index: false, values: false, textAgg: false, insensitive: false }, maxLength: 1000 },
-  { type: 'string', 'x-display': 'markdown', title: 'Texte formatté', icon: mdiFormatText, 'x-capabilities': { index: false, values: false, textAgg: false, insensitive: false }, maxLength: 1000 },
-  { type: 'string', format: 'date', title: 'Date', icon: mdiCalendar },
-  { type: 'string', format: 'date-time', title: 'Date et heure', icon: mdiClockOutline },
-  { type: 'integer', title: 'Nombre entier', icon: mdiNumeric },
-  { type: 'number', title: 'Nombre', icon: mdiNumeric },
-  { type: 'boolean', title: 'Booléen', icon: mdiCheckboxMarkedCircleOutline }
+export const propertyTypes: Record<string, any>[] = [
+  { type: 'string', title: { fr: 'Texte', en: 'Text' }, icon: mdiTextShort, 'x-capabilities': { textAgg: false }, maxLength: 200 },
+  { type: 'string', 'x-display': 'textarea', title: { fr: 'Texte long', en: 'Long text' }, icon: mdiTextLong, 'x-capabilities': { index: false, values: false, textAgg: false, insensitive: false }, maxLength: 1000 },
+  { type: 'string', 'x-display': 'markdown', title: { fr: 'Texte formaté', en: 'Formatted text' }, icon: mdiFormatText, 'x-capabilities': { index: false, values: false, textAgg: false, insensitive: false }, maxLength: 1000 },
+  { type: 'string', format: 'date', title: { fr: 'Date', en: 'Date' }, icon: mdiCalendar },
+  { type: 'string', format: 'date-time', title: { fr: 'Date et heure', en: 'Date and time' }, icon: mdiClockOutline },
+  { type: 'integer', title: { fr: 'Nombre entier', en: 'Integer' }, icon: mdiNumeric },
+  { type: 'number', title: { fr: 'Nombre', en: 'Number' }, icon: mdiNumeric },
+  { type: 'boolean', title: { fr: 'Booléen', en: 'Boolean' }, icon: mdiCheckboxMarkedCircleOutline }
 ]
 
-export const propTypeTitle = (prop: { type?: string, format?: string | null }) => {
-  if (prop.type === 'object') return 'Objet JSON'
-  if (prop.type === 'array') return 'Tableau JSON'
+export const propTypeTitle = (
+  prop: { type?: string, format?: string | null },
+  locale: string = 'en'
+): string | undefined => {
+  if (prop.type === 'object') return { fr: 'Objet JSON', en: 'JSON object' }[locale]
+  if (prop.type === 'array') return { fr: 'Tableau JSON', en: 'JSON array' }[locale]
   if (prop.format) {
     const type = propertyTypes.find(p => p.type === prop.type && p.format === prop.format)
-    if (type) return type.title
+    if (type) return type.title[locale]
   }
-  return propertyTypes.find(p => p.type === prop.type)?.title
+  return propertyTypes.find(p => p.type === prop.type)?.title[locale]
 }
 
 export const propTypeIcon = (prop: { type: string, format?: string }) => {

--- a/ui/src/utils/dataset.ts
+++ b/ui/src/utils/dataset.ts
@@ -1,6 +1,18 @@
 import { mdiTextShort, mdiTextLong, mdiFormatText, mdiCalendar, mdiClockOutline, mdiNumeric, mdiCheckboxMarkedCircleOutline, mdiCodeBraces, mdiCodeArray } from '@mdi/js'
 
-export const propertyTypes: Record<string, any>[] = [
+type LocalizedTitle = { fr: string, en: string }
+
+export type PropertyType = {
+  type: string
+  format?: string
+  title: LocalizedTitle
+  icon: string
+  'x-display'?: 'textarea' | 'markdown'
+  'x-capabilities'?: Record<string, boolean>
+  maxLength?: number
+}
+
+export const propertyTypes: PropertyType[] = [
   { type: 'string', title: { fr: 'Texte', en: 'Text' }, icon: mdiTextShort, 'x-capabilities': { textAgg: false }, maxLength: 200 },
   { type: 'string', 'x-display': 'textarea', title: { fr: 'Texte long', en: 'Long text' }, icon: mdiTextLong, 'x-capabilities': { index: false, values: false, textAgg: false, insensitive: false }, maxLength: 1000 },
   { type: 'string', 'x-display': 'markdown', title: { fr: 'Texte formaté', en: 'Formatted text' }, icon: mdiFormatText, 'x-capabilities': { index: false, values: false, textAgg: false, insensitive: false }, maxLength: 1000 },
@@ -11,17 +23,23 @@ export const propertyTypes: Record<string, any>[] = [
   { type: 'boolean', title: { fr: 'Booléen', en: 'Boolean' }, icon: mdiCheckboxMarkedCircleOutline }
 ]
 
-export const propTypeTitle = (
-  prop: { type?: string, format?: string | null },
-  locale: string = 'en'
-): string | undefined => {
-  if (prop.type === 'object') return { fr: 'Objet JSON', en: 'JSON object' }[locale]
-  if (prop.type === 'array') return { fr: 'Tableau JSON', en: 'JSON array' }[locale]
-  if (prop.format) {
-    const type = propertyTypes.find(p => p.type === prop.type && p.format === prop.format)
-    if (type) return type.title[locale]
+const pickLang = (locale: string): keyof LocalizedTitle => locale === 'fr' ? 'fr' : 'en'
+
+type PropLike = { type?: string, format?: string | null, 'x-display'?: string }
+
+export const usePropTypeTitle = () => {
+  const { locale } = useI18n({ useScope: 'global' })
+  return (prop: PropLike): string | undefined => {
+    const lang = pickLang(locale.value)
+    if (prop.type === 'object') return { fr: 'Objet JSON', en: 'JSON object' }[lang]
+    if (prop.type === 'array') return { fr: 'Tableau JSON', en: 'JSON array' }[lang]
+    const found = propertyTypes.find(p =>
+      p.type === prop.type &&
+      (p.format || null) === (prop.format || null) &&
+      (p['x-display'] || null) === (prop['x-display'] || null)
+    )
+    return found?.title[lang]
   }
-  return propertyTypes.find(p => p.type === prop.type)?.title[locale]
 }
 
 export const propTypeIcon = (prop: { type: string, format?: string }) => {


### PR DESCRIPTION
> **Context** — this branch started as a fix for a regression introduced in the last release: `/embed/dataset/:id/fields` had lost its `fluid` container, leaving the schema view squeezed inside a max-width column instead of filling the iframe. The embed page is now `fluid` again and sized to the full window height. The other changes piggybacked on that fix to give the same view a proper details panel.

## Summary
- Add an inline expandable details panel under each row of the dataset schema view, replacing the previous "concept" column with a richer per-field surface: title, original name, type/format, cardinality, concept + linked vocabulary URI, description, `x-display`, capability chips, and an enum/labels table.
- Only one row can be expanded at a time; the more-info / close toggle uses an `i` / `x` icon with an accessible `title`.
- Tighten the schema table itself: drop the concept column (kept in the details), truncate the title and description columns with ellipsis (`max-width: 0` + `text-overflow`), and move the schema-download button into the expand-column header as an icon-only button. Download menu labels are clearer too: *Download as JSON Schema* / *Download as Table Schema*.
- Localize property type titles (fr/en): `propertyTypes` now carry `{ fr, en }` labels and a typed `PropertyType`. A `usePropTypeTitle()` composable resolves the label from the global locale, so callers in `dataset-property-transform`, `dataset-virtual-child-compat`, `dataset-add-column-dialog`, `dataset-column-editor`, `dataset-schema-view` and `dataset-schema-field-details` no longer need to thread the locale around. v-selects keep raw `propertyTypes` as items with `:item-title="propTypeTitle"`, which keeps the v-model stable across language switches while the displayed label updates reactively.
- Embed page `/embed/dataset/:id/fields` now fills the full window height (via `useWindowSize`) so the schema view scrolls inside the iframe instead of pushing the host page.
