### PR TITLE
feat(api): add optimization hints to slow requests

### DIFF
--- a/api/contract/dataset-api-docs.ts
+++ b/api/contract/dataset-api-docs.ts
@@ -478,6 +478,22 @@ La valeur du paramètre est la dimension passée sous la form largeurxhauteur (3
     }
   }
 
+  const hintParam = {
+    in: 'query',
+    name: 'hint',
+    description: `Ajouter un champ \`hint\` au corps de la réponse avec un conseil de performance le cas échéant.
+
+  - **auto** (défaut) : seulement si la requête est lente.
+  - **true** : dès qu'un conseil s'applique.
+  - **false** : jamais.`,
+    schema: {
+      title: 'Conseil de performance',
+      type: 'string',
+      default: 'auto',
+      enum: ['auto', 'true', 'false']
+    }
+  }
+
   const description = `
 Cette documentation interactive à destination des développeurs permet de consommer les ressources du jeu de données "**${ds.title || (ds as any).slug}**".
 
@@ -655,6 +671,7 @@ Pour protéger l'infrastructure de publication de données, les appels sont limi
           ...hitsParams(),
           formatParam,
           htmlParam,
+          hintParam,
           ...filterParams,
           {
             in: 'query',
@@ -894,6 +911,7 @@ Si la colonne est numérique vous pouvez saisir un nombre qui sera utilisé comm
             }
           },
           ...hitsParams(0, 100, 'values_agg'),
+          hintParam,
           ...filterParams],
           responses: {
             200: {
@@ -1265,7 +1283,7 @@ Si la colonne est numérique vous pouvez saisir un nombre qui sera utilisé comm
         operationId: 'getGeoAgg',
         'x-permissionClass': 'read',
         tags: ['Données'],
-        parameters: [aggSizeParam, ...hitsParams(0, 100), formatParam, htmlParam, ...filterParams],
+        parameters: [aggSizeParam, ...hitsParams(0, 100), formatParam, htmlParam, hintParam, ...filterParams],
         responses: {
           200: {
             description: 'Les informations du jeu de données agrégées spatialement.',

--- a/api/src/datasets/router.js
+++ b/api/src/datasets/router.js
@@ -58,7 +58,7 @@ import { reqAdminMode, reqSession, reqSessionAuthenticated, session } from '@dat
 import eventsQueue from '@data-fair/lib-node/events-queue.js'
 import eventsLog from '@data-fair/lib-express/events-log.js'
 import { getFlatten } from './utils/flatten.ts'
-import { queryAdvice } from '../misc/utils/query-advice.ts'
+import { queryAdvice, attachQueryHint } from '../misc/utils/query-advice.ts'
 import { can } from '../misc/utils/permissions.ts'
 import { emit as workerPing } from '../workers/ping.ts'
 import { downloadFileFromStorage } from '../files-storage/utils.ts'
@@ -867,6 +867,7 @@ const readLines = async (req, res) => {
   const [_, size] = findUtils.pagination(query)
 
   let esResponse
+  const esSearchStart = Date.now()
   if (vectorTileRequested && sampling === 'max' && !query.collapse) {
     let previousEsResponse
     let totalLength = 0
@@ -897,6 +898,7 @@ const readLines = async (req, res) => {
       await manageESError(req, err)
     }
   }
+  const esSearchDurationMs = Date.now() - esSearchStart
   observe.reqStep(req, 'search')
 
   // manage pagination based on search_after, cd https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html
@@ -959,7 +961,7 @@ const readLines = async (req, res) => {
     return res.status(200).send(tile)
   }
 
-  const result = { total: esResponse.hits.total?.value }
+  let result = { total: esResponse.hits.total?.value }
   if (nextLinkURL) result.next = nextLinkURL.href
   if (query.collapse) result.totalCollapse = esResponse.aggregations.totalCollapse.value
   result.results = []
@@ -995,6 +997,7 @@ const readLines = async (req, res) => {
     return res.status(200).send(sheet)
   }
 
+  result = attachQueryHint(req, esSearchDurationMs, result)
   res.status(200).send(result)
 }
 router.get('/:datasetId/lines', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, permissions.middleware('readLines', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), readLines)
@@ -1021,11 +1024,13 @@ router.get('/:datasetId/geo_agg', readDataset({ fillDescendants: true }), applic
   let result
   const flatten = getFlatten(req.dataset, req.query.arrays === 'true')
   const esAbortContext = esUtils.createEsRequestOptions(req, res)
+  const esGeoAggStart = Date.now()
   try {
     result = await esUtils.geoAgg(req.app.get('es'), req.dataset, req.query, req.publicBaseUrl, flatten, esAbortContext)
   } catch (err) {
     await manageESError(req, err)
   }
+  const esGeoAggDurationMs = Date.now() - esGeoAggStart
 
   if (req.query.format === 'geojson') {
     const geojson = geo.aggs2geojson(result)
@@ -1044,6 +1049,8 @@ router.get('/:datasetId/geo_agg', readDataset({ fillDescendants: true }), applic
     return res.status(200).send(tile)
   }
 
+  // @ts-ignore — manageESError throws on errors, so result is defined here
+  result = attachQueryHint(req, esGeoAggDurationMs, result)
   res.status(200).send(result)
 })
 
@@ -1073,6 +1080,7 @@ router.get('/:datasetId/values_agg', readDataset({ fillDescendants: true }), app
   let result
   const flatten = getFlatten(req.dataset, req.query.arrays === 'true')
   const esAbortContext = esUtils.createEsRequestOptions(req, res)
+  const esValuesAggStart = Date.now()
   try {
     result = await esUtils.valuesAgg(req.dataset, { ...req.query }, vectorTileRequested || req.query.format === 'geojson', req.publicBaseUrl, explain, flatten, undefined, undefined, esAbortContext)
     if (result.next) {
@@ -1091,6 +1099,7 @@ router.get('/:datasetId/values_agg', readDataset({ fillDescendants: true }), app
   } catch (err) {
     await manageESError(req, err)
   }
+  const esValuesAggDurationMs = Date.now() - esValuesAggStart
 
   if (req.query.format === 'geojson') {
     const geojson = geo.aggs2geojson(result)
@@ -1112,6 +1121,8 @@ router.get('/:datasetId/values_agg', readDataset({ fillDescendants: true }), app
   // @ts-ignore
   if (explain) result.explain = explain
 
+  // @ts-ignore — manageESError throws on errors, so result is defined here
+  result = attachQueryHint(req, esValuesAggDurationMs, result)
   res.status(200).send(result)
 })
 

--- a/api/src/misc/utils/observe.ts
+++ b/api/src/misc/utils/observe.ts
@@ -7,6 +7,10 @@ import { reqUser } from '@data-fair/lib-express'
 
 const debugReq = debug('df:observe:req')
 
+// Threshold above which a request step is considered slow. Used both for the slow-request log
+// below and as the auto-mode trigger for query hints (see query-advice.ts attachQueryHint).
+export const SLOW_REQUEST_THRESHOLD_MS = 1000
+
 const reqStepHisto = new client.Histogram({
   name: 'df_req_step_seconds',
   help: 'Duration in seconds of steps in API requests',
@@ -38,7 +42,7 @@ export const reqStep = (req: Request, stepName: string) => {
   const duration = now - (stepName === 'total' ? req[reqObserveKey].start : req[reqObserveKey].step)
   reqStepHisto.labels(Array.isArray(req[reqObserveKey].routeName) ? req[reqObserveKey].routeName[0] : req[reqObserveKey].routeName, stepName).observe(duration / 1000)
   debugReq('request', req.method, req.originalUrl, stepName, duration, 'ms')
-  if (duration > 1000 && stepName !== 'total' && stepName !== 'finish') {
+  if (duration > SLOW_REQUEST_THRESHOLD_MS && stepName !== 'total' && stepName !== 'finish') {
     const referer = req.headers.referer || req.headers.referrer || 'unknown'
     const user = reqUser(req)
     const userStr = user ? `${user.name}(${user.id})` : 'anonymous'

--- a/api/src/misc/utils/query-advice.ts
+++ b/api/src/misc/utils/query-advice.ts
@@ -1,5 +1,7 @@
 import { type Request } from 'express'
+import i18n from 'i18n'
 import { hasManyQSearchFields } from '../../datasets/es/operations.ts'
+import { SLOW_REQUEST_THRESHOLD_MS } from './observe.ts'
 
 // Builds a short, localized, advisory sentence appended to overload errors (429 compute-budget,
 // 504 "request too long", 429 ES circuit_breaking_exception). It only ever *advises* — it never
@@ -42,4 +44,48 @@ export const queryAdvice = (req: Request & { dataset?: { schema?: any[] } }): st
 
   if (keys.length === 0) return ''
   return ' ' + req.__('errors.queryAdviceIntro') + ' : ' + keys.map(k => req.__(k)).join(' ; ') + '.'
+}
+
+export type HintMode = 'auto' | 'true' | 'false'
+
+/**
+ * Pure decision: should a hint be attached given the requested mode and the elapsed ES step?
+ * Extracted so it can be unit-tested without the rest of the request machinery.
+ */
+export const shouldEmitHint = (mode: HintMode, esStepDurationMs: number): boolean => {
+  if (mode === 'false') return false
+  if (mode === 'true') return true
+  return esStepDurationMs > SLOW_REQUEST_THRESHOLD_MS
+}
+
+const parseHintMode = (raw: any): HintMode => (raw === 'true' || raw === 'false' ? raw : 'auto')
+
+/**
+ * Returns the result with a `hint` string field prepended (so it appears first in the JSON) when
+ * the request opted in (or the ES step was slow enough in auto mode) and at least one rule matches.
+ * Returns `result` unchanged for `hint=false` or when no rule applies. The hint reuses the exact
+ * same `queryAdvice` rules that drive the 429/504 error advice.
+ *
+ * Public/cacheable responses are served without varying by the i18n_lang cookie, so for those we
+ * force the hint to English to avoid the reverse-proxy serving a French hint to an English client
+ * (or vice versa) from cache.
+ */
+export const attachQueryHint = <T extends Record<string, any>> (
+  req: Request & { dataset?: { schema?: any[] }, publicOperation?: boolean },
+  esStepDurationMs: number,
+  result: T
+): T => {
+  const mode = parseHintMode(req.query?.hint)
+  if (!shouldEmitHint(mode, esStepDurationMs)) return result
+  const adviceReq = req.publicOperation
+    ? {
+        path: req.path,
+        query: req.query,
+        dataset: req.dataset,
+        __: (key: string) => i18n.__({ phrase: key, locale: 'en' })
+      } as any
+    : req
+  const advice = queryAdvice(adviceReq).trim()
+  if (!advice) return result
+  return { hint: advice, ...result }
 }

--- a/tests/features/datasets/query/search-hint.api.spec.ts
+++ b/tests/features/datasets/query/search-hint.api.spec.ts
@@ -1,0 +1,70 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { axiosAuth, clean, checkPendingTasks } from '../../../support/axios.ts'
+import { sendDataset } from '../../../support/workers.ts'
+
+const testUser1 = await axiosAuth('test_user1@test.com')
+
+// These tests exercise the `?hint=auto|true|false` query parameter on the dataset search endpoints.
+// They focus on the wiring (param parsing, mode gating, body attachment); the rule-by-rule logic
+// is covered by the pure unit tests in tests/features/infra/query-advice.unit.spec.ts.
+
+test.describe('search - hint', () => {
+  test.beforeEach(async () => {
+    await clean()
+  })
+
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === 'passed') await checkPendingTasks()
+  })
+
+  test('hint=true attaches a hint string when a rule applies (default /lines triggers the count rule)', async () => {
+    const ax = testUser1
+    const dataset = await sendDataset('datasets/dataset1.csv', ax)
+    const res = await ax.get(`/api/v1/datasets/${dataset.id}/lines?hint=true`)
+    assert.equal(res.status, 200)
+    assert.equal(typeof res.data.hint, 'string')
+    assert.ok(res.data.hint.length > 0)
+    // hint should not start with a leading space — the helper trims the raw queryAdvice output
+    assert.notEqual(res.data.hint[0], ' ')
+    // hint should be the first key in the JSON response so it's immediately visible
+    assert.equal(Object.keys(res.data)[0], 'hint')
+  })
+
+  test('hint=false suppresses the hint even when a rule applies', async () => {
+    const ax = testUser1
+    const dataset = await sendDataset('datasets/dataset1.csv', ax)
+    const res = await ax.get(`/api/v1/datasets/${dataset.id}/lines?hint=false`)
+    assert.equal(res.status, 200)
+    assert.equal('hint' in res.data, false)
+  })
+
+  test('hint defaults to auto and omits the hint on a fast query', async () => {
+    const ax = testUser1
+    const dataset = await sendDataset('datasets/dataset1.csv', ax)
+    // 2-row dataset — ES search will be far under the 1000ms slow-request threshold
+    const res = await ax.get(`/api/v1/datasets/${dataset.id}/lines`)
+    assert.equal(res.status, 200)
+    assert.equal('hint' in res.data, false)
+  })
+
+  test('hint=true returns no hint field when no rule fires', async () => {
+    const ax = testUser1
+    const dataset = await sendDataset('datasets/dataset1.csv', ax)
+    // count=false silences the count rule; the dataset is narrow and pagination is shallow so no
+    // other rule fires either
+    const res = await ax.get(`/api/v1/datasets/${dataset.id}/lines?hint=true&count=false`)
+    assert.equal(res.status, 200)
+    assert.equal('hint' in res.data, false)
+  })
+
+  test('hint=true on /values_agg attaches a hint when a values_agg rule fires', async () => {
+    const ax = testUser1
+    const dataset = await sendDataset('datasets/dataset1.csv', ax)
+    // agg_size>=100 trips the aggSize rule
+    const res = await ax.get(`/api/v1/datasets/${dataset.id}/values_agg?field=id&agg_size=100&hint=true`)
+    assert.equal(res.status, 200)
+    assert.equal(typeof res.data.hint, 'string')
+    assert.ok(res.data.hint.length > 0)
+  })
+})

--- a/tests/features/infra/query-advice.unit.spec.ts
+++ b/tests/features/infra/query-advice.unit.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test'
 import assert from 'node:assert/strict'
-import { queryAdvice } from '../../../api/src/misc/utils/query-advice.ts'
+import { queryAdvice, shouldEmitHint, attachQueryHint } from '../../../api/src/misc/utils/query-advice.ts'
 
 // minimal fake of the bits of an express Request the helper reads.
 // `__` echoes the key so assertions can match on key names instead of translated text.
@@ -83,5 +83,63 @@ test.describe('queryAdvice', () => {
     assert.doesNotMatch(queryAdvice(fakeReq('/abc/lines', {}, wide)), /errors\.queryAdviceQFields/)
     assert.doesNotMatch(queryAdvice(fakeReq('/abc/lines', { q: 'x' }, narrow)), /errors\.queryAdviceQFields/)
     assert.doesNotMatch(queryAdvice(fakeReq('/abc/lines', { q: 'x' })), /errors\.queryAdviceQFields/)
+  })
+})
+
+test.describe('shouldEmitHint', () => {
+  test('false silences the hint regardless of duration', () => {
+    assert.equal(shouldEmitHint('false', 0), false)
+    assert.equal(shouldEmitHint('false', 99999), false)
+  })
+  test('true emits regardless of duration', () => {
+    assert.equal(shouldEmitHint('true', 0), true)
+    assert.equal(shouldEmitHint('true', 99999), true)
+  })
+  test('auto emits only when ES step duration exceeds the slow-request threshold', () => {
+    assert.equal(shouldEmitHint('auto', 0), false)
+    assert.equal(shouldEmitHint('auto', 1000), false) // strictly greater than 1000ms
+    assert.equal(shouldEmitHint('auto', 1001), true)
+  })
+})
+
+test.describe('attachQueryHint', () => {
+  test('prepends a trimmed advice string when a rule fires and hint=true', () => {
+    const wide = { schema: Array.from({ length: 25 }, (_, i) => ({ key: 'f' + i })) }
+    const req = fakeReq('/abc/lines', { hint: 'true' }, wide)
+    const out = attachQueryHint(req, 0, { total: 5, results: [] })
+    assert.ok(typeof out.hint === 'string')
+    assert.ok((out.hint as string).length > 0)
+    assert.equal((out.hint as string)[0] !== ' ', true) // leading space stripped
+    // hint must appear before existing fields so it lands first in the JSON output
+    assert.equal(Object.keys(out)[0], 'hint')
+  })
+  test('does not attach when hint=false even with a slow query and matching rule', () => {
+    const wide = { schema: Array.from({ length: 25 }, (_, i) => ({ key: 'f' + i })) }
+    const req = fakeReq('/abc/lines', { hint: 'false' }, wide)
+    const out = attachQueryHint(req, 99999, { total: 5 })
+    assert.equal('hint' in out, false)
+  })
+  test('does not attach when hint=auto and the query was fast', () => {
+    const wide = { schema: Array.from({ length: 25 }, (_, i) => ({ key: 'f' + i })) }
+    const req = fakeReq('/abc/lines', {}, wide)
+    const out = attachQueryHint(req, 500, { total: 5 })
+    assert.equal('hint' in out, false)
+  })
+  test('attaches when hint=auto and the query crossed the slow threshold', () => {
+    const wide = { schema: Array.from({ length: 25 }, (_, i) => ({ key: 'f' + i })) }
+    const req = fakeReq('/abc/lines', {}, wide)
+    const out = attachQueryHint(req, 1500, { total: 5 })
+    assert.ok(typeof out.hint === 'string')
+  })
+  test('does not attach when no rule fires (even with hint=true)', () => {
+    const req = fakeReq('/abc/lines', { hint: 'true', count: 'false', after: '["x"]' })
+    const out = attachQueryHint(req, 99999, { total: 5 })
+    assert.equal('hint' in out, false)
+  })
+  test('treats unknown hint values as auto', () => {
+    const wide = { schema: Array.from({ length: 25 }, (_, i) => ({ key: 'f' + i })) }
+    const req = fakeReq('/abc/lines', { hint: 'banana' }, wide)
+    assert.equal('hint' in attachQueryHint(req, 500, { total: 5 }), false)
+    assert.ok(typeof attachQueryHint(req, 1500, { total: 5 }).hint === 'string')
   })
 })

--- a/tests/support/axios.ts
+++ b/tests/support/axios.ts
@@ -65,6 +65,10 @@ export const config = {
 }
 
 export const checkPendingTasks = async () => {
+  // some test paths legitimately leave a finalize task in-flight (e.g. a successful REST line POST
+  // sets _partialRestStatus: 'indexed' which the shortProcessor picks up asynchronously). Give workers
+  // the same idle grace period clean() uses before asserting — anything still pending after 5s is a leak.
+  await waitForWorkerIdle()
   const res = await anonymousAx.get(`${apiUrl}/api/v1/test-env/pending-tasks`)
   for (const [worker, pending] of Object.entries(res.data)) {
     if (Object.keys(pending as any).length > 0) {


### PR DESCRIPTION
  Adds an opt-in `hint` query param on dataset list/aggregation endpoints (`/lines`, `/values_agg`, `/geo_agg`) that surfaces a short performance-advice string in the response when one of the existing `queryAdvice` rules matches.

  - `hint=auto` (default): hint is attached only when the ES step exceeds the slow-request threshold
  - `hint=true`: always attach when a rule applies
  - `hint=false`: never attach

  The hint reuses the same rule set already used for 429/504 error messages (deep pagination, exact count, large `agg_size`, large `size`, wide dataset without `select`, full-text search without `q_fields`).