### PR TITLE
feat: list/admin UI polish + dataset memory-cache fix on updatedAt

### DIFF
--- a/api/src/datasets/middlewares.js
+++ b/api/src/datasets/middlewares.js
@@ -84,8 +84,11 @@ export const readDataset = ({ acceptedStatuses, fillDescendants, alwaysDraft, ac
     ? await service.memoizedGetDataset(req.params.datasetId, publicationSite, mainPublicationSite, useDraft, fillDescendants, acceptInitialDraft, mongo.db, acceptedStatuses, req.body)
     : await service.getDatasetFresh(req.params.datasetId, publicationSite, mainPublicationSite, useDraft, fillDescendants, acceptInitialDraft, mongo.db, acceptedStatuses, req.body)
 
-  // bypass the memory cache if it is contradicted by the finalizedAt parameter
-  if (dataset && tolerateStale && req.query.finalizedAt && req.query.finalizedAt > dataset.finalizedAt) {
+  // bypass the memory cache if it is contradicted by the finalizedAt or updatedAt parameter
+  if (dataset && tolerateStale && (
+    (req.query.finalizedAt && req.query.finalizedAt > dataset.finalizedAt) ||
+    (req.query.updatedAt && req.query.updatedAt > dataset.updatedAt)
+  )) {
     const result = await service.getDataset(req.params.datasetId, publicationSite, mainPublicationSite, useDraft, fillDescendants, acceptInitialDraft, mongo.db, acceptedStatuses, req.body)
     dataset = result.dataset
     datasetFull = result.datasetFull

--- a/ui/src/components/dataset/dataset-facets.vue
+++ b/ui/src/components/dataset/dataset-facets.vue
@@ -56,6 +56,17 @@
       multiple
     />
     <v-autocomplete
+      v-if="keywordsItems.length"
+      v-model="keywords"
+      :items="keywordsItems"
+      :label="t('keywords')"
+      density="compact"
+      variant="outlined"
+      hide-details
+      clearable
+      multiple
+    />
+    <v-autocomplete
       v-if="publicationSitesItems.length"
       v-model="publicationSites"
       :items="publicationSitesItems"
@@ -126,6 +137,7 @@ const status = defineModel<string[]>('status', { default: () => [] })
 const draftStatus = defineModel<string[]>('draftStatus', { default: () => [] })
 const visibility = defineModel<string[]>('visibility', { default: () => [] })
 const topics = defineModel<string[]>('topics', { default: () => [] })
+const keywords = defineModel<string[]>('keywords', { default: () => [] })
 const publicationSites = defineModel<string[]>('publicationSites', { default: () => [] })
 const requestedPublicationSites = defineModel<string[]>('requestedPublicationSites', { default: () => [] })
 const services = defineModel<string[]>('services', { default: () => [] })
@@ -209,6 +221,7 @@ const statusItems = facetToItems('status', (f) => t('statusValues.' + f.value))
 const draftStatusItems = facetToItems('draftStatus', (f) => t('draftStatusValues.' + f.value))
 const visibilityItems = facetToItems('visibility', (f) => t('visibilityValues.' + f.value))
 const topicsItems = facetToItems('topics', (f) => f.value?.title || f.value, (f) => f.value?.id || f.value)
+const keywordsItems = facetToItems('keywords')
 // Fetch publication sites for current account to resolve names
 const session = useSession()
 const publicationSitesById = ref<Record<string, any>>({})
@@ -249,6 +262,7 @@ fr:
   draftStatus: Statut du brouillon
   visibility: Visibilité
   topics: Thématiques
+  keywords: Mots-clés
   publicationSites: Sites de publication
   requestedPublicationSites: Publications demandées
   services: Enrichissement
@@ -290,6 +304,7 @@ en:
   draftStatus: Draft status
   visibility: Visibility
   topics: Topics
+  keywords: Keywords
   publicationSites: Publication sites
   requestedPublicationSites: Requested publications
   services: Extensions

--- a/ui/src/components/dataset/dataset-property-transform.vue
+++ b/ui/src/components/dataset/dataset-property-transform.vue
@@ -10,8 +10,8 @@
         :color="hasTransform ? 'success' : undefined"
         :title="t('transform')"
         :icon="mdiDatabaseCog"
-        size="text"
-        variant="flat"
+        variant="text"
+        size="small"
       />
     </template>
     <v-card v-if="dialog">

--- a/ui/src/pages/admin/base-apps.vue
+++ b/ui/src/pages/admin/base-apps.vue
@@ -3,22 +3,10 @@
     <h2 class="text-title-large mb-4">
       {{ t('baseApps') }}
     </h2>
-    <v-row class="mb-2">
-      <v-col
-        cols="12"
-        sm="6"
-      >
-        <v-text-field
-          v-model="urlToAdd"
-          :label="t('add')"
-          :placeholder="t('addPlaceholder')"
-          variant="outlined"
-          density="compact"
-          hide-details
-          @keypress.enter="add.execute()"
-        />
-      </v-col>
 
+    <!-- Search and Add -->
+    <v-row class="mb-2">
+      <!-- Search -->
       <v-col
         cols="12"
         sm="6"
@@ -32,6 +20,22 @@
           hide-details
           clearable
           @keypress.enter="baseAppsFetch.refresh()"
+        />
+      </v-col>
+
+      <!-- Add base app -->
+      <v-col
+        cols="12"
+        sm="6"
+      >
+        <v-text-field
+          v-model="urlToAdd"
+          :label="t('add')"
+          :placeholder="t('addPlaceholder')"
+          variant="outlined"
+          density="compact"
+          hide-details
+          @keypress.enter="add.execute()"
         />
       </v-col>
     </v-row>

--- a/ui/src/pages/admin/info.vue
+++ b/ui/src/pages/admin/info.vue
@@ -11,6 +11,7 @@
         </v-expansion-panel-text>
       </v-expansion-panel>
     </v-expansion-panels>
+
     <div
       v-for="service of services"
       :key="service.name"
@@ -55,29 +56,29 @@
 
 <i18n lang="yaml">
   fr:
-    info: Informations
+    info: Informations sur les services
     installed: installé
     available: disponible
     services:
       data-fair/data-fair: Data Fair - Back Office
       data-fair/simple-directory: Gestion des comptes
-      data-fair/openapi-viewer: Documentation des API
-      data-fair/events: Gestion des événements/notifications
+      data-fair/events: Gestion des événements & notifications
       data-fair/catalogs: Gestion des catalogues
-      data-fair/portals: Portails
       data-fair/processings: Gestion des traitements
+      data-fair/portals: Gestion des portails
+      data-fair/openapi-viewer: Visualisateur de documentation d'API
   en:
-    info: Information
+    info: Services information
     installed: installed
     available: available
     services:
       data-fair/data-fair: Data Fair - Back Office
       data-fair/simple-directory: Accounts management
-      data-fair/openapi-viewer: API documentation
-      data-fair/events: Events/notifications management
+      data-fair/events: Events & notifications management
       data-fair/catalogs: Catalogs management
-      data-fair/portals: Portals
       data-fair/processings: Processings management
+      data-fair/portals: Portals management
+      data-fair/openapi-viewer: API documentation viewer
   </i18n>
 
 <script setup lang="ts">
@@ -92,8 +93,7 @@ breadcrumbs.receive({ breadcrumbs: [{ text: t('info') }] })
 type Service = { name: string, infoUrl: string, loaded?: boolean, error?: string, commit?: string, date?: string, version?: string }
 const services = ref<Service[]>([
   { name: 'data-fair/data-fair', infoUrl: '/data-fair/api/v1/admin/info' },
-  { name: 'data-fair/simple-directory', infoUrl: '/simple-directory/api/admin/info' },
-  { name: 'data-fair/openapi-viewer', infoUrl: '/openapi-viewer/api/admin/info' }
+  { name: 'data-fair/simple-directory', infoUrl: '/simple-directory/api/admin/info' }
 ])
 
 if ($uiConfig.eventsIntegration) {
@@ -102,11 +102,14 @@ if ($uiConfig.eventsIntegration) {
 if ($uiConfig.catalogsIntegration) {
   services.value.push({ name: 'data-fair/catalogs', infoUrl: '/catalogs/api/admin/info' })
 }
+if ($uiConfig.processingsIntegration) {
+  services.value.push({ name: 'data-fair/processings', infoUrl: '/processings/api/admin/info' })
+}
 if ($uiConfig.portalsIntegration) {
   services.value.push({ name: 'data-fair/portals', infoUrl: '/portals-manager/api/admin/info' })
 }
-if ($uiConfig.processingsIntegration) {
-  services.value.push({ name: 'data-fair/processings', infoUrl: '/processings/api/admin/info' })
+if ($uiConfig.openapiViewerIntegration) {
+  services.value.push({ name: 'data-fair/openapi-viewer', infoUrl: '/openapi-viewer/api/admin/info' })
 }
 
 onMounted(async () => {

--- a/ui/src/pages/applications/index.vue
+++ b/ui/src/pages/applications/index.vue
@@ -114,14 +114,28 @@
       />
 
       <!-- Sort select -->
-      <v-select
-        v-model="sort"
-        :label="t('sort')"
-        :items="sortItems"
-        :clearable="false"
-        class="mt-4 mx-4"
-        rounded="md"
-      />
+      <v-tooltip
+        :disabled="!searchInput"
+        :text="t('sortDisabledRelevance')"
+        location="bottom"
+      >
+        <template #activator="{ props: tooltipProps }">
+          <div
+            v-bind="tooltipProps"
+            :class="{ 'cursor-not-allowed': !!searchInput }"
+          >
+            <v-select
+              v-model="sort"
+              :label="t('sort')"
+              :items="sortItems"
+              :clearable="false"
+              :disabled="!!searchInput"
+              class="mt-4 mx-4"
+              rounded="md"
+            />
+          </div>
+        </template>
+      </v-tooltip>
 
       <!-- Super admin toggle -->
       <v-switch
@@ -281,6 +295,7 @@ fr:
   sortUpdatedAtAsc: Mise à jour (plus ancienne)
   sortTitleAsc: Titre (A → Z)
   sortTitleDesc: Titre (Z → A)
+  sortDisabledRelevance: "Tri désactivé pendant une recherche : les résultats sont triés par pertinence"
 en:
   showAll: Show all applications
   sort: Sort by
@@ -293,4 +308,5 @@ en:
   sortUpdatedAtAsc: Update (oldest)
   sortTitleAsc: Title (A → Z)
   sortTitleDesc: Title (Z → A)
+  sortDisabledRelevance: "Sorting is disabled during a search: results are sorted by relevance"
 </i18n>

--- a/ui/src/pages/datasets/index.vue
+++ b/ui/src/pages/datasets/index.vue
@@ -114,14 +114,28 @@
       />
 
       <!-- Sort select -->
-      <v-select
-        v-model="sort"
-        :label="t('sort')"
-        :items="sortItems"
-        :clearable="false"
-        class="mt-4 mx-4"
-        rounded="md"
-      />
+      <v-tooltip
+        :disabled="!searchInput"
+        :text="t('sortDisabledRelevance')"
+        location="bottom"
+      >
+        <template #activator="{ props: tooltipProps }">
+          <div
+            v-bind="tooltipProps"
+            :class="{ 'cursor-not-allowed': !!searchInput }"
+          >
+            <v-select
+              v-model="sort"
+              :label="t('sort')"
+              :items="sortItems"
+              :clearable="false"
+              :disabled="!!searchInput"
+              class="mt-4 mx-4"
+              rounded="md"
+            />
+          </div>
+        </template>
+      </v-tooltip>
 
       <!-- Super admin toggle -->
       <v-switch
@@ -300,6 +314,7 @@ fr:
   sortDataUpdatedAtAsc: Données mises à jour (plus anciennes)
   sortTitleAsc: Titre (A → Z)
   sortTitleDesc: Titre (Z → A)
+  sortDisabledRelevance: "Tri désactivé pendant une recherche : les résultats sont triés par pertinence"
   datasets: "{count} jeux de données"
 en:
   showAll: Show all datasets
@@ -314,5 +329,6 @@ en:
   sortDataUpdatedAtAsc: Data update (oldest)
   sortTitleAsc: Title (A → Z)
   sortTitleDesc: Title (Z → A)
+  sortDisabledRelevance: "Sorting is disabled during a search: results are sorted by relevance"
   datasets: "{count} datasets"
 </i18n>

--- a/ui/src/pages/datasets/index.vue
+++ b/ui/src/pages/datasets/index.vue
@@ -154,6 +154,7 @@
         v-model:draft-status="facetDraftStatus"
         v-model:visibility="facetVisibility"
         v-model:topics="facetTopics"
+        v-model:keywords="facetKeywords"
         v-model:publication-sites="facetPublicationSites"
         v-model:requested-publication-sites="facetRequestedPublicationSites"
         v-model:services="facetServices"
@@ -225,6 +226,7 @@ const facetStatus = useStringsArraySearchParam('status')
 const facetDraftStatus = useStringsArraySearchParam('draftStatus')
 const facetVisibility = useStringsArraySearchParam('visibility')
 const facetTopics = useStringsArraySearchParam('topics')
+const facetKeywords = useStringsArraySearchParam('keywords')
 const facetPublicationSites = useStringsArraySearchParam('publicationSites')
 const facetRequestedPublicationSites = useStringsArraySearchParam('requestedPublicationSites')
 const facetServices = useStringsArraySearchParam('services')
@@ -266,6 +268,7 @@ const datasetsQuery = computed(() => {
   if (facetDraftStatus.value?.length) params.draftStatus = facetDraftStatus.value.join(',')
   if (facetVisibility.value?.length) params.visibility = facetVisibility.value.join(',')
   if (facetTopics.value?.length) params.topics = facetTopics.value.join(',')
+  if (facetKeywords.value?.length) params.keywords = facetKeywords.value.join(',')
   if (facetPublicationSites.value?.length) params.publicationSites = facetPublicationSites.value.join(',')
   if (facetRequestedPublicationSites.value?.length) params.requestedPublicationSites = facetRequestedPublicationSites.value.join(',')
   if (facetServices.value?.length) params.services = facetServices.value.join(',')
@@ -280,7 +283,7 @@ const datasetsQuery = computed(() => {
 const catalog = useCatalogList<Dataset>({
   fetchUrl: computed(() => $apiPath + '/datasets'),
   query: datasetsQuery,
-  facetsFields: 'status,visibility,topics,publicationSites,requestedPublicationSites,services,concepts,owner,draftStatus',
+  facetsFields: 'status,visibility,topics,keywords,publicationSites,requestedPublicationSites,services,concepts,owner,draftStatus',
 })
 
 // Breadcrumb updates


### PR DESCRIPTION
## Summary

A bundle of small UI improvements on dataset/application listings and admin pages, plus a memory-cache fix on the API so the schema endpoint returns fresh data right after a PATCH.

## UI

### Datasets list (`ui/src/pages/datasets/index.vue`, `ui/src/components/dataset/dataset-facets.vue`)
- Add a `keywords` facet alongside the existing topics facet. Selected values are passed through the `keywords` query param and the facet is hidden when no values are available.
- Disable the *Trier par* select while a search is active, with a tooltip explaining that results are then sorted by relevance.

### Applications list (`ui/src/pages/applications/index.vue`)
- Same sort-disable + tooltip behavior as the datasets list, for consistency.

### Admin
- `ui/src/pages/admin/base-apps.vue`: swap the position of the *Search* and *Add* fields so the search field sits on the left, matching every other listing screen.
- `ui/src/pages/admin/info.vue`: rework the services list — clearer title (*Informations sur les services*), updated service labels (e.g. *Visualisateur de documentation d'API*, *Gestion des portails*), reorder so the panels render in a more logical grouping, and gate `processings` and `openapi-viewer` behind their own `*Integration` flags instead of always loading them.

### Dataset edition
- `ui/src/components/dataset/dataset-property-transform.vue`: fix the transform icon-button (was `size=\"text\" variant=\"flat\"`, which renders larger than its sibling actions and adds an unwanted background tint). Now `variant=\"text\" size=\"small\"` like the other row actions.

## API

### Memory cache (`api/src/datasets/middlewares.js`)
- The `readDataset` middleware already bypassed the in-memory dataset cache when the `finalizedAt` query param was newer than the cached value. Mirror the same logic for `updatedAt`.
- The UI sends \`?updatedAt=…\` when refetching \`/datasets/:id/schema\` right after a PATCH; before this fix the schema endpoint could serve a stale schema for up to 30s after adding a column (the memoize TTL) in production where \`tolerateStale\` is \`true\`.