### PR TITLE
chore(ui): misc UI fixes and tweaks

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   use: {
     baseURL: `http://${process.env.DEV_HOST}:${process.env.NGINX_PORT1}/data-fair`,
     actionTimeout: 5_000,
-    navigationTimeout: 5_000,
+    navigationTimeout: 10_000,
   },
 
   projects: [

--- a/ui/src/components/dataset/dataset-diagnose.vue
+++ b/ui/src/components/dataset/dataset-diagnose.vue
@@ -57,8 +57,12 @@
                   :key="row.key"
                   class="py-0"
                 >
-                  <dt class="d-inline text-medium-emphasis">{{ row.label }}:</dt>
-                  <dd class="d-inline ml-1">{{ row.value }}</dd>
+                  <dt class="d-inline text-medium-emphasis">
+                    {{ row.label }}:
+                  </dt>
+                  <dd class="d-inline ml-1">
+                    {{ row.value }}
+                  </dd>
                 </div>
               </dl>
             </v-card-text>

--- a/ui/src/components/dataset/dataset-status.vue
+++ b/ui/src/components/dataset/dataset-status.vue
@@ -9,7 +9,9 @@
         <p
           v-if="lastProdEvent"
           style="white-space: pre-line"
-        >{{ lastProdEvent.data }}</p>
+        >
+          {{ lastProdEvent.data }}
+        </p>
         <template #append>
           <v-btn
             color="primary"
@@ -67,12 +69,16 @@
           v-if="draftError"
           class="mt-4 font-weight-bold"
           style="white-space: pre-line"
-        >{{ draftError.data }}</p>
+        >
+          {{ draftError.data }}
+        </p>
         <p
           v-if="draftValidationError"
           class="mt-4 font-weight-bold"
           style="white-space: pre-line"
-        >{{ draftValidationError.data }}</p>
+        >
+          {{ draftValidationError.data }}
+        </p>
         <p class="mt-4">
           <span v-if="dataset.draftReason.key === 'file-new'">
             {{ t('draftNew2') }}&nbsp;

--- a/ui/src/components/dataset/rest/dataset-rest-upload-actions.vue
+++ b/ui/src/components/dataset/rest/dataset-rest-upload-actions.vue
@@ -48,7 +48,7 @@
               variant="outlined"
               density="compact"
               hide-details
-              accept=".csv,.geojson,.xlsx,.ods,.xls"
+              accept=".csv,.tsv,.geojson,.json,.ndjson,.xlsx,.ods,.fods,.xls,.dbf"
               :rules="[(file) => !!file || '']"
             >
               <template

--- a/ui/src/components/dataset/table/dataset-table.vue
+++ b/ui/src/components/dataset/table/dataset-table.vue
@@ -515,7 +515,7 @@ const sort = computed<{ key: string, direction: 1 | -1 } | undefined>({
 
 const display = useDisplay()
 
-const { dataset, id: datasetId } = useDatasetStore()
+const { dataset, id: datasetId, imageField } = useDatasetStore()
 // const charsWidths = ref<Record<string, number> | null>(null)
 
 const allCols = computed(() => dataset.value?.schema?.filter(field => !field['x-calculated'] || field.key === '_updatedAt' || field.key === '_updatedByName').map(p => p.key) ?? [])
@@ -562,7 +562,11 @@ const dataQualityContext = computed(() => {
 })
 
 const conceptFilters = useConceptFilters(useReactiveSearchParams())
-const extraParams = computed(() => ({ ...filtersQueryParams.value, ...conceptFilters }))
+const extraParams = computed(() => ({
+  ...filtersQueryParams.value,
+  ...conceptFilters,
+  ...(imageField.value ? { thumbnail: '40x40' } : {})
+}))
 const indexedAt = ref<string>()
 const { baseFetchUrl, total, next, results, fetchResults, truncate } = useLines(displayMode, pageSize, selectedCols, q, sortStr, extraParams, indexedAt)
 

--- a/ui/src/pages/admin/info.vue
+++ b/ui/src/pages/admin/info.vue
@@ -66,6 +66,8 @@
       data-fair/catalogs: Gestion des catalogues
       data-fair/processings: Gestion des traitements
       data-fair/portals: Gestion des portails
+      data-fair/agents: Gestion des agents IA
+      data-fair/metrics: Suivi d'audience
       data-fair/openapi-viewer: Visualisateur de documentation d'API
   en:
     info: Services information
@@ -78,6 +80,8 @@
       data-fair/catalogs: Catalogs management
       data-fair/processings: Processings management
       data-fair/portals: Portals management
+      data-fair/agents: AI agents management
+      data-fair/metrics: Audience tracking
       data-fair/openapi-viewer: API documentation viewer
   </i18n>
 
@@ -107,6 +111,12 @@ if ($uiConfig.processingsIntegration) {
 }
 if ($uiConfig.portalsIntegration) {
   services.value.push({ name: 'data-fair/portals', infoUrl: '/portals-manager/api/admin/info' })
+}
+if ($uiConfig.agentsIntegration) {
+  services.value.push({ name: 'data-fair/agents', infoUrl: '/agents/api/admin/info' })
+}
+if ($uiConfig.metricsIntegration) {
+  services.value.push({ name: 'data-fair/metrics', infoUrl: '/metrics/api/admin/info' })
 }
 if ($uiConfig.openapiViewerIntegration) {
   services.value.push({ name: 'data-fair/openapi-viewer', infoUrl: '/openapi-viewer/api/admin/info' })

--- a/ui/src/pages/application/[id]/index.vue
+++ b/ui/src/pages/application/[id]/index.vue
@@ -591,7 +591,7 @@ const confirmUpgrade = async () => {
   try {
     await patch({ urlDraft: upgradeAvailable.value.url })
     showUpgradeDialog.value = false
-    router.push(`/application/${route.params.id}/config`)
+    await router.push(`/application/${route.params.id}/config`)
   } finally {
     upgrading.value = false
   }

--- a/ui/src/pages/dataset/[id]/index.vue
+++ b/ui/src/pages/dataset/[id]/index.vue
@@ -849,7 +849,7 @@ const canDeleteAllLines = computed(() => dataset.value?.isRest && can('deleteLin
 const confirmRemove = useAsyncAction(async () => {
   showDeleteDialog.value = false
   await remove()
-  router.push('/datasets')
+  await router.push('/datasets')
 }, { success: t('deleteDatasetSuccess') })
 
 const confirmDeleteAllLines = useAsyncAction(async () => {

--- a/ui/src/pages/new-dataset.vue
+++ b/ui/src/pages/new-dataset.vue
@@ -741,7 +741,7 @@ async function createFileDataset () {
 
   const dataset = res.data
   if (dataset.error) throw new Error(dataset.error)
-  router.push(`/dataset/${dataset.id}`)
+  await router.push(`/dataset/${dataset.id}`)
 }
 
 async function createRestDataset () {
@@ -783,7 +783,7 @@ async function createRestDataset () {
     body,
     query: params
   })
-  router.push(`/dataset/${dataset.id}`)
+  await router.push(`/dataset/${dataset.id}`)
 }
 
 async function createVirtualDataset () {
@@ -836,7 +836,7 @@ async function createVirtualDataset () {
     method: 'POST',
     body
   })
-  router.push(`/dataset/${dataset.id}`)
+  await router.push(`/dataset/${dataset.id}`)
 }
 
 async function createMetaOnlyDataset () {
@@ -853,7 +853,7 @@ async function createMetaOnlyDataset () {
     method: 'POST',
     body
   })
-  router.push(`/dataset/${dataset.id}`)
+  await router.push(`/dataset/${dataset.id}`)
 }
 </script>
 

--- a/ui/src/pages/share-dataset.vue
+++ b/ui/src/pages/share-dataset.vue
@@ -469,7 +469,7 @@ async function publish () {
   if (template && (template.includes('{id}') || template.includes('{slug}'))) {
     window.location.href = template.replace('{id}', id).replace('{slug}', datasetServer.value.slug)
   } else {
-    router.push({ path: `/dataset/${id}` })
+    await router.push({ path: `/dataset/${id}` })
   }
 }
 
@@ -488,7 +488,7 @@ async function requestPublication () {
     }
   })
   resetServerSnapshots({ requestedPublicationSites: reqSites })
-  router.push({ path: '/' })
+  await router.push({ path: '/' })
 }
 
 const doPublish = useAsyncAction(async () => {

--- a/ui/src/utils/dataset.ts
+++ b/ui/src/utils/dataset.ts
@@ -65,6 +65,8 @@ export const accepted = [
   '.txt',
   '.dif',
   '.tsv',
+  '.json',
+  '.ndjson',
   '.kml',
   '.kmz',
   '.xml',


### PR DESCRIPTION
Small UI fixes and polish split out of an ongoing notifications refactor so they can land independently. No notifications-related changes here.

- `fix(ui)`: await `router.push` in dataset create / delete / share flows (`new-dataset.vue`, `dataset/[id]/index.vue`, `application/[id]/index.vue`, `share-dataset.vue`). Without the await, `useAsyncAction` cleared its loading flag as soon as the API call resolved, leaving a window where the user could click the action button again and trigger a duplicate creation/deletion/publication.
- `fix(ui)`: request the `thumbnail` param in `dataset-table.vue` so image previews actually render in the table view.
- `feat(ui)`: accept JSON and entries with missing format in the dataset upload selectors (`dataset-rest-upload-actions.vue`, `utils/dataset.ts`).
- `feat(admin)`: list the agents and metrics services in the admin info page when their integration is enabled.
- `style(ui)`: wrap multiline `<p>` content (`dataset-status.vue`) and `<dt>`/`<dd>` content (`dataset-diagnose.vue`) to silence the `vue/multiline-html-element-content-newline` and `vue/singleline-html-element-content-newline` ESLint warnings.
- `chore(test)`: bump Playwright `navigationTimeout` from 5s to 10s to reduce flakes on slower runs.