### PR TITLE
fix(ui): use exposedUrl in application iframe embed snippet

### DIFF
--- a/ui/src/components/common/embed-integration.vue
+++ b/ui/src/components/common/embed-integration.vue
@@ -84,7 +84,7 @@ import { mdiCheck, mdiContentCopy } from '@mdi/js'
 
 const props = defineProps<{
   resourceType: 'datasets' | 'applications'
-  resource: { id: string, slug?: string, href?: string, previews?: { id?: string, href?: string, title?: string }[] }
+  resource: { id: string, slug?: string, href?: string, exposedUrl?: string, previews?: { id?: string, href?: string, title?: string }[] }
 }>()
 
 const { t } = useI18n()
@@ -97,7 +97,7 @@ const embedUrl = computed(() => {
   if (props.resourceType === 'datasets') {
     return props.resource.previews?.[0]?.href || ''
   }
-  return props.resource.href || ''
+  return props.resource.exposedUrl || ''
 })
 
 const syncParamsAttr = computed(() => {


### PR DESCRIPTION
## Summary

The Integration tab on an application was generating an `<iframe>` whose `src` pointed at the API route instead of the front-facing app URL:

```html
<!-- before -->
<iframe src="https://.../data-fair/api/v1/applications/1bntpa-XXymAS2W4BAIAj" ... />
<!-- after -->
<iframe src="https://.../data-fair/app/1bntpa-XXymAS2W4BAIAj" ... />
```

`ui/src/components/common/embed-integration.vue` was using `resource.href` for applications, but for an application the API exposes two distinct links (see `setResourceLinks` in `api/src/misc/utils/find.js`):
- `href` — `${publicUrl}/api/v1/applications/:id` (API endpoint)
- `exposedUrl` — `${publicUrl}/app/:id` (front-facing app URL)

The legacy UI built the snippet from `publicUrl + '/app/' + id` (`ui-legacy/public/store/application.js`), which is the same value as `exposedUrl`. Switch the embed snippet to that field; `application.href` is still used elsewhere where the API URL is the right one (e.g. card thumbnails `…/capture`).

Datasets are unaffected: their snippet already uses `previews[0].href`, which points to `/embed/dataset/:id/<view>`.