### PR TITLE
fix(api): lower memory usage of streaming API responses

### DIFF
--- a/api/src/api-compat/ods/index.ts
+++ b/api/src/api-compat/ods/index.ts
@@ -600,9 +600,14 @@ const exports = (version: '2.0' | '2.1') => async (req, res, next) => {
   }
   try {
     await pump(
-      Readable.from(iterHits(esClient, dataset, esQuery, aliases, selectSource, selectAggs, selectTransforms, query.limit ? Number(query.limit) : -1, grouped, composite, query.timezone, preserveArrays)),
+      // tight hwm: iterHits yields whole batches (~1000 hits each). With the default object-mode
+      // hwm of 16 the upstream readable + downstream writable would pre-buffer up to ~32 batches
+      // (~32 000 hits) per stuck/slow stream — concurrent slow consumers multiply that into GiBs of
+      // retained external memory. Keep ~1-2 batches in flight instead.
+      Readable.from(iterHits(esClient, dataset, esQuery, aliases, selectSource, selectAggs, selectTransforms, query.limit ? Number(query.limit) : -1, grouped, composite, query.timezone, preserveArrays), { highWaterMark: 2 }),
       new Transform({
         objectMode: true,
+        writableHighWaterMark: 2,
         transform (items, encoding, callback) {
           for (const item of items) this.push(item)
           callback(null)

--- a/api/src/api-compat/ods/index.ts
+++ b/api/src/api-compat/ods/index.ts
@@ -390,7 +390,7 @@ const getRecords = (version: '2.0' | '2.1') => async (req, res, next) => {
 
 const maxChunkSize = 1000
 
-async function * iterHits (es, dataset, esQuery, aliases, selectSource, selectAggs, selectTransforms, totalSize, grouped, composite, timezone = 'utc', preserveArrays = false) {
+async function * iterHits (es, dataset, esQuery, aliases, selectSource, selectAggs, selectTransforms, totalSize, grouped, composite, timezone = 'utc', preserveArrays = false, abortContext?: esUtils.EsAbortContext) {
   const flatten = getFlatten(dataset, preserveArrays, selectSource)
 
   let chunkSize = maxChunkSize
@@ -404,7 +404,7 @@ async function * iterHits (es, dataset, esQuery, aliases, selectSource, selectAg
       body: { ...esQuery, size },
       timeout: config.elasticsearch.searchTimeout,
       allow_partial_search_results: false
-    }))
+    }, abortContext))
 
     const lines = []
     if (grouped) {
@@ -448,6 +448,13 @@ const exports = (version: '2.0' | '2.1') => async (req, res, next) => {
   const { grouped, from, esQuery, selectAggs, selectSource, selectFinalKeys, selectTransforms, aliases, composite } = prepareEsQuery(dataset, query, 'exports')
 
   if (from) throw httpError(400, 'offset parameter is not supported for exports')
+
+  // abort the streaming ES iteration as soon as the http client goes away — without this, iterHits
+  // keeps paging from ES while csv-stringify / format streams keep buffering parsed rows in memory
+  // until server.requestTimeout (15 min) fires. The AbortController fires on res 'close' (unless
+  // writableEnded), cancels the in-flight ES search, and the iterHits generator throws AbortError
+  // → pump tears the pipeline down, releasing every batch/Buffer along the way.
+  const esAbortContext = esUtils.createEsRequestOptions(req, res)
 
   if (req.params.format === 'geojson') {
     const geoshapeProp = req.dataset.schema.find(p => p.key === '_geoshape')
@@ -505,7 +512,7 @@ const exports = (version: '2.0' | '2.1') => async (req, res, next) => {
       const worksheet = workbookWriter.addWorksheet('Feuille 1')
       // Define columns (optional)
       worksheet.columns = columns
-      const iter = iterHits(esClient, dataset, esQuery, aliases, selectSource, selectAggs, selectTransforms, query.limit ? Number(query.limit) : -1, grouped, composite, query.timezone)
+      const iter = iterHits(esClient, dataset, esQuery, aliases, selectSource, selectAggs, selectTransforms, query.limit ? Number(query.limit) : -1, grouped, composite, query.timezone, false, esAbortContext)
       for await (const items of iter) {
         for (const item of items) {
           worksheet.addRow(item).commit()
@@ -516,7 +523,8 @@ const exports = (version: '2.0' | '2.1') => async (req, res, next) => {
       // compatReqCounter.inc({ route: 'exports', status: 'ok' })
     } catch (err) {
       const { message, status } = esUtils.extractError(err)
-      logCompatODSError(err, req.url, 'exports', 'xlsx-error', dataset.id)
+      // 499 = the http client gave up, the search was aborted: nothing to log or report
+      if (status !== 499) logCompatODSError(err, req.url, 'exports', 'xlsx-error', dataset.id)
       throw httpError(status, (status === 504 || status === 429) ? message + queryAdvice(req) : message)
     }
     // return early, xlsx export is written directly ro response,
@@ -604,7 +612,7 @@ const exports = (version: '2.0' | '2.1') => async (req, res, next) => {
       // hwm of 16 the upstream readable + downstream writable would pre-buffer up to ~32 batches
       // (~32 000 hits) per stuck/slow stream — concurrent slow consumers multiply that into GiBs of
       // retained external memory. Keep ~1-2 batches in flight instead.
-      Readable.from(iterHits(esClient, dataset, esQuery, aliases, selectSource, selectAggs, selectTransforms, query.limit ? Number(query.limit) : -1, grouped, composite, query.timezone, preserveArrays), { highWaterMark: 2 }),
+      Readable.from(iterHits(esClient, dataset, esQuery, aliases, selectSource, selectAggs, selectTransforms, query.limit ? Number(query.limit) : -1, grouped, composite, query.timezone, preserveArrays, esAbortContext), { highWaterMark: 2 }),
       new Transform({
         objectMode: true,
         writableHighWaterMark: 2,
@@ -619,7 +627,8 @@ const exports = (version: '2.0' | '2.1') => async (req, res, next) => {
     )
   } catch (err) {
     const { message, status } = esUtils.extractError(err)
-    logCompatODSError(err, req.url, 'exports', 'stream-error', dataset.id)
+    // 499 = the http client gave up, the search was aborted: nothing to log or report
+    if (status !== 499) logCompatODSError(err, req.url, 'exports', 'stream-error', dataset.id)
     throw httpError(status, (status === 504 || status === 429) ? message + queryAdvice(req) : message)
   }
   // compatReqCounter.inc({ route: 'exports', status: 'ok' })

--- a/api/src/datasets/utils/rest.ts
+++ b/api/src/datasets/utils/rest.ts
@@ -1339,10 +1339,13 @@ export const applyTTL = async (dataset: RestDataset) => {
   // @ts-ignore
   const iter = iterHits(dataset, { size: 1000, qs })
   await pump(
-    Readable.from(iter),
+    // tight hwm: see comment at api-compat/ods/index.ts — keep ~1-2 batches in flight rather than
+    // the default 16 to bound per-stream retained memory.
+    Readable.from(iter, { highWaterMark: 2 }),
     // @ts-ignore
     new Transform({
       objectMode: true,
+      writableHighWaterMark: 2,
       transform (hits, encoding, callback) {
         for (const hit of hits) {
           this.push({ _action: 'delete', _id: hit._id })

--- a/api/src/misc/utils/rate-limiting.ts
+++ b/api/src/misc/utils/rate-limiting.ts
@@ -55,7 +55,11 @@ export const clear = () => {
 export const getRateLimiter = (req: Request, limitType: string, throttlingKey = '') => {
   const user = reqUser(req)
   const throttlingId = throttlingKey + '_' + (user ? user.id : requestIp.getClientIp(req)) + '_' + limitType
+  // init lastUsed at creation so the 20-min sweep can detect this entry as idle later — without it,
+  // a limiter that's never followed by a consume() (or whose consume() path errors out) stays with
+  // lastUsed=undefined forever (undefined < threshold is always false → never deleted).
   const rateLimiter = rateLimiters[throttlingId] = rateLimiters[throttlingId] || {
+    lastUsed: Date.now(),
     rateLimiter: new RateLimiter({
       tokensPerInterval: config.defaultLimits.apiRate[limitType].nb,
       interval: config.defaultLimits.apiRate[limitType].duration * 1000
@@ -104,8 +108,13 @@ export const getTokenBucket = (req, limitType, bandwidthType) => {
   const user = reqUser(req)
   const throttlingId = user ? user.id : requestIp.getClientIp(req)
   const bucketSize = config.defaultLimits.apiRate[limitType].bandwidth[bandwidthType] * burstFactor
+  // init lastUsed at creation so the 20-min sweep can detect this entry as idle later — every call
+  // to res.throttle() creates a bucket via this path but lastUsed is only set inside the Throttle
+  // _transform; a stream that never receives bytes (empty body, immediate error before any chunk)
+  // would leave lastUsed=undefined and the sweep would skip it forever.
   const tokenBucket: TokenBucketWrapper = tokenBuckets[throttlingId + bandwidthType] = tokenBuckets[throttlingId + bandwidthType] || {
     bucketSize,
+    lastUsed: Date.now(),
     bucket: new TokenBucket({
       bucketSize,
       tokensPerInterval: config.defaultLimits.apiRate[limitType].bandwidth[bandwidthType],
@@ -117,18 +126,29 @@ export const getTokenBucket = (req, limitType, bandwidthType) => {
 
 class Throttle extends Transform {
   tokenBucket: TokenBucketWrapper
+  // resolves to `true` once the Throttle is closed (normal end or destroy/abort). Used to race against
+  // `removeTokens`: without this the slice currently waiting for tokens would be retained for up to one
+  // refill window (bucketSize / bandwidth seconds) after the request was aborted, multiplied by every
+  // stalled stream from the same client. Underscore-prefixed to avoid clashing with Readable.closed.
+  private _closedPromise: Promise<true>
 
   constructor (tokenBucket: TokenBucketWrapper) {
     super()
     this.tokenBucket = tokenBucket
+    this._closedPromise = new Promise<true>(resolve => this.once('close', () => resolve(true)))
   }
 
   async transformPromise (chunk: Buffer, encoding: string) {
     this.tokenBucket.lastUsed = Date.now()
     let pos = 0
     while (chunk.length > pos) {
+      if (this.destroyed) return
       const slice = chunk.subarray(pos, pos + this.tokenBucket.bucketSize)
-      await this.tokenBucket.bucket.removeTokens(slice.length)
+      const stop = await Promise.race([
+        this.tokenBucket.bucket.removeTokens(slice.length).then(() => false as const),
+        this._closedPromise
+      ])
+      if (stop) return // stream torn down mid-wait — drop the slice, let it be GC'd
       this.push(slice)
       pos += slice.length
     }
@@ -139,11 +159,20 @@ class Throttle extends Transform {
   }
 }
 
-const throttledEnd = async (res: Response, buffer: Buffer, tokenBucket) => {
+const throttledEnd = async (res: Response, buffer: Buffer, tokenBucket: TokenBucketWrapper) => {
+  // mirror the Throttle abort race for the wrapped res.end path — if the client disconnects while we're
+  // waiting on tokens, stop awaiting and drop the rest of `buffer` instead of holding it for the full
+  // refill window
+  const closed = new Promise<true>(resolve => res.once('close', () => resolve(true)))
   let pos = 0
   while (buffer.length > pos) {
+    if (res.writableEnded || res.destroyed) return
     const slice = buffer.subarray(pos, pos + tokenBucket.bucketSize)
-    await tokenBucket.bucket.removeTokens(slice.length)
+    const stop = await Promise.race([
+      tokenBucket.bucket.removeTokens(slice.length).then(() => false as const),
+      closed
+    ])
+    if (stop) return
     res.write(slice)
     pos += slice.length
   }

--- a/api/src/workers/files-manager/initialize.ts
+++ b/api/src/workers/files-manager/initialize.ts
@@ -166,9 +166,12 @@ export default async function (dataset: DatasetInternal) {
           if (hasAttachments && parentDataset.isVirtual) select.push('_attachment_url')
           const iter = iterHits(parentDataset, { size: 1000, select: select.join(',') })
           inputStreams = [
-            Readable.from(iter),
+            // tight hwm: see comment at api-compat/ods/index.ts — keep ~1-2 batches in flight
+            // rather than the default 16 to bound per-stream retained memory.
+            Readable.from(iter, { highWaterMark: 2 }),
             new Transform({
               objectMode: true,
+              writableHighWaterMark: 2,
               transform (hits, encoding, callback) {
                 for (const hit of hits) {
                   if (hasAttachments && parentDataset.isVirtual && hit._source._attachment_url) {


### PR DESCRIPTION
  - **Tighten highWaterMark on iterHits** → Transform pipelines (ods/index.ts, datasets/utils/rest.ts, workers/files-manager/initialize.ts): batches are ~1000 hits; the default object-mode hwm of 16 was letting ~32 000 parsed rows sit in flight per stream. Set highWaterMark: 2 on the source and writableHighWaterMark: 2 on the expansion Transform.
  - Wire ODS /exports for disconnect-abort (api-compat/ods/index.ts): mirror the /records pattern — createEsRequestOptions(req, res) and thread the esAbortContext through both iterHits call sites so a TCP disconnect cancels the in-flight ES search and tears the pipeline down immediately. Also skip logCompatODSError for 499 to match /records.
  - Throttle releases its in-flight slice on abort (misc/utils/rate-limiting.ts): race tokenBucket.removeTokens() against the stream's close event so the awaited buffer slice is GC'able right away instead of being held until the next refill. Initialize lastUsed at wrapper creation so the 20-min sweep can actually reap entries whose first use never fired.
