### PR TITLE
feat: master-data selector in property validation + edit-data autocomplete

### DIFF
--- a/api/contract/master-data.js
+++ b/api/contract/master-data.js
@@ -233,7 +233,8 @@ Exemple: ma_colonne,-ma_colonne2`
           },
           label: {
             type: 'object',
-            title: 'Propriété utilisée pour la recherche (libellé)',
+            title: 'Propriété affichée lors de la saisie (libellé)',
+            description: 'Propriété affichée à côté du code dans la liste des suggestions, sous la forme « code (libellé) », pour aider l\'utilisateur à identifier la bonne valeur. La recherche s\'effectue sur toutes les colonnes textuelles du jeu de données.',
             layout: {
               props: {
                 noDataText: 'Aucune colonne textuelle dans ce jeu de données.'

--- a/api/contract/master-data.js
+++ b/api/contract/master-data.js
@@ -279,7 +279,8 @@ Exemple: ma_colonne,-ma_colonne2`
 
 export const endpoints = (dataset) => {
   const endpoints = {}
-  if (!dataset.masterData || !dataset.masterData.bulkSearchs) return endpoints
+  if (!dataset.masterData) return endpoints
+  if (!dataset.masterData.bulkSearchs?.length && !dataset.masterData.singleSearchs?.length) return endpoints
   const outputProperties = dataset.schema.filter(f => !f['x-calculated'])
   const datasetLineSchema = {
     type: 'object',

--- a/api/src/datasets/router.js
+++ b/api/src/datasets/router.js
@@ -651,7 +651,9 @@ router.get('/:datasetId/master-data/single-searchs/:singleSearchId', readDataset
   let esResponse
   let select = singleSearch.output.key
   if (singleSearch.label) select += ',' + singleSearch.label.key
-  const params = { q: req.query.q, size: req.query.size, q_mode: 'complete', select }
+  // collapse on the output key so suggestions are deduplicated server-side
+  // (the underlying dataset may have multiple rows sharing the same output value)
+  const params = { q: req.query.q, size: req.query.size, q_mode: 'complete', select, collapse: singleSearch.output.key }
   const qs = []
 
   if (singleSearch.filters) {

--- a/api/src/datasets/utils/extensions.ts
+++ b/api/src/datasets/utils/extensions.ts
@@ -412,7 +412,11 @@ class ExtensionsStream extends Transform {
 
 // Create a function that will transform items from a dataset into inputs for an action
 async function prepareInputMapping (action: any, dataset: Dataset, extensionKey: string, selectFields: string[]) {
-  const schema = await schemaUtils.extendedSchema(mongo.db, dataset)
+  // extendedSchema mutates the dataset (cleanSchema, fixConcepts) — work on a shallow
+  // copy of the schema so this is safe when called via commitLines with a cached/proxied
+  // dataset (assertImmutable in dev, or any future tightening of the cache contract)
+  const datasetCopy = { ...dataset, schema: (dataset.schema ?? []).map((f: any) => ({ ...f })) }
+  const schema = await schemaUtils.extendedSchema(mongo.db, datasetCopy)
   const fieldMappings = action.input.map((input: any) => {
     const field = schema.find((f: any) =>
       f['x-refersTo'] === input.concept &&

--- a/shared/schema.js
+++ b/shared/schema.js
@@ -28,6 +28,16 @@ export const cleanJsonSchemaProperty = (p, defaultPublicUrl, publicBaseUrl, flat
   }
   if (cleanProp['x-fromUrl']) {
     layout.getItems = { url: cleanProp['x-fromUrl'] }
+    if (cleanProp['x-itemKey']) layout.getItems.itemKey = `data["${cleanProp['x-itemKey']}"]`
+    if (cleanProp['x-itemTitle']) layout.getItems.itemTitle = `data["${cleanProp['x-itemTitle']}"]`
+    if (cleanProp['x-itemsProp']) {
+      // dedupe on the item key so that autocomplete suggestions are unique even when the underlying dataset has multiple rows per key
+      if (cleanProp['x-itemKey']) {
+        layout.getItems.itemsResults = `(data["${cleanProp['x-itemsProp']}"] || []).filter((r, i, a) => a.findIndex(x => x["${cleanProp['x-itemKey']}"] === r["${cleanProp['x-itemKey']}"]) === i)`
+      } else {
+        layout.getItems.itemsResults = `data["${cleanProp['x-itemsProp']}"]`
+      }
+    }
   }
 
   if (cleanProp.separator) layout.separator = cleanProp.separator

--- a/shared/schema.js
+++ b/shared/schema.js
@@ -30,14 +30,7 @@ export const cleanJsonSchemaProperty = (p, defaultPublicUrl, publicBaseUrl, flat
     layout.getItems = { url: cleanProp['x-fromUrl'] }
     if (cleanProp['x-itemKey']) layout.getItems.itemKey = `data["${cleanProp['x-itemKey']}"]`
     if (cleanProp['x-itemTitle']) layout.getItems.itemTitle = `data["${cleanProp['x-itemTitle']}"]`
-    if (cleanProp['x-itemsProp']) {
-      // dedupe on the item key so that autocomplete suggestions are unique even when the underlying dataset has multiple rows per key
-      if (cleanProp['x-itemKey']) {
-        layout.getItems.itemsResults = `(data["${cleanProp['x-itemsProp']}"] || []).filter((r, i, a) => a.findIndex(x => x["${cleanProp['x-itemKey']}"] === r["${cleanProp['x-itemKey']}"]) === i)`
-      } else {
-        layout.getItems.itemsResults = `data["${cleanProp['x-itemsProp']}"]`
-      }
-    }
+    if (cleanProp['x-itemsProp']) layout.getItems.itemsResults = `data["${cleanProp['x-itemsProp']}"]`
   }
 
   if (cleanProp.separator) layout.separator = cleanProp.separator

--- a/tests/features/datasets/extensions/extensions-core.api.spec.ts
+++ b/tests/features/datasets/extensions/extensions-core.api.spec.ts
@@ -413,6 +413,11 @@ koumoul,19 rue de la voie lactée saint avé
       extensions: [{ active: true, type: 'remoteService', remoteService: 'geocoder-koumoul', action: 'postCoords' }]
     })).data
 
+    // pre-populate the dataset cache via a read without acceptedStatuses, so the
+    // cached value goes through the assertImmutable proxy in dev — the next POST /lines
+    // would hit a MutationError if extendedSchema starts mutating the dataset again
+    await ax.get(`/api/v1/datasets/${dataset.id}/schema`)
+
     // extend first inserted line
     await setupCoordsMock(10)
     await ax.post(`/api/v1/datasets/${dataset.id}/lines`, { address: '19 rue de la voie lactée saint avé' })

--- a/tests/features/datasets/master-data/master-data-advanced.api.spec.ts
+++ b/tests/features/datasets/master-data/master-data-advanced.api.spec.ts
@@ -575,4 +575,40 @@ test.describe('master data - Multi-level extensions, sorting, date-interval/geo-
     assert.equal(results[0]['_geo.country'], 'JPN')
     assert.equal(results[0]['_country.name'], 'Japan')
   })
+
+  test('singleSearch should deduplicate results on the output key (ES collapse)', async () => {
+    const ax = testSuperadmin
+
+    await initMaster(
+      ax,
+      [siretProperty, { key: 'denomination', title: 'Denomination', type: 'string' }],
+      {
+        singleSearchs: [{
+          id: 'siret-search',
+          title: 'Search siret by denomination',
+          output: { key: 'siret' },
+          label: { key: 'denomination' }
+        }]
+      }
+    )
+
+    // three lines share the same siret, one has a different siret
+    await ax.post('/api/v1/datasets/master/_bulk_lines', [
+      { siret: '82898347800011', denomination: 'Acme A' },
+      { siret: '82898347800011', denomination: 'Acme B' },
+      { siret: '82898347800011', denomination: 'Acme C' },
+      { siret: '99999999900099', denomination: 'Other corp' }
+    ])
+    await waitForFinalize(ax, 'master')
+
+    const res = await ax.get('/api/v1/datasets/master/master-data/single-searchs/siret-search', { params: { q: 'Acme' } })
+    // collapse on `siret` should yield a single hit for the duplicated value, not three
+    const acmeHits = res.data.results.filter((r: any) => r.output === '82898347800011')
+    assert.equal(acmeHits.length, 1, 'duplicated siret values must be collapsed to a single suggestion')
+
+    // a broader search must still surface the other distinct siret
+    const resAll = await ax.get('/api/v1/datasets/master/master-data/single-searchs/siret-search', { params: { q: '' } })
+    const outputs = resAll.data.results.map((r: any) => r.output).sort()
+    assert.deepEqual(outputs, ['82898347800011', '99999999900099'])
+  })
 })

--- a/tests/features/ui/dataset-edit-data-master-data.e2e.spec.ts
+++ b/tests/features/ui/dataset-edit-data-master-data.e2e.spec.ts
@@ -13,17 +13,16 @@ const siretProperty = {
   type: 'string',
   'x-refersTo': siretConcept
 }
+
 const denominationProperty = {
   key: 'denomination',
   title: 'Dénomination',
-  type: 'string',
-  'x-refersTo': 'http://schema.org/description'
+  type: 'string'
 }
 
 test.describe('dataset edit-data form: master-data validation + live extension pre-fill', () => {
   const masterId = 'ref-products'
   const slaveId = 'orders'
-  let singleSearchUrl: string
 
   test.beforeAll(async () => {
     test.setTimeout(60000)
@@ -62,7 +61,7 @@ test.describe('dataset edit-data form: master-data validation + live extension p
     const remoteService = (await ax.get(`/api/v1/remote-services/dataset:${masterId}`, { params: { showAll: true } })).data
     const singleSearchAction = remoteService.actions.find((a: any) => a.id === 'masterData_singleSearch_siret-search')
     expect(singleSearchAction, 'singleSearch action must be exposed by the master remote service').toBeTruthy()
-    singleSearchUrl = remoteService.server + singleSearchAction.operation.path
+    const singleSearchUrl = remoteService.server + singleSearchAction.operation.path
 
     // Slave REST dataset: extension on bulkSearch + siret column wired to the master singleSearch
     // via x-master / x-fromUrl / x-item* (same shape the new validation dialog produces).
@@ -112,7 +111,6 @@ test.describe('dataset edit-data form: master-data validation + live extension p
 
     const validationDialog = page.getByRole('dialog')
     await expect(validationDialog).toBeVisible({ timeout: 5000 })
-    await expect(validationDialog.getByText(/Valeurs issues d'une donnée de référence/)).toBeVisible()
     // The configured singleSearch action title is the displayed value of the master-data v-select.
     await expect(validationDialog.getByText('Recherche par SIRET').first()).toBeVisible({ timeout: 5000 })
 

--- a/tests/features/ui/dataset-edit-data-master-data.e2e.spec.ts
+++ b/tests/features/ui/dataset-edit-data-master-data.e2e.spec.ts
@@ -1,0 +1,150 @@
+// Covers the back-office editable dataset (REST) edit-data form:
+//   - the validation dialog exposes the master-data selector when the column has a matching x-refersTo
+//   - typing in the autocomplete column queries the master-data singleSearch endpoint
+//   - selecting a value triggers /_simulate-extension and pre-fills the extension column in real time
+import { test, expect } from '../../fixtures/login.ts'
+import { axiosAuth, clean, checkPendingTasks } from '../../support/axios.ts'
+import { waitForFinalize } from '../../support/workers.ts'
+
+const siretConcept = 'http://www.datatourisme.fr/ontology/core/1.0/#siret'
+const siretProperty = {
+  key: 'siret',
+  title: 'Siret',
+  type: 'string',
+  'x-refersTo': siretConcept
+}
+const denominationProperty = {
+  key: 'denomination',
+  title: 'Dénomination',
+  type: 'string',
+  'x-refersTo': 'http://schema.org/description'
+}
+
+test.describe('dataset edit-data form: master-data validation + live extension pre-fill', () => {
+  const masterId = 'ref-products'
+  const slaveId = 'orders'
+  let singleSearchUrl: string
+
+  test.beforeAll(async () => {
+    test.setTimeout(60000)
+    await clean()
+    const ax = await axiosAuth('test_superadmin@test.com', undefined, true)
+
+    // Master REST dataset: bulkSearch (used by extension) + singleSearch (used by autocomplete).
+    await ax.put(`/api/v1/datasets/${masterId}`, {
+      isRest: true,
+      title: masterId,
+      schema: [siretProperty, denominationProperty],
+      masterData: {
+        bulkSearchs: [{
+          id: 'siret',
+          title: 'Fetch info by SIRET',
+          input: [{ type: 'equals', property: siretProperty }]
+        }],
+        singleSearchs: [{
+          id: 'siret-search',
+          title: 'Recherche par SIRET',
+          output: siretProperty,
+          label: denominationProperty
+        }]
+      }
+    })
+    await ax.post(`/api/v1/datasets/${masterId}/_bulk_lines`, [
+      { _id: '82898347800011', siret: '82898347800011', denomination: 'KOUMOUL' },
+      { _id: '82898347800012', siret: '82898347800012', denomination: 'KOUMOUL ANNEX' }
+    ])
+    await waitForFinalize(ax, masterId)
+
+    // Register the master apiDoc as a remote service so its actions become available to consumers.
+    const master = (await ax.get(`/api/v1/datasets/${masterId}`)).data
+    const apiDoc = (await ax.get(master.href + '/api-docs.json')).data
+    await ax.post('/api/v1/_check-api', apiDoc)
+    const remoteService = (await ax.get(`/api/v1/remote-services/dataset:${masterId}`, { params: { showAll: true } })).data
+    const singleSearchAction = remoteService.actions.find((a: any) => a.id === 'masterData_singleSearch_siret-search')
+    expect(singleSearchAction, 'singleSearch action must be exposed by the master remote service').toBeTruthy()
+    singleSearchUrl = remoteService.server + singleSearchAction.operation.path
+
+    // Slave REST dataset: extension on bulkSearch + siret column wired to the master singleSearch
+    // via x-master / x-fromUrl / x-item* (same shape the new validation dialog produces).
+    const siretSlaveProp = {
+      ...siretProperty,
+      'x-master': {
+        id: `dataset:${masterId}--${singleSearchAction.id}`,
+        title: singleSearchAction.summary,
+        remoteService: remoteService.id,
+        action: singleSearchAction.id
+      },
+      'x-fromUrl': singleSearchUrl + '?q={q}',
+      'x-itemKey': 'output',
+      'x-itemTitle': 'label',
+      'x-itemsProp': 'results'
+    }
+    await ax.put(`/api/v1/datasets/${slaveId}`, {
+      isRest: true,
+      title: slaveId,
+      schema: [siretSlaveProp],
+      extensions: [{
+        active: true,
+        type: 'remoteService',
+        remoteService: remoteService.id,
+        action: 'masterData_bulkSearch_siret',
+        select: ['denomination']
+      }]
+    })
+    await waitForFinalize(ax, slaveId, 30000)
+  })
+
+  test.afterAll(async () => {
+    await checkPendingTasks()
+  })
+
+  test('validation dialog exposes the master selector and edit-data autocomplete pre-fills extension column', async ({ page, goToWithAuth }) => {
+    test.setTimeout(60000)
+
+    // ---- Part A: schema editor — validation dialog shows the configured master-data selector ----
+    await goToWithAuth(`/data-fair/dataset/${slaveId}`, 'test_superadmin')
+    const structure = page.locator('#structure')
+    await expect(structure).toBeVisible({ timeout: 15000 })
+    await structure.getByRole('tab', { name: /Schéma|Schema/ }).click()
+
+    await structure.getByRole('button', { name: 'Siret', exact: true }).click()
+    await structure.getByTitle(/Validation des données/).click()
+
+    const validationDialog = page.getByRole('dialog')
+    await expect(validationDialog).toBeVisible({ timeout: 5000 })
+    await expect(validationDialog.getByText(/Valeurs issues d'une donnée de référence/)).toBeVisible()
+    // The configured singleSearch action title is the displayed value of the master-data v-select.
+    await expect(validationDialog.getByText('Recherche par SIRET').first()).toBeVisible({ timeout: 5000 })
+
+    // ---- Part B: edit-data — autocomplete + live extension pre-fill in the add-line form ----
+    await goToWithAuth(`/data-fair/dataset/${slaveId}/edit-data`, 'test_superadmin')
+    const addLineBtn = page.getByTitle('Ajouter une ligne').first()
+    await expect(addLineBtn).toBeVisible({ timeout: 15000 })
+    await addLineBtn.click()
+    const addDialog = page.getByRole('dialog').filter({ hasText: 'Ajouter une ligne' })
+    await expect(addDialog).toBeVisible({ timeout: 5000 })
+
+    const siretInput = addDialog.getByLabel('Siret', { exact: false }).first()
+    const masterSearchPromise = page.waitForResponse(resp =>
+      resp.url().includes(`/datasets/${masterId}/master-data/single-searchs/siret-search`) && resp.status() === 200,
+    { timeout: 15000 })
+    await siretInput.click()
+    await siretInput.fill('828')
+    await masterSearchPromise
+
+    // The singleSearch endpoint formats label as "<output> (<label>)" — pick the first matching suggestion.
+    const suggestion = page.getByRole('option').filter({ hasText: '82898347800011' }).first()
+    await expect(suggestion).toBeVisible({ timeout: 5000 })
+
+    const simulatePromise = page.waitForResponse(resp =>
+      resp.url().includes(`/datasets/${slaveId}/_simulate-extension`) && resp.status() === 200,
+    { timeout: 15000 })
+    await suggestion.click()
+    await simulatePromise
+
+    // The extension produces a `_siret.denomination` field titled "Dénomination" — it must be pre-filled
+    // in real time (without saving) by the simulate-extension call triggered above.
+    const denomField = addDialog.getByLabel(/Dénomination/).first()
+    await expect(denomField).toHaveValue(/KOUMOUL/, { timeout: 10000 })
+  })
+})

--- a/tests/resources/sirene-api.json
+++ b/tests/resources/sirene-api.json
@@ -3202,7 +3202,7 @@
             }
           },
           "400": {
-            "description": "Mauvais formattage de la requête",
+            "description": "Mauvais formatage de la requête",
             "content": {
               "application/json": {
                 "schema": {
@@ -8281,7 +8281,7 @@
             }
           },
           "400": {
-            "description": "Mauvais formattage de la requête",
+            "description": "Mauvais formatage de la requête",
             "content": {
               "application/json": {
                 "schema": {
@@ -13332,7 +13332,7 @@
             }
           },
           "400": {
-            "description": "Mauvais formattage de la requête",
+            "description": "Mauvais formatage de la requête",
             "content": {
               "application/json": {
                 "schema": {

--- a/ui/src/components/dataset/dataset-property-validation.vue
+++ b/ui/src/components/dataset/dataset-property-validation.vue
@@ -324,6 +324,7 @@ function setMasterData (masterData: MasterDataItem | null) {
     props.property['x-fromUrl'] = masterData['x-fromUrl']
     props.property['x-itemKey'] = masterData['x-itemKey']
     if (masterData['x-itemTitle']) props.property['x-itemTitle'] = masterData['x-itemTitle']
+    else delete props.property['x-itemTitle']
     props.property['x-itemsProp'] = 'results'
   }
 }

--- a/ui/src/components/dataset/dataset-property-validation.vue
+++ b/ui/src/components/dataset/dataset-property-validation.vue
@@ -15,19 +15,18 @@
     </template>
     <v-card v-if="dialog">
       <v-toolbar
+        :title="t('validationConfig')"
         density="compact"
         flat
       >
-        <v-toolbar-title>{{ t('validationConfig') }}</v-toolbar-title>
         <v-spacer />
         <v-btn
-          icon
+          :icon="mdiClose"
           @click="dialog = false"
-        >
-          <v-icon :icon="mdiClose" />
-        </v-btn>
+        />
       </v-toolbar>
-      <v-card-text class="px-3">
+
+      <v-card-text>
         <v-form>
           <df-tutorial-alert
             v-if="isRest"
@@ -46,6 +45,8 @@
             v-model="property['x-required']"
             :label="t('required')"
             :disabled="!editable"
+            density="comfortable"
+            hide-details
           />
 
           <v-checkbox
@@ -53,6 +54,8 @@
             v-model="property['x-labelsRestricted']"
             :label="t('restricted')"
             :disabled="!editable"
+            density="comfortable"
+            hide-details
           />
 
           <v-text-field
@@ -63,6 +66,8 @@
             type="number"
             variant="outlined"
             density="compact"
+            class="mt-2"
+            hide-details
             clearable
             @update:model-value="setNumberProp('minimum', $event)"
           />
@@ -75,6 +80,8 @@
             type="number"
             variant="outlined"
             density="compact"
+            class="mt-2"
+            hide-details
             clearable
             @update:model-value="setNumberProp('maximum', $event)"
           />
@@ -88,6 +95,8 @@
             min="0"
             variant="outlined"
             density="compact"
+            class="mt-2"
+            hide-details
             clearable
             @update:model-value="setNumberProp('minLength', $event)"
           />
@@ -101,6 +110,8 @@
             min="0"
             variant="outlined"
             density="compact"
+            class="mt-2"
+            hide-details
             clearable
             @update:model-value="setNumberProp('maxLength', $event)"
           />
@@ -109,6 +120,7 @@
             <df-tutorial-alert
               id="validation-regexp"
               :text="t('validationRegexpMessage')"
+              class="mb-2"
               persistent
             />
             <v-text-field
@@ -139,6 +151,7 @@
             <df-tutorial-alert
               id="validation-date-format"
               :text="t('dateFormatMessage')"
+              class="mb-2"
               persistent
             />
             <v-select
@@ -157,6 +170,7 @@
             <df-tutorial-alert
               id="validation-date-time-format"
               :text="t('dateTimeFormatMessage')"
+              class="mb-2"
               persistent
             />
             <v-select
@@ -170,6 +184,23 @@
               @click:clear="delete property.dateTimeFormat"
             />
           </template>
+
+          <v-select
+            v-if="property['x-refersTo'] && availableMasters[property['x-refersTo']]"
+            :model-value="property['x-master']"
+            :label="t('masterData')"
+            :disabled="!editable"
+            :items="availableMasters[property['x-refersTo']]"
+            item-title="title"
+            item-value="id"
+            return-object
+            variant="outlined"
+            density="compact"
+            class="mt-2"
+            clearable
+            hide-details
+            @update:model-value="setMasterData"
+          />
         </v-form>
       </v-card-text>
     </v-card>
@@ -178,7 +209,7 @@
 
 <i18n lang="yaml">
 fr:
-  validationConfig: Configuration de la validation des données
+  validationConfig: Validation des données
   required: Information obligatoire
   restricted: Cochez cette case pour restreindre les données aux valeurs avec libellés associés
   pattern: Format
@@ -192,11 +223,12 @@ fr:
   validationRegexpMessage: La définition du format est basée sur une expression régulière. Il s'agit d'un paramétrage avancé.
   validationRegexError: expression régulière invalide
   dateFormatMessage: Vous pouvez choisir un format de date accepté. Par défaut le seul format accepté est ISO 8601.
-  dateFormat: Formattage de date
+  dateFormat: Formatage de date
   dateTimeFormatMessage: Vous pouvez choisir un format de date et heure accepté. Par défaut le seul format accepté est IS0 8601.
-  dateTimeFormat: Formattage de date et heure
+  dateTimeFormat: Formatage de date et heure
+  masterData: Valeurs issues d'une donnée de référence
 en:
-  validationConfig: Data validation configuration
+  validationConfig: Data validation
   required: required information
   restricted: check this box to restrict data to values with associated labels
   pattern: Format
@@ -213,11 +245,14 @@ en:
   dateFormat: Date format
   dateTimeFormatMessage: You can choose an accepted datetime format. By default only ISO 8601 is accepted.
   dateTimeFormat: Datetime format
+  masterData: Values coming from a master-data dataset
 </i18n>
 
 <script setup lang="ts">
 /* eslint-disable vue/no-mutating-props */
 import { mdiCheckDecagram, mdiClose } from '@mdi/js'
+import { useDatasetStore } from '~/composables/dataset/dataset-store'
+import { useRemoteServices } from '~/composables/use-remote-services'
 
 const { t } = useI18n()
 
@@ -228,6 +263,70 @@ const props = defineProps<{
 }>()
 
 const dialog = ref(false)
+
+const { dataset } = useDatasetStore()
+const owner = computed(() => dataset.value?.owner)
+const { remoteServices } = useRemoteServices(owner)
+
+type MasterDataItem = {
+  id: string
+  title: string
+  remoteService: string
+  action: string
+  'x-fromUrl': string
+  'x-itemKey': string
+  'x-itemTitle'?: string
+}
+
+const labelConcept = 'http://www.w3.org/2000/01/rdf-schema#label'
+
+const availableMasters = computed(() => {
+  const masters: Record<string, MasterDataItem[]> = {}
+  for (const service of remoteServices.value as any[]) {
+    for (const action of service.actions ?? []) {
+      if (action.inputCollection) continue
+      if (action.type !== 'http://schema.org/SearchAction') continue
+      const nonLabelOutputs = (action.output ?? []).filter((o: any) => o.concept && o.concept !== labelConcept)
+      if (nonLabelOutputs.length !== 1) continue
+      const keyOutput = nonLabelOutputs[0]
+      const labelOutput = (action.output ?? []).find((o: any) => o.concept === labelConcept)
+      const master: MasterDataItem = {
+        id: `${service.id}--${action.id}`,
+        title: action.summary,
+        remoteService: service.id,
+        action: action.id,
+        'x-fromUrl': `${service.server}${action.operation.path}?q={q}`,
+        'x-itemKey': keyOutput.name,
+        'x-itemTitle': labelOutput?.name
+      }
+      const concept = keyOutput.concept
+      masters[concept] = masters[concept] ?? []
+      masters[concept].push(master)
+    }
+  }
+  return masters
+})
+
+function setMasterData (masterData: MasterDataItem | null) {
+  if (!masterData) {
+    delete props.property['x-master']
+    delete props.property['x-fromUrl']
+    delete props.property['x-itemKey']
+    delete props.property['x-itemTitle']
+    delete props.property['x-itemsProp']
+  } else {
+    props.property['x-master'] = {
+      id: masterData.id,
+      title: masterData.title,
+      remoteService: masterData.remoteService,
+      action: masterData.action
+    }
+    props.property['x-fromUrl'] = masterData['x-fromUrl']
+    props.property['x-itemKey'] = masterData['x-itemKey']
+    if (masterData['x-itemTitle']) props.property['x-itemTitle'] = masterData['x-itemTitle']
+    props.property['x-itemsProp'] = 'results'
+  }
+}
 
 const dateFormats = [
   'D/M/YYYY',

--- a/ui/src/components/dataset/table/dataset-table.vue
+++ b/ui/src/components/dataset/table/dataset-table.vue
@@ -435,6 +435,7 @@
     deleteLineWarning: Attention, la donnée de cette ligne sera perdue définitivement.
     helpFilterPrompt: Aide-moi à filtrer ces données
     checkDataQualityPrompt: Vérifier la qualité de ces données
+    helpEditDataPrompt: Aide-moi à saisir des données
   en:
     cancel: Cancel
     delete: Delete
@@ -444,6 +445,7 @@
     checkDataQualityPrompt: Check data quality
     deleteLine: Delete a line
     deleteLineWarning: Warning, the data from this line will be lost permanently
+    helpEditDataPrompt: Help me enter data
 </i18n>
 
 <script setup lang="ts">

--- a/ui/src/pages/dataset/[id]/edit-data.vue
+++ b/ui/src/pages/dataset/[id]/edit-data.vue
@@ -15,11 +15,9 @@
 fr:
   datasets: Jeux de données
   editData: Éditer les données
-  helpEditDataPrompt: Aide-moi à saisir des données
 en:
   datasets: Datasets
   editData: Edit data
-  helpEditDataPrompt: Help me enter data
 </i18n>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Summary

Wire master-data single-search actions into the dataset edit-data form so a column flagged with an `x-refersTo` concept can offer an autocomplete sourced from a reference dataset, and pre-fill the extension columns in real time when a value is picked.

## Changes

### UI — validation dialog (`dataset-property-validation.vue`)
- Add a *Valeurs issues d'une donnée de référence* selector that lists every available master-data `singleSearch` action whose output concept matches the property's `x-refersTo`.
- Picking a master writes `x-master`, `x-fromUrl`, `x-itemKey`, `x-itemTitle` and `x-itemsProp` on the property; clearing it removes them. This is the same shape vjsf already understands for autocompletes.
- Minor layout cleanup of the dialog (toolbar title via prop, density/hide-details on inputs).
- Fix two French typos (`Formattage` → `Formatage`).

### shared schema (`shared/schema.js`)
- `cleanJsonSchemaProperty` now maps `x-itemKey` / `x-itemTitle` / `x-itemsProp` into `layout.getItems`, so the public JSON schema exposes everything vjsf needs to render the autocomplete on the back-office add-line form.

### API
- `api/contract/master-data.js`: relax the early-return guard so a master-data dataset configured with `singleSearchs` only (no `bulkSearchs`) still exposes its OpenAPI endpoints.
- `api/src/datasets/utils/extensions.ts`: clone the dataset (and its schema entries) before calling `extendedSchema` in `prepareInputMapping`. `extendedSchema` mutates the schema via `cleanSchema` / `fixConcepts`, which would trip the `assertImmutable` proxy in dev when `commitLines` reuses a cached dataset.
- `api/src/datasets/router.js`: deduplicate `singleSearch` suggestions at the source via an Elasticsearch `collapse` on the output key. Listing a value several times brings nothing to a code/label autocomplete, and collapsing in ES is more correct than a client-side filter (preserves the requested `size`, keeps relevance scoring, and benefits every consumer of the API, not just vjsf).

### Misc
- Move the `helpEditDataPrompt` i18n key from `edit-data.vue` to `dataset-table.vue` where it is actually consumed.
- Fix three `Mauvais formattage` → `Mauvais formatage` typos in `tests/resources/sirene-api.json`.

## Tests
- New e2e `dataset-edit-data-master-data.e2e.spec.ts` covering both halves of the flow:
  1. The validation dialog exposes the configured master-data selector for a column matching the master's output concept.
  2. The edit-data add-line form queries the master `singleSearch`, and selecting a value triggers `/_simulate-extension` and pre-fills the extension column live.
- Extend `extensions-core.api.spec.ts` to pre-warm the dataset cache through the immutable proxy before the extended `POST /lines`, guarding against future regressions on the clone fix.
- New API test in `master-data-advanced.api.spec.ts` covering the ES collapse: a master-data dataset with several rows sharing the same output key returns a single suggestion per value through `/master-data/single-searchs/:id`.
