### PR TITLE
fix(notifications): preserve special chars in event titles and emit creation events in dev

### DIFF
--- a/api/i18n/messages/en.json
+++ b/api/i18n/messages/en.json
@@ -20,7 +20,7 @@
 		"dupSlug": "This slug is already used"
 	},
 	"appRequire": {
-		"noDataset": "does not use a dataset as source.",
+		"noDataset": "Does not use a dataset as source.",
 		"aDataset": "a dataset",
 		"geoData": "geolocalized data (latitude/longitude concepts)",
 		"aConcept": "the concept {{{concept}}}",
@@ -28,10 +28,10 @@
 		"aType": "the type {{{type}}}",
 		"oneOfTypes": "one of the types {{{types}}}",
 		"orJoin": " or ",
-		"requires": "requires ",
+		"requires": "Requires ",
 		"requiresJoin": " and "
 	},
-	"hasBreakingChanges": "the dataset \"{{{title}}}\" has breaking changes:",
+	"hasBreakingChanges": "The dataset \"{{{title}}}\" has breaking changes:",
 	"breakingChanges": {
 		"missing": "the column \"{{{key}}}\" doesn't exist anymore",
 		"type": "the column \"{{{key}}}\" changed type"

--- a/api/i18n/messages/en.json
+++ b/api/i18n/messages/en.json
@@ -3,8 +3,8 @@
 		"missingBaseApp": "The base application is unknown or as a restricted access.",
 		"missingApp": "Application configuration not found",
 		"brokenHTML": "HTML structure is broken, expect html, head and body elements",
-		"noAppAtUrl": "The page at URL {{url}} doesn't seem to host an application compatible with this service.",
-		"missingDataset": "The dataset {{id}} is unknown or does not belong to you",
+		"noAppAtUrl": "The page at URL {{{url}}} doesn't seem to host an application compatible with this service.",
+		"missingDataset": "The dataset {{{id}}} is unknown or does not belong to you",
 		"extensionShortIdConflict": "The dataset contains 2 extensions that have a conflict on the prefix of the extended columns.",
 		"badContentType": "This API expects a compatible content-type header, most often application/json",
 		"exceedLimitStorage": "You exceeded your strorage limit.",
@@ -16,25 +16,25 @@
 		"looksLikeSpam": "Message rejected, activity looks like a spam robot.",
 		"requireAnonymousToken": "An anonymous token is required.",
 		"noCrossDomain": "Request from an other domain not supported.",
-		"urlFriendly": "\"{{value}}\" should be more URL friendly, maybe you could use \"{{slug}}\" ?",
+		"urlFriendly": "\"{{{value}}}\" should be more URL friendly, maybe you could use \"{{{slug}}}\" ?",
 		"dupSlug": "This slug is already used"
 	},
 	"appRequire": {
 		"noDataset": "does not use a dataset as source.",
 		"aDataset": "a dataset",
 		"geoData": "geolocalized data (latitude/longitude concepts)",
-		"aConcept": "the concept {{concept}}",
-		"oneOfConcepts": "one of the concepts {{concepts}}",
-		"aType": "the type {{type}}",
-		"oneOfTypes": "one of the types {{types}}",
+		"aConcept": "the concept {{{concept}}}",
+		"oneOfConcepts": "one of the concepts {{{concepts}}}",
+		"aType": "the type {{{type}}}",
+		"oneOfTypes": "one of the types {{{types}}}",
 		"orJoin": " or ",
 		"requires": "requires ",
 		"requiresJoin": " and "
 	},
-	"hasBreakingChanges": "the dataset \"{{title}}\" has breaking changes:",
+	"hasBreakingChanges": "the dataset \"{{{title}}}\" has breaking changes:",
 	"breakingChanges": {
-		"missing": "the column \"{{key}}\" doesn't exist anymore",
-		"type": "the column \"{{key}}\" changed type"
+		"missing": "the column \"{{{key}}}\" doesn't exist anymore",
+		"type": "the column \"{{{key}}}\" changed type"
 	},
 	"sheets": {
 		"data": "data",
@@ -54,82 +54,82 @@
 	"notifications": {
 		"datasets": {
 			"error": {
-				"title": "Error of dataset {{label}}",
-				"body": "There was an error during processing of the dataset {{label}}: {{detail}}."
+				"title": "Error of dataset {{{label}}}",
+				"body": "There was an error during processing of the dataset {{{label}}}: {{{detail}}}."
 			},
 			"draft-error": {
-				"title": "Error of draft dataset {{label}}",
-				"body": "There was an error during processing of the draft of the dataset {{label}}: {{detail}}."
+				"title": "Error of draft dataset {{{label}}}",
+				"body": "There was an error during processing of the draft of the dataset {{{label}}}: {{{detail}}}."
 			},
 			"dataset-created": {
-				"title": "New dataset {{label}}",
-				"body": "The new dataset {{label}} was just created."
+				"title": "New dataset {{{label}}}",
+				"body": "The new dataset {{{label}}} was just created."
 			},
 			"draft-dataset-created": {
-				"title": "New draft dataset {{label}}",
-				"body": "The new dataset {{label}} was just created in draft mode."
+				"title": "New draft dataset {{{label}}}",
+				"body": "The new dataset {{{label}}} was just created in draft mode."
 			},
 			"publication-requested": {
 				"title": "Request for publication of a dataset",
-				"body": "A contributor is asking to publish the dataset {{label}} on {{publicationSite}}."
+				"body": "A contributor is asking to publish the dataset {{{label}}} on {{{publicationSite}}}."
 			},
 			"published": {
-				"title": "Publication of {{label}}",
-				"body": "The dataset {{label}} has been published on {{publicationSite}}."
+				"title": "Publication of {{{label}}}",
+				"body": "The dataset {{{label}}} has been published on {{{publicationSite}}}."
 			},
 			"published-topic": {
-				"title": "Publication of {{label}} in {{topic}}",
-				"body": "The dataset {{label}} has been published on {{publicationSite}} in the topic {{topic}}."
+				"title": "Publication of {{{label}}} in {{{topic}}}",
+				"body": "The dataset {{{label}}} has been published on {{{publicationSite}}} in the topic {{{topic}}}."
 			},
 			"draft-data-updated": {
-				"title": "Draft file updated {{label}}",
-				"body": "A new file was loaded on the dataset {{label}} in draft mode."
+				"title": "Draft file updated {{{label}}}",
+				"body": "A new file was loaded on the dataset {{{label}}} in draft mode."
 			},
 			"data-updated": {
-				"title": "File updated {{label}}",
-				"body": "A new file was loaded on the dataset {{label}}."
+				"title": "File updated {{{label}}}",
+				"body": "A new file was loaded on the dataset {{{label}}}."
 			},
 			"structure-updated": {
-				"title": "Structure change of {{label}}",
-				"body": "The structure of the dataset {{label}} was modified."
+				"title": "Structure change of {{{label}}}",
+				"body": "The structure of the dataset {{{label}}} was modified."
 			},
 			"draft-structure-updated": {
-				"title": "Structure change of draft {{label}}",
-				"body": "The structure of the draft of the dataset {{label}} was modified."
+				"title": "Structure change of draft {{{label}}}",
+				"body": "The structure of the draft of the dataset {{{label}}} was modified."
 			},
 			"draft-draft-validated": {
-				"title": "Draft validated {{label}}",
-				"body": "The draft of the dataset {{label}} has been validated ({{cause}})."
+				"title": "Draft validated {{{label}}}",
+				"body": "The draft of the dataset {{{label}}} has been validated ({{{cause}}})."
 			},
 			"breaking-change": {
-				"title": "Breaking change {{label}}",
-				"body": "The dataset {{label}} was modified in a way that might entail breakages : {{breakingChangesDesc}}."
+				"title": "Breaking change {{{label}}}",
+				"body": "The dataset {{{label}}} was modified in a way that might entail breakages : {{{breakingChangesDesc}}}."
 			},
 			"draft-draft-cancelled": {
-				"title": "Draft cancelled {{label}}",
-				"body": "The draft of the dataset {{label}} was cancelled, it is back to its previous validated state."
+				"title": "Draft cancelled {{{label}}}",
+				"body": "The draft of the dataset {{{label}}} was cancelled, it is back to its previous validated state."
 			}
 		},
 		"applications": {
 			"error": {
-				"title": "Error of application {{label}}",
-				"body": "There was an error during processing of the application {{label}}: {{detail}}."
+				"title": "Error of application {{{label}}}",
+				"body": "There was an error during processing of the application {{{label}}}: {{{detail}}}."
 			},
 			"application-created": {
-				"title": "New application {{label}}",
-				"body": "The new application {{label}} was just created."
+				"title": "New application {{{label}}}",
+				"body": "The new application {{{label}}} was just created."
 			},
 			"publication-requested": {
 				"title": "Request for publication of an application",
-				"body": "A contributor is asking to publish the application {{label}} on {{publicationSite}}."
+				"body": "A contributor is asking to publish the application {{{label}}} on {{{publicationSite}}}."
 			},
 			"published": {
-				"title": "Publication of {{label}}",
-				"body": "The application {{label}} has been published on {{publicationSite}}."
+				"title": "Publication of {{{label}}}",
+				"body": "The application {{{label}}} has been published on {{{publicationSite}}}."
 			},
 			"published-topic": {
-				"title": "Publication of {{label}} in {{topic}}",
-				"body": "The application {{label}} has been published on {{publicationSite}} in the topic {{topic}}."
+				"title": "Publication of {{{label}}} in {{{topic}}}",
+				"body": "The application {{{label}}} has been published on {{{publicationSite}}} in the topic {{{topic}}}."
 			}
 		}
 	}

--- a/api/i18n/messages/fr.json
+++ b/api/i18n/messages/fr.json
@@ -31,7 +31,7 @@
 		"requires": "Nécessite ",
 		"requiresJoin": " et "
 	},
-	"hasBreakingChanges": "le jeu de données \"{{{title}}}\" a des ruptures de compatibilité :",
+	"hasBreakingChanges": "Le jeu de données \"{{{title}}}\" a des ruptures de compatibilité :",
 	"breakingChanges": {
 		"missing": "la colonne \"{{{key}}}\" n'existe plus",
 		"type": "la colonne \"{{{key}}}\" a changé de type"
@@ -119,10 +119,10 @@
 			},
 			"application-created": {
 				"title": "Nouvelle application {{{label}}}",
-				"body": "L'application' {{{label}}} vient d'être créée."
+				"body": "L'application {{{label}}} vient d'être créée."
 			},
 			"publication-requested": {
-				"title": "Demande de publication d'application'",
+				"title": "Demande de publication d'application",
 				"body": "Un contributeur demande de publier l'application {{{label}}} sur {{{publicationSite}}}."
 			},
 			"published": {

--- a/api/i18n/messages/fr.json
+++ b/api/i18n/messages/fr.json
@@ -3,8 +3,8 @@
 		"missingBaseApp": "Modèle d'application inconnu ou à accès restreint.",
 		"missingApp": "Application configuration not found",
 		"brokenHTML": "La structure HTML est corrompue, les éléments html, head et body sont requis",
-		"noAppAtUrl": "La page à l'adresse {{url}} ne semble pas héberger une application compatible avec ce service.",
-		"missingDataset": "Le jeu de données {{id}} est inconnu ou ne vous appartient pas.",
+		"noAppAtUrl": "La page à l'adresse {{{url}}} ne semble pas héberger une application compatible avec ce service.",
+		"missingDataset": "Le jeu de données {{{id}}} est inconnu ou ne vous appartient pas.",
 		"extensionShortIdConflict": "Le jeu de données contient 2 extensions qui sont en conflit sur le préfixe des colonnes étendus.",
 		"badContentType": "Cette API attend un header content-type compatible, le plus souvent application/json.",
 		"exceedLimitStorage": "Vous avez atteint la limite de votre espace de stockage.",
@@ -16,25 +16,25 @@
 		"looksLikeSpam": "Message refusé, l'activité ressemble à celle d'un robot spammeur.",
 		"requireAnonymousToken": "Un jeton d'action anonyme est requis.",
 		"noCrossDomain": "Appel depuis un domaine extérieur non supporté.",
-		"urlFriendly": "\"{{value}}\" n'est pas assez lisible pour être utilisé dans une URL, peut-être pourriez vous utiliser \"{{slug}}\" ?",
+		"urlFriendly": "\"{{{value}}}\" n'est pas assez lisible pour être utilisé dans une URL, peut-être pourriez vous utiliser \"{{{slug}}}\" ?",
 		"dupSlug": "Ce slug est déjà utilisé"
 	},
 	"appRequire": {
 		"noDataset": "N'utilise pas de jeu de données comme source.",
 		"aDataset": "une source de données",
 		"geoData": "des données géolocalisées (concepts latitude/longitude)",
-		"aConcept": "le concept {{concept}}",
-		"oneOfConcepts": "un des concepts {{concepts}}",
-		"aType": "le type {{type}}",
-		"oneOfTypes": "un des types {{types}}",
+		"aConcept": "le concept {{{concept}}}",
+		"oneOfConcepts": "un des concepts {{{concepts}}}",
+		"aType": "le type {{{type}}}",
+		"oneOfTypes": "un des types {{{types}}}",
 		"orJoin": " ou ",
 		"requires": "Nécessite ",
 		"requiresJoin": " et "
 	},
-	"hasBreakingChanges": "le jeu de données \"{{title}}\" a des ruptures de compatibilité :",
+	"hasBreakingChanges": "le jeu de données \"{{{title}}}\" a des ruptures de compatibilité :",
 	"breakingChanges": {
-		"missing": "la colonne \"{{key}}\" n'existe plus",
-		"type": "la colonne \"{{key}}\" a changé de type"
+		"missing": "la colonne \"{{{key}}}\" n'existe plus",
+		"type": "la colonne \"{{{key}}}\" a changé de type"
 	},
 	"sheets": {
 		"data": "données",
@@ -56,82 +56,82 @@
 	"notifications": {
 		"datasets": {
 			"error": {
-				"title": "Erreur du jeu de données {{label}}",
-				"body": "Il y a eu une erreur pendant le traitement du jeu de données {{label}} : {{detail}}."
+				"title": "Erreur du jeu de données {{{label}}}",
+				"body": "Il y a eu une erreur pendant le traitement du jeu de données {{{label}}} : {{{detail}}}."
 			},
 			"draft-error": {
-				"title": "Erreur du brouillon du jeu de données {{label}}",
-				"body": "Il y a eu une erreur pendant le traitement du brouillon du jeu de données {{label}} : {{detail}}."
+				"title": "Erreur du brouillon du jeu de données {{{label}}}",
+				"body": "Il y a eu une erreur pendant le traitement du brouillon du jeu de données {{{label}}} : {{{detail}}}."
 			},
 			"dataset-created": {
-				"title": "Nouveau jeu de données {{label}}",
-				"body": "Le jeu de données {{label}} vient d'être créé."
+				"title": "Nouveau jeu de données {{{label}}}",
+				"body": "Le jeu de données {{{label}}} vient d'être créé."
 			},
 			"draft-dataset-created": {
-				"title": "Nouveau jeu de données brouillon {{label}}",
-				"body": "Le jeu de données {{label}} vient d'être créé en mode brouillon."
+				"title": "Nouveau jeu de données brouillon {{{label}}}",
+				"body": "Le jeu de données {{{label}}} vient d'être créé en mode brouillon."
 			},
 			"publication-requested": {
 				"title": "Demande de publication de jeu de données",
-				"body": "Un contributeur demande de publier le jeu de données {{label}} sur {{publicationSite}}."
+				"body": "Un contributeur demande de publier le jeu de données {{{label}}} sur {{{publicationSite}}}."
 			},
 			"published": {
-				"title": "Publication de {{label}}",
-				"body": "Le jeu de données {{label}} a été publié sur {{publicationSite}}."
+				"title": "Publication de {{{label}}}",
+				"body": "Le jeu de données {{{label}}} a été publié sur {{{publicationSite}}}."
 			},
 			"published-topic": {
-				"title": "Publication de {{label}} dans {{topic}}",
-				"body": "Le jeu de données {{label}} a été publié sur {{publicationSite}} dans la thématique {{topic}}."
+				"title": "Publication de {{{label}}} dans {{{topic}}}",
+				"body": "Le jeu de données {{{label}}} a été publié sur {{{publicationSite}}} dans la thématique {{{topic}}}."
 			},
 			"draft-data-updated": {
-				"title": "Fichier brouillon mis à jour {{label}}",
-				"body": "Un nouveau fichier a été chargé sur le jeu de données {{label}} en mode brouillon."
+				"title": "Fichier brouillon mis à jour {{{label}}}",
+				"body": "Un nouveau fichier a été chargé sur le jeu de données {{{label}}} en mode brouillon."
 			},
 			"data-updated": {
-				"title": "Fichier mis à jour {{label}}",
-				"body": "Un nouveau fichier a été chargé sur le jeu de données {{label}}."
+				"title": "Fichier mis à jour {{{label}}}",
+				"body": "Un nouveau fichier a été chargé sur le jeu de données {{{label}}}."
 			},
 			"structure-updated": {
-				"title": "Changement de structure {{label}}",
-				"body": "La structure du jeu de données {{label}} a été modifiée."
+				"title": "Changement de structure {{{label}}}",
+				"body": "La structure du jeu de données {{{label}}} a été modifiée."
 			},
 			"draft-structure-updated": {
-				"title": "Changement de structure brouillon {{label}}",
-				"body": "La structure du brouillon du jeu de données {{label}} a été modifiée."
+				"title": "Changement de structure brouillon {{{label}}}",
+				"body": "La structure du brouillon du jeu de données {{{label}}} a été modifiée."
 			},
 			"draft-draft-validated": {
-				"title": "Brouillon validé {{label}}",
-				"body": "Le brouillon du jeu de données {{label}} a été validé ({{cause}})."
+				"title": "Brouillon validé {{{label}}}",
+				"body": "Le brouillon du jeu de données {{{label}}} a été validé ({{{cause}}})."
 			},
 			"breaking-change": {
-				"title": "Rupture de compatibilité de {{label}}",
-				"body": "Le jeu de données {{label}} a été modifié d'une manière qui inclue des risques de rupture de compatibilité : {{breakingChangesDesc}}."
+				"title": "Rupture de compatibilité de {{{label}}}",
+				"body": "Le jeu de données {{{label}}} a été modifié d'une manière qui inclue des risques de rupture de compatibilité : {{{breakingChangesDesc}}}."
 			},
 			"draft-draft-cancelled": {
-				"title": "Brouillon annulé {{label}}",
-				"body": "Le brouillon du jeu de données {{label}} a été annulé, il est de retour à son état validé précédent."
+				"title": "Brouillon annulé {{{label}}}",
+				"body": "Le brouillon du jeu de données {{{label}}} a été annulé, il est de retour à son état validé précédent."
 			}
 		},
 		"applications": {
 			"error": {
-				"title": "Erreur de l'application {{label}}",
-				"body": "Il y a eu une erreur pendant le traitement de l'application {{label}} : {{detail}}."
+				"title": "Erreur de l'application {{{label}}}",
+				"body": "Il y a eu une erreur pendant le traitement de l'application {{{label}}} : {{{detail}}}."
 			},
 			"application-created": {
-				"title": "Nouvelle application {{label}}",
-				"body": "L'application' {{label}} vient d'être créée."
+				"title": "Nouvelle application {{{label}}}",
+				"body": "L'application' {{{label}}} vient d'être créée."
 			},
 			"publication-requested": {
 				"title": "Demande de publication d'application'",
-				"body": "Un contributeur demande de publier l'application {{label}} sur {{publicationSite}}."
+				"body": "Un contributeur demande de publier l'application {{{label}}} sur {{{publicationSite}}}."
 			},
 			"published": {
-				"title": "Publication de {{label}}",
-				"body": "L'application {{label}} a été publiée sur {{publicationSite}}."
+				"title": "Publication de {{{label}}}",
+				"body": "L'application {{{label}}} a été publiée sur {{{publicationSite}}}."
 			},
 			"published-topic": {
-				"title": "Publication de {{label}} dans {{topic}}",
-				"body": "L'application {{label}} a été publiée sur {{publicationSite}} dans la thématique {{topic}}."
+				"title": "Publication de {{{label}}} dans {{{topic}}}",
+				"body": "L'application {{{label}}} a été publiée sur {{{publicationSite}}} dans la thématique {{{topic}}}."
 			}
 		}
 	}

--- a/api/src/misc/utils/notifications.ts
+++ b/api/src/misc/utils/notifications.ts
@@ -71,14 +71,13 @@ export const send = async (event: PushEvent, sessionState?: SessionState) => {
       // @ts-ignore
       parentPort?.postMessage(event)
     }
-  } else {
-    if (config.privateEventsUrl) {
-      if (sessionState?.user && (sessionState as SessionState & { isApiKey?: boolean }).isApiKey) {
-        event.originator = { apiKey: { id: sessionState.user.id.replace('apiKey:', ''), title: sessionState.user.name } }
-      }
-      debug('send event to events queue', event)
-      eventsQueue.pushEvent(event, sessionState)
+  }
+  if (config.privateEventsUrl) {
+    if (sessionState?.user && (sessionState as SessionState & { isApiKey?: boolean }).isApiKey) {
+      event.originator = { apiKey: { id: sessionState.user.id.replace('apiKey:', ''), title: sessionState.user.name } }
     }
+    debug('send event to events queue', event)
+    eventsQueue.pushEvent(event, sessionState)
   }
 }
 

--- a/tests/features/datasets/upload/datasets-drafts-lifecycle.api.spec.ts
+++ b/tests/features/datasets/upload/datasets-drafts-lifecycle.api.spec.ts
@@ -118,13 +118,16 @@ test.describe('datasets in draft mode - lifecycle', () => {
   test('create a draft when updating the data file', async () => {
     const notifCollector = await collectNotifications()
 
-    // Send dataset
+    // Send dataset (use a title with apostrophe and accents to detect HTML-encoding regressions in i18n)
+    const titleWithSpecialChars = "test d'apostrophe + àccéent"
     const datasetFd = fs.readFileSync('./tests/resources/datasets/dataset1.csv')
     const form = new FormData()
     form.append('file', datasetFd, 'dataset1.csv')
+    form.append('title', titleWithSpecialChars)
     const ax = testUser1
     let res = await ax.post('/api/v1/datasets', form, { headers: { 'Content-Length': form.getLengthSync(), ...form.getHeaders() } })
     let dataset = await waitForFinalize(ax, res.data.id)
+    assert.equal(dataset.title, titleWithSpecialChars)
 
     // upload a new file with incompatible schema
     const datasetFd2 = fs.readFileSync('./tests/resources/datasets/dataset2.csv')
@@ -198,6 +201,11 @@ test.describe('datasets in draft mode - lifecycle', () => {
     assert.equal(notifications[0].topic.key, 'data-fair:dataset-dataset-created:' + dataset.slug)
     assert.equal(notifications[1].topic.key, 'data-fair:dataset-draft-data-updated:' + dataset.slug)
     assert.equal(notifications[2].topic.key, 'data-fair:dataset-draft-draft-validated:' + dataset.slug)
+    // notification title and body must not be HTML-encoded (apostrophes, accents must be preserved as-is)
+    assert.equal(notifications[0].title.fr, `Nouveau jeu de données ${titleWithSpecialChars}`)
+    assert.equal(notifications[0].title.en, `New dataset ${titleWithSpecialChars}`)
+    assert.ok(notifications[0].body.fr.includes(titleWithSpecialChars), 'notification body should contain the raw title')
+    assert.ok(!JSON.stringify(notifications[0]).includes('&#39;'), 'notification must not contain HTML-encoded apostrophes')
   })
 
   test('create a draft when updating the data file and cancel it', async () => {


### PR DESCRIPTION
## Summary
- Switch i18n templates to triple-mustache (`{{{var}}}`) so dataset/application labels with apostrophes or accents are no longer HTML-encoded in notification titles/bodies.
- Always push events to the events queue when `privateEventsUrl` is configured, even in dev/worker context, so creation events are emitted in dev.
- Add regression coverage in the drafts-lifecycle API spec asserting raw special chars round-trip into notifications.
