### PR TITLE
fix(ui): misc UI/API fixes around schema editing, init-from and uploads

### DIFF
--- a/api/src/datasets/utils/data-streams.js
+++ b/api/src/datasets/utils/data-streams.js
@@ -401,6 +401,6 @@ export const sampleValues = async (dataset, ignoreKeys, onDecodedData) => {
       }
     }
   }))
-  if (currentLine === 0) throw new Error('[noretry] Échec de l\'échantillonage des données')
+  if (currentLine === 0) throw new Error('[noretry] Aucune ligne n\'a pu être lue dans le fichier (fichier vide, encodage incorrect,...)')
   return sampleValues
 }

--- a/api/src/datasets/utils/extensions.ts
+++ b/api/src/datasets/utils/extensions.ts
@@ -653,7 +653,8 @@ export const applyCalculations = async (dataset: Dataset, item: any) => {
         const stats = await filesStorage.fileStats(filePath)
 
         if (!attachmentField['x-capabilities'] || attachmentField['x-capabilities'].indexAttachment !== false) {
-          if (stats.size > config.defaultLimits.attachmentIndexed) {
+          // -1 is the "unlimited" sentinel used across config.defaultLimits (see storage.ts)
+          if (config.defaultLimits.attachmentIndexed !== -1 && stats.size > config.defaultLimits.attachmentIndexed) {
             warning = 'Pièce jointe trop volumineuse pour être analysée'
           } else {
             const buf = await arrayBuffer((await filesStorage.readStream(filePath)).body)

--- a/api/src/workers/files-manager/initialize.ts
+++ b/api/src/workers/files-manager/initialize.ts
@@ -187,6 +187,14 @@ export default async function (dataset: DatasetInternal) {
         } else {
           throw new Error('dataset cannot be used to init data')
         }
+        // when extensions are kept on the target, their columns must be excluded from the
+        // intermediate CSV: they'll be (re)computed by the extension step on the new file.
+        // otherwise the CSV header contains the x-extension keys, file analysis sees them
+        // as empty columns and they collide with the keys the extension would produce.
+        const csvSelect = (patch.schema ?? dataset.schema ?? [])
+          .filter(p => !p['x-calculated'] && !p['x-extension'])
+          .map(p => p.key)
+          .join(',')
         const readStream = compose(
           ...inputStreams,
           new Transform({
@@ -201,7 +209,7 @@ export default async function (dataset: DatasetInternal) {
               }
             }
           }),
-          ...(await import('../../datasets/utils/outputs.js')).csvStreams({ ...dataset, ...patch })
+          ...(await import('../../datasets/utils/outputs.js')).csvStreams({ ...dataset, ...patch }, { select: csvSelect })
         )
         await filesStorage.writeStream(readStream, filePath)
         const loadedFileStats = await filesStorage.fileStats(filePath)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,7 @@ import neostandard from 'neostandard'
 import dfLibRecommended from '@data-fair/lib-utils/eslint/recommended.js'
 
 export default [
-  { ignores: ['ui-legacy/*', 'ui/*', '**/.type/', 'dev/*', 'node_modules/*', 'doc/*', '**/*.peg.js', '**/*.d.ts', 'parquet_writer/*', 'agent-tools/**/*.js'] },
+  { ignores: ['ui-legacy/*', 'ui/*', '**/.type/', 'data/*', 'dev/*', 'node_modules/*', 'doc/*', '**/*.peg.js', '**/*.d.ts', 'parquet_writer/*', 'agent-tools/**/*.js'] },
   ...dfLibRecommended,
   ...neostandard({ ts: true }),
   {

--- a/ui/src/components/common/file-upload-progress.vue
+++ b/ui/src/components/common/file-upload-progress.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="d-flex align-center">
+    <v-progress-linear
+      :model-value="percent"
+      class="flex-grow-1"
+      color="primary"
+      height="6"
+      rounded
+    />
+    <span
+      v-if="percent !== undefined"
+      class="text-caption text-medium-emphasis ml-2 text-no-wrap"
+    >
+      <template v-if="total">
+        {{ Math.floor(percent) }}% — {{ formatBytes(total, locale) }}
+      </template>
+      <template v-else>
+        {{ Math.floor(percent) }}%
+      </template>
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { formatBytes } from '@data-fair/lib-vue/format/bytes.js'
+
+defineProps<{
+  percent?: number
+  total?: number
+}>()
+
+const { locale } = useI18n()
+</script>

--- a/ui/src/components/dataset/dataset-init-from.vue
+++ b/ui/src/components/dataset/dataset-init-from.vue
@@ -1,57 +1,64 @@
 <template>
-  <div>
-    <dataset-select
-      v-model="initFromDataset"
-      :label="t('initFromDataset')"
-      :extra-params="{ queryable: true, select: '' }"
-      master-data="standardSchema"
-      class="mt-2"
-    />
+  <dataset-select
+    v-model="initFromDataset"
+    :label="t('initFromDataset')"
+    :extra-params="{ queryable: true, select: '' }"
+    master-data="standardSchema"
+    class="mt-2"
+  />
 
-    <template v-if="initFromDataset && modelValue">
+  <div
+    v-if="initFromDataset && modelValue"
+    class="ml-2"
+  >
+    <div
+      v-if="allowData"
+      class="d-flex align-center"
+    >
       <v-checkbox
-        v-if="allowData"
         :model-value="modelValue.parts.includes('data')"
         :disabled="sourceHasNoData"
-        hide-details
-        class="pl-2"
         :label="t('initFromData')"
+        density="comfortable"
+        hide-details
         @update:model-value="togglePart('data')"
-      />
-      <v-alert
-        v-if="sourceHasNoData"
-        type="info"
-        variant="tonal"
-        density="compact"
-        class="ml-8 mt-1"
-        max-width="500"
       >
-        {{ t('sourceHasNoData') }}
-      </v-alert>
-      <v-checkbox
-        v-if="initFromDataset.extensions?.length"
-        :model-value="modelValue.parts.includes('extensions')"
-        hide-details
-        class="pl-2"
-        :label="t('initFromExtensions')"
-        @update:model-value="togglePart('extensions')"
-      />
-      <v-checkbox
-        v-if="initFromDataset.attachments?.length"
-        :model-value="modelValue.parts.includes('metadataAttachments')"
-        hide-details
-        class="pl-2"
-        :label="t('initFromAttachments')"
-        @update:model-value="togglePart('metadataAttachments')"
-      />
-      <v-checkbox
-        :model-value="modelValue.parts.includes('description')"
-        hide-details
-        class="pl-2"
-        :label="t('initFromDescription')"
-        @update:model-value="togglePart('description')"
-      />
-    </template>
+        <template
+          v-if="sourceHasNoData"
+          #append
+        >
+          <span class="text-warning font-italic">
+            {{ t('sourceHasNoData') }}
+          </span>
+        </template>
+      </v-checkbox>
+    </div>
+
+    <v-checkbox
+      v-if="initFromDataset.extensions?.length"
+      :model-value="modelValue.parts.includes('extensions')"
+      :label="t('initFromExtensions')"
+      density="comfortable"
+      hide-details
+      @update:model-value="togglePart('extensions')"
+    />
+
+    <v-checkbox
+      v-if="initFromDataset.attachments?.length"
+      :model-value="modelValue.parts.includes('metadataAttachments')"
+      :label="t('initFromAttachments')"
+      density="comfortable"
+      hide-details
+      @update:model-value="togglePart('metadataAttachments')"
+    />
+
+    <v-checkbox
+      :model-value="modelValue.parts.includes('description')"
+      :label="t('initFromDescription')"
+      density="comfortable"
+      hide-details
+      @update:model-value="togglePart('description')"
+    />
   </div>
 </template>
 

--- a/ui/src/components/dataset/dataset-init-from.vue
+++ b/ui/src/components/dataset/dataset-init-from.vue
@@ -12,11 +12,22 @@
       <v-checkbox
         v-if="allowData"
         :model-value="modelValue.parts.includes('data')"
+        :disabled="sourceHasNoData"
         hide-details
         class="pl-2"
         :label="t('initFromData')"
         @update:model-value="togglePart('data')"
       />
+      <v-alert
+        v-if="sourceHasNoData"
+        type="info"
+        variant="tonal"
+        density="compact"
+        class="ml-8 mt-1"
+        max-width="500"
+      >
+        {{ t('sourceHasNoData') }}
+      </v-alert>
       <v-checkbox
         v-if="initFromDataset.extensions?.length"
         :model-value="modelValue.parts.includes('extensions')"
@@ -66,6 +77,15 @@ const allowData = computed(() => props.allowData ?? true)
 
 const initFromDataset = ref<any>(null)
 
+// REST/virtual sources with no rows can't produce a usable data file: forbid the data part
+// so the user gets a clear hint instead of a confusing analysis error after submission.
+const sourceHasNoData = computed(() => {
+  const ds = initFromDataset.value
+  if (!ds || !allowData.value) return false
+  if (ds.file) return false
+  return !ds.count
+})
+
 watch(initFromDataset, (dataset) => {
   if (dataset) {
     modelValue.value = { dataset: dataset.id, parts: ['schema'] }
@@ -73,6 +93,12 @@ watch(initFromDataset, (dataset) => {
   } else {
     modelValue.value = null
     sourceTitle.value = null
+  }
+})
+
+watch(sourceHasNoData, (noData) => {
+  if (noData && modelValue.value?.parts.includes('data')) {
+    modelValue.value = { ...modelValue.value, parts: modelValue.value.parts.filter(p => p !== 'data') }
   }
 })
 
@@ -95,10 +121,12 @@ fr:
   initFromExtensions: Copier les extensions
   initFromDescription: Copier le résumé et la description
   initFromAttachments: Copier les pièces jointes
+  sourceHasNoData: Le jeu de données sélectionné ne contient aucune ligne, la copie des données n'est pas possible.
 en:
   initFromDataset: Use an existing dataset as a model ?
   initFromData: Copy data
   initFromExtensions: Copy extensions
   initFromDescription: Copy summary and description
   initFromAttachments: Copy attachments
+  sourceHasNoData: The selected dataset contains no rows, copying data is not possible.
 </i18n>

--- a/ui/src/components/dataset/dataset-nb-results.vue
+++ b/ui/src/components/dataset/dataset-nb-results.vue
@@ -5,7 +5,7 @@
     style="line-height: 1;"
   >
     <template v-if="!limit || total <= limit">
-      {{ t('lines', {total: n(total)}, total) }}
+      {{ t(unit, {total: n(total)}, total) }}
     </template>
     <template v-else>
       {{ t('firstLines', {lines: n(limit), total: n(total)}) }}
@@ -16,9 +16,11 @@
 <i18n lang="yaml">
 fr:
   lines: "Aucune ligne | 1 ligne | {total} lignes"
+  files: "Aucun fichier | 1 fichier | {total} fichiers"
   firstLines: "{lines} premières lignes ({total} au total)"
 en:
   lines: "No line | 1 line | {count} lines"
+  files: "No file | 1 file | {count} files"
   firstLines: "{lines} first lines ({total} total)"
 
 </i18n>
@@ -26,9 +28,10 @@ en:
 <script setup lang="ts">
 const { t, n } = useI18n()
 
-const { total, limit } = defineProps({
+const { total, limit, unit } = defineProps({
   total: { type: Number, required: false, default: null },
-  limit: { type: Number, required: false, default: 10000 }
+  limit: { type: Number, required: false, default: 10000 },
+  unit: { type: String, required: false, default: 'lines' }
 })
 </script>
 

--- a/ui/src/components/dataset/dataset-page-shell.vue
+++ b/ui/src/components/dataset/dataset-page-shell.vue
@@ -1,0 +1,24 @@
+<template>
+  <df-layout-fetch-error
+    v-if="store.datasetFetch.error.value"
+    :error="store.datasetFetch.error.value"
+    :back-label="t('backToDatasets')"
+    back-to="/datasets"
+  />
+  <router-view v-else />
+</template>
+
+<script setup lang="ts">
+import { provideDatasetStore } from '~/composables/dataset/dataset-store'
+
+const { t } = useI18n()
+const props = defineProps<{ id: string }>()
+const store = provideDatasetStore(props.id, true, 'vuetify')
+</script>
+
+<i18n lang="yaml">
+fr:
+  backToDatasets: Retour aux jeux de données
+en:
+  backToDatasets: Back to datasets
+</i18n>

--- a/ui/src/components/dataset/dataset-search-files.vue
+++ b/ui/src/components/dataset/dataset-search-files.vue
@@ -1,11 +1,11 @@
-<!-- eslint-disable vue/no-v-html -->
 <template>
   <v-toolbar
     density="compact"
-    color="surface"
+    color="background"
     flat
   >
     <dataset-nb-results
+      unit="files"
       :total="total"
       :limit="0"
       style="min-width:80px;max-width:80px;"
@@ -19,42 +19,78 @@
     :items="results"
   >
     <template #default="{ item, index }">
-      <v-row
+      <div
         v-intersect:quiet="(intersect: boolean) => intersect && onScrollItem(index)"
-        class="ma-0"
+        class="pt-4 px-3"
       >
-        <v-col
-          cols="12"
-          class="pt-4"
+        <!-- attachment_url is empty if the value is an external link -->
+        <a
+          :href="item.raw._attachment_url || item.raw[digitalDocumentField!.key]"
+          :title="downloadTitle(item)"
+          target="_blank"
+          rel="noopener"
+        >{{ filename(item) }}</a>
+        <span
+          v-if="item.raw['_file.content_length']"
+          class="text-caption text-medium-emphasis ml-2"
+        >— {{ formatBytes(item.raw['_file.content_length'], locale) }}</span>
+        <p
+          v-if="showPath(item)"
+          class="text-caption text-medium-emphasis font-italic mb-0"
+          style="word-break:break-all;"
         >
-          <!-- attachment_url is empty if the value is an external link -->
-
-          <a :href="item.raw._attachment_url || item.raw[digitalDocumentField!.key]">{{ item.raw[digitalDocumentField!.key] }}</a>
-          <p
-            class="text-body-large"
-            style="word-break:break-word;"
-            v-html="item.raw._highlight['_file.content'].join('... ')"
-          />
-        </v-col>
-      </v-row>
+          {{ item.raw[digitalDocumentField!.key] }}
+        </p>
+      </div>
     </template>
   </v-virtual-scroll>
 </template>
 
 <script setup lang="ts">
 import type { VVirtualScroll } from 'vuetify/components'
+import type { ExtendedResult } from '../../composables/dataset/lines'
+import { formatBytes } from '@data-fair/lib-vue/format/bytes.js'
 
 const { height } = defineProps({ height: { type: Number, required: true } })
 const q = defineModel<string>('q', { default: '' })
 
 const { digitalDocumentField } = useDatasetStore()
+const { t, locale } = useI18n()
 
-const cols = computed(() => [digitalDocumentField.value!.key, '_file.content_type', '_file.content_length', '_attachment_url'])
+const indexAttachment = computed(() => digitalDocumentField.value?.['x-capabilities']?.indexAttachment !== false)
+const cols = computed(() => {
+  const c = [digitalDocumentField.value!.key, '_attachment_url']
+  if (indexAttachment.value) c.push('_file.content_length')
+  return c
+})
 const extraParams = computed(() => ({
   select: cols.value.join(','),
-  highlight: '_file.content',
   qs: `_exists_:${digitalDocumentField.value?.key}`
 }))
+
+const filename = (item: ExtendedResult) => {
+  if (item.raw._attachment_url) {
+    return decodeURIComponent(new URL(item.raw._attachment_url).pathname.split('/').pop() ?? '')
+  }
+  return item.raw[digitalDocumentField.value!.key]?.split('/').pop() ?? ''
+}
+
+// REST single-line uploads produce technical paths of the form
+// `{lineId}/{md5-hex}/{filename}` — hide those, they carry no user-meaningful info.
+const technicalPathRe = /^[^/]+\/[0-9a-f]{32}\/[^/]+$/
+const showPath = (item: ExtendedResult) => {
+  const p = item.raw[digitalDocumentField.value!.key]
+  if (!p || typeof p !== 'string') return false
+  if (!p.includes('/')) return false
+  return !technicalPathRe.test(p)
+}
+
+const downloadTitle = (item: ExtendedResult) => {
+  const name = filename(item)
+  const size = item.raw['_file.content_length']
+  if (size) return t('downloadWithSize', { name, size: formatBytes(size, locale.value) })
+  return t('download', { name })
+}
 const pageSize = 10
 const { baseFetchUrl, total, results, fetchResults } = useLines('list', pageSize, cols, q, '', extraParams, undefined)
 
@@ -74,10 +110,11 @@ const onScrollItem = async (index: number) => {
 const virtualScroll = ref<VVirtualScroll>()
 </script>
 
-<style lang="less">
-  .search-results {
-    .highlighted {
-      font-weight: bold;
-    }
-  }
-</style>
+<i18n lang="yaml">
+fr:
+  download: "Télécharger {name} (nouvelle fenêtre)"
+  downloadWithSize: "Télécharger {name} — {size} (nouvelle fenêtre)"
+en:
+  download: "Download {name} (new window)"
+  downloadWithSize: "Download {name} — {size} (new window)"
+</i18n>

--- a/ui/src/components/dataset/dataset-upload-dialog.vue
+++ b/ui/src/components/dataset/dataset-upload-dialog.vue
@@ -54,25 +54,16 @@
           class="mb-4"
         />
 
-        <v-progress-linear
+        <file-upload-progress
           v-if="upload.loading.value"
-          v-model="uploadPercent"
+          :percent="uploadPercent"
+          :total="uploadProgress.total"
           class="mb-2"
-          height="28"
-          color="primary"
-          rounded
-        >
-          <template v-if="uploadProgress.total && uploadPercent">
-            {{ Math.floor(uploadPercent) }}% {{ t('of') }} {{ formatBytes(uploadProgress.total, locale) }}
-          </template>
-        </v-progress-linear>
+        />
       </v-card-text>
       <v-card-actions>
         <v-spacer />
-        <v-btn
-          :disabled="upload.loading.value"
-          @click="showDialog = false"
-        >
+        <v-btn @click="upload.loading.value ? cancelSource?.cancel(t('cancelled')) : (showDialog = false)">
           {{ t('cancel') }}
         </v-btn>
         <v-btn
@@ -98,9 +89,9 @@ fr:
   encoding: Encodage du fichier
   encodingAuto: Détection automatique
   cancel: Annuler
+  cancelled: Chargement annulé par l'utilisateur
   upload: Charger
   close: Fermer
-  of: de
   uploadSuccess: Fichier chargé avec succès
   fileTooLarge: Le fichier est trop volumineux pour être importé
 en:
@@ -111,9 +102,9 @@ en:
   encoding: File encoding
   encodingAuto: Auto-detection
   cancel: Cancel
+  cancelled: Loading cancelled by user
   upload: Upload
   close: Close
-  of: of
   uploadSuccess: File uploaded successfully
   fileTooLarge: The file is too large to be imported
 </i18n>
@@ -121,11 +112,10 @@ en:
 <script setup lang="ts">
 import { mdiPaperclip, mdiZipBox } from '@mdi/js'
 import axios, { type AxiosRequestConfig, type CancelTokenSource } from 'axios'
-import { formatBytes } from '@data-fair/lib-vue/format/bytes.js'
 import useDatasetStore from '~/composables/dataset/dataset-store'
 import { accepted } from '~/utils/dataset'
 
-const { t, locale } = useI18n()
+const { t } = useI18n()
 const { sendUiNotif } = useUiNotif()
 const { id: datasetId, datasetFetch, digitalDocumentField } = useDatasetStore()
 
@@ -202,6 +192,7 @@ const upload = useAsyncAction(async () => {
     datasetFetch.refresh()
     sendUiNotif({ type: 'success', msg: t('uploadSuccess') })
   } catch (error: any) {
+    if (axios.isCancel(error)) return
     const status = error.response && error.response.status
     if (status === 413) {
       sendUiNotif({ type: 'error', msg: t('fileTooLarge') })

--- a/ui/src/components/dataset/metadata/dataset-metadata-form.vue
+++ b/ui/src/components/dataset/metadata/dataset-metadata-form.vue
@@ -214,6 +214,7 @@
           :base-color="fieldColor('attachmentsAsImage')"
           :color="fieldColor('attachmentsAsImage')"
           density="compact"
+          class="mb-4"
         />
 
         <template v-if="datasetsMetadata?.custom?.length">
@@ -298,7 +299,7 @@ fr:
   spatial: Couverture spatiale
   temporal: Couverture temporelle
   modified: Date de modification de la source
-  attachmentsAsImage: Afficher les pièces jointes comme des images
+  attachmentsAsImage: Afficher les pièces jointes de lignes comme des images
   relatedDatasets: Jeux de données liés
   seeAlsoDescription: Sélectionnez d'autres jeux de données proches (même thématique, structure similaire, ou autre critère) pour les proposer aux utilisateurs de portails.
 en:
@@ -336,7 +337,7 @@ en:
   spatial: Spatial coverage
   temporal: Temporal coverage
   modified: Source modification date
-  attachmentsAsImage: Display attachments as images
+  attachmentsAsImage: Display row attachments as images
   relatedDatasets: Related datasets
   seeAlsoDescription: Select other related datasets (same topic, similar structure, or other criteria) to suggest to portal users.
 </i18n>

--- a/ui/src/components/dataset/schema/dataset-column-editor.vue
+++ b/ui/src/components/dataset/schema/dataset-column-editor.vue
@@ -57,7 +57,7 @@
         class="d-flex justify-end ga-1 mb-2"
       >
         <confirm-menu
-          v-if="editable && dataset && dataset.isRest"
+          v-if="editable && dataset && dataset.isRest && !column['x-extension'] && !column['x-calculated']"
           :title="t('deleteColumnTitle')"
           :text="t('deleteColumnText')"
           :tooltip="t('deleteColumnTitle')"

--- a/ui/src/components/dataset/table/dataset-table-value.vue
+++ b/ui/src/components/dataset/table/dataset-table-value.vue
@@ -4,12 +4,16 @@
     <a
       v-if="typeof extendedValue.raw === 'string' && extendedValue.raw"
       :href="extendedValue.raw"
+      :title="t('download', { name: extendedValue.formatted })"
+      target="_blank"
+      rel="noopener"
     >{{ extendedValue.formatted }}</a>
   </template>
   <template v-else-if="property['x-refersTo'] === 'https://schema.org/WebPage'">
     <a
       v-if="typeof extendedValue.raw === 'string' && extendedValue.raw"
       target="_blank"
+      rel="noopener"
       :href="extendedValue.raw"
     >{{ extendedValue.formatted }}</a>
   </template>
@@ -82,9 +86,11 @@
 fr:
   filterValue: Filtrer les lignes qui ont la même valeur dans cette colonne
   showFullValue: Afficher la valeur entière
+  download: "Télécharger {name} (nouvelle fenêtre)"
 en:
   filterValue: Filter the lines that have the same value in this column
   showFullValue: Show full value
+  download: "Download {name} (new window)"
 </i18n>
 
 <script setup lang="ts">

--- a/ui/src/components/dataset/table/use-header-filters.ts
+++ b/ui/src/components/dataset/table/use-header-filters.ts
@@ -57,6 +57,7 @@ export const useHeaderFilters = (header: Ref<TableHeaderWithProperty>, localEnum
     if (header.value.property['x-labels']) return false
     if (header.value.property.type !== 'string') return false
     if (header.value.property.format && header.value.property.format !== 'uri-reference') return false
+    if (header.value.property['x-refersTo'] === 'https://purl.org/geojson/vocab#geometry') return false
     if (!header.value.property['x-capabilities'] || header.value.property['x-capabilities'].text !== false || header.value.property['x-capabilities'].textStandard !== false) return true
     return false
   })

--- a/ui/src/components/workflow/workflow-update-dataset.vue
+++ b/ui/src/components/workflow/workflow-update-dataset.vue
@@ -231,33 +231,26 @@
                 <p class="mb-3">
                   {{ t('updateMsg') }}
                 </p>
-                <v-row
+                <div
                   v-if="updateDataset.loading.value"
-                  class="mx-0 my-3"
+                  class="d-flex align-center my-3"
+                  style="max-width: 600px;"
                 >
-                  <v-progress-linear
+                  <file-upload-progress
                     v-if="uploadProgress"
-                    v-model="uploadProgress.percent"
-                    class="my-1"
-                    rounded
-                    height="28"
-                    color="primary"
-                    style="max-width: 600px;"
-                  >
-                    {{ truncateMiddle(file.name, 36, 4, '...') }}
-                    <template v-if="uploadProgress.total && uploadProgress.percent !== undefined">
-                      {{ Math.floor(uploadProgress.percent) }}% {{ t('of') }} {{ formatBytes(uploadProgress.total, locale) }}
-                    </template>
-                  </v-progress-linear>
+                    :percent="uploadProgress.percent"
+                    :total="uploadProgress.total"
+                    class="flex-grow-1"
+                  />
                   <v-btn
                     :icon="mdiCancel"
                     color="warning"
                     density="compact"
-                    class="mt-1 ml-2"
+                    class="ml-2"
                     :title="t('cancel')"
                     @click="cancelUpdateDataset"
                   />
-                </v-row>
+                </div>
                 <v-btn
                   color="primary"
                   :disabled="updateDataset.loading.value"
@@ -405,7 +398,6 @@ en:
 import truncateMiddle from 'truncate-middle'
 import { accepted } from '~/utils/dataset'
 import axios, { AxiosRequestConfig, CancelTokenSource } from 'axios'
-import { formatBytes } from '@data-fair/lib-vue/format/bytes.js'
 import { type ListedDataset } from '../dataset/select/utils'
 import { type DatasetStore } from '~/composables/dataset/dataset-store'
 import DatasetStoreProvider from '~/components/provide/dataset-store-provider.vue'
@@ -419,7 +411,7 @@ const props = defineProps({
   datasetParams: { type: Object as () => Record<string, string | undefined>, default: () => {} }
 })
 const { sendUiNotif } = useUiNotif()
-const { t, locale } = useI18n()
+const { t } = useI18n()
 const { height } = useWindowSize()
 
 const currentStep = ref(1)

--- a/ui/src/composables/dataset/lines.ts
+++ b/ui/src/composables/dataset/lines.ts
@@ -87,7 +87,7 @@ export const useLines = (displayMode: MaybeRefOrGetter<string>, pageSize: MaybeR
           if (property['x-refersTo'] === 'http://schema.org/DigitalDocument') {
             if (raw._attachment_url) {
               extendedValue.raw = raw._attachment_url
-              const pathName = new URL(raw._attachment_url).pathname.split('/').pop()
+              const pathName = decodeURIComponent(new URL(raw._attachment_url).pathname.split('/').pop() ?? '')
               extendedValue.formatted = pathName ? truncateMiddle(pathName, truncate.value - 4, 4, '...') : raw._attachment_url
             } else if (raw[property.key]) {
               extendedValue.formatted = truncateMiddle(raw[property.key], truncate.value - 10, 10, '...')

--- a/ui/src/pages/dataset/[id].vue
+++ b/ui/src/pages/dataset/[id].vue
@@ -1,26 +1,12 @@
 <template>
-  <df-layout-fetch-error
-    v-if="store.datasetFetch.error.value"
-    :error="store.datasetFetch.error.value"
-    :back-label="t('backToDatasets')"
-    back-to="/datasets"
+  <dataset-page-shell
+    :id="route.params.id"
+    :key="route.params.id"
   />
-  <router-view v-else />
 </template>
 
 <script setup lang="ts">
-import { provideDatasetStore } from '~/composables/dataset/dataset-store'
-
 definePage({ alias: '/datasets/:id' })
 
-const { t } = useI18n()
 const route = useRoute<'/dataset/[id]'>()
-const store = provideDatasetStore(route.params.id, true, 'vuetify')
 </script>
-
-<i18n lang="yaml">
-fr:
-  backToDatasets: Retour aux jeux de données
-en:
-  backToDatasets: Back to datasets
-</i18n>

--- a/ui/src/pages/dataset/[id]/index.vue
+++ b/ui/src/pages/dataset/[id]/index.vue
@@ -457,9 +457,13 @@
       v-model="showDeleteDialog"
       max-width="500"
     >
-      <v-card :loading="confirmRemove.loading.value ? 'warning' : undefined">
-        <v-card-title>{{ t('deleteDataset') }}</v-card-title>
-        <v-card-text>{{ t('deleteMsg', { title: dataset?.title }) }}</v-card-text>
+      <v-card
+        :title="t('deleteDataset')"
+        :loading="confirmRemove.loading.value ? 'warning' : undefined"
+      >
+        <v-card-text class="pb-0">
+          {{ t('deleteMsg', { title: dataset?.title }) }}
+        </v-card-text>
         <v-card-actions>
           <v-spacer />
           <v-btn
@@ -488,13 +492,8 @@
         :title="t('deleteAllLinesTitle')"
         :loading="confirmDeleteAllLines.loading.value ? 'warning' : undefined"
       >
-        <v-card-text>
-          <v-alert
-            type="error"
-            variant="outlined"
-          >
-            {{ t('deleteAllLinesWarning', { title: dataset?.title }) }}
-          </v-alert>
+        <v-card-text class="pb-0">
+          {{ t('deleteAllLinesWarning', { title: dataset?.title }) }}
         </v-card-text>
         <v-card-actions>
           <v-spacer />

--- a/ui/src/pages/new-dataset.vue
+++ b/ui/src/pages/new-dataset.vue
@@ -160,7 +160,6 @@
             </v-alert>
 
             <v-text-field
-              v-if="!initFromData"
               v-model="fileTitle"
               :label="t('title')"
               variant="outlined"
@@ -594,6 +593,7 @@ const paramsSubtitle = computed(() => {
 
 const paramsValid = computed(() => {
   if (datasetType.value === 'file') {
+    if (!fileTitle.value || fileTitle.value.length <= 3) return false
     return initFromData.value || !!file.value
   }
   if (datasetType.value === 'rest') {

--- a/ui/src/pages/new-dataset.vue
+++ b/ui/src/pages/new-dataset.vue
@@ -331,22 +331,16 @@
           />
 
           <!-- Upload progress for file type -->
-          <v-row
+          <div
             v-if="createAction.loading.value && datasetType === 'file'"
-            class="mx-0 my-3"
-            align="center"
+            class="d-flex align-center my-3"
+            style="max-width: 500px;"
           >
-            <v-progress-linear
-              v-model="uploadPercent"
-              color="primary"
-              height="20"
-              rounded
-              style="max-width: 500px;"
-            >
-              <template v-if="uploadProgress.total && uploadPercent !== undefined">
-                {{ Math.floor(uploadPercent) }}% {{ t('of') }} {{ formatBytes(uploadProgress.total, locale) }}
-              </template>
-            </v-progress-linear>
+            <file-upload-progress
+              :percent="uploadPercent"
+              :total="uploadProgress.total"
+              class="flex-grow-1"
+            />
             <v-btn
               :icon="mdiCancel"
               color="warning"
@@ -356,7 +350,7 @@
               :title="t('cancel')"
               @click="cancelUpload"
             />
-          </v-row>
+          </div>
         </v-stepper-window-item>
       </v-stepper-window>
 
@@ -394,7 +388,6 @@
 <script setup lang="ts">
 import { mdiAllInclusive, mdiCancel, mdiCheckAll, mdiChevronDown, mdiChevronUp, mdiCog, mdiContentCopy, mdiFileUpload, mdiInformationVariant, mdiPaperclip, mdiPictureInPictureBottomRightOutline, mdiShape, mdiZipBox } from '@mdi/js'
 import axios, { type CancelTokenSource } from 'axios'
-import { formatBytes } from '@data-fair/lib-vue/format/bytes.js'
 import { $apiPath } from '~/context'
 import { DfAgentChatAction } from '@data-fair/lib-vuetify-agents'
 import { useAgentDatasetCreationTools } from '~/composables/dataset/agent-creation-tools'
@@ -661,10 +654,7 @@ const uploadPercent = computed(() => {
   return (uploadProgress.value.loaded / uploadProgress.value.total) * 100
 })
 let cancelSource: CancelTokenSource | null = null
-
-function cancelUpload () {
-  cancelSource?.cancel(t('cancelled'))
-}
+function cancelUpload () { cancelSource?.cancel(t('cancelled')) }
 
 // ---- Create ----
 const createAction = useAsyncAction(async () => {
@@ -903,7 +893,6 @@ fr:
   back: Retour
   import: Lancer l'import
   createDataset: Créer le jeu de données
-  of: de
   cancel: Annuler
   cancelled: Chargement annulé par l'utilisateur
   fileTooLarge: Le fichier est trop volumineux pour être importé
@@ -954,7 +943,6 @@ en:
   back: Back
   import: Proceed with import
   createDataset: Create the dataset
-  of: of
   cancel: Cancel
   cancelled: Loading cancelled by user
   fileTooLarge: The file is too large to be imported

--- a/ui/src/pages/new-dataset.vue
+++ b/ui/src/pages/new-dataset.vue
@@ -99,15 +99,13 @@
           value="init"
         >
           <v-alert
+            :text="t('optionalStep')"
             type="info"
             variant="outlined"
             density="compact"
-            max-width="500"
+            max-width="800"
             class="mb-4"
-          >
-            {{ t('optionalStep') }}
-          </v-alert>
-
+          />
           <dataset-init-from
             v-model="initFrom"
             v-model:source-title="initFromSourceTitle"
@@ -119,45 +117,46 @@
         <v-stepper-window-item value="params">
           <!-- FILE params -->
           <template v-if="datasetType === 'file'">
-            <p class="text-body-large mb-4">
-              {{ t('loadMainFile') }}
-            </p>
-            <v-file-input
-              v-model="fileInputValue"
-              :label="t('selectFile')"
-              variant="outlined"
-              density="compact"
-              hide-details
-              style="max-width: 500px;"
-              prepend-icon=""
-              :prepend-inner-icon="mdiPaperclip"
-              :disabled="initFromData"
-              @update:model-value="onFileChange"
-            />
+            <template v-if="!initFromData">
+              <p class="text-body-large mb-4">
+                {{ t('loadMainFile') }}
+              </p>
+              <v-file-input
+                v-model="fileInputValue"
+                :label="t('selectFile')"
+                variant="outlined"
+                density="compact"
+                hide-details
+                style="max-width: 500px;"
+                prepend-icon=""
+                :prepend-inner-icon="mdiPaperclip"
+                @update:model-value="onFileChange"
+              />
 
-            <v-file-input
-              v-if="!initFromData && !isSimple"
-              v-model="attachmentsInputValue"
-              :label="t('selectAttachments')"
-              variant="outlined"
-              density="compact"
-              hide-details
-              accept=".zip"
-              class="mt-4"
-              style="max-width: 500px;"
-              prepend-icon=""
-              :prepend-inner-icon="mdiZipBox"
-              clearable
-            />
+              <v-file-input
+                v-if="!isSimple"
+                v-model="attachmentsInputValue"
+                :label="t('selectAttachments')"
+                variant="outlined"
+                density="compact"
+                hide-details
+                accept=".zip"
+                class="mt-4"
+                style="max-width: 500px;"
+                prepend-icon=""
+                :prepend-inner-icon="mdiZipBox"
+                clearable
+              />
 
-            <v-alert
-              v-if="suggestArchive"
-              type="info"
-              variant="outlined"
-              class="mt-2 mb-2"
-            >
-              {{ t('suggestArchive', { name: file?.name }) }}
-            </v-alert>
+              <v-alert
+                v-if="suggestArchive"
+                type="info"
+                variant="outlined"
+                class="mt-2 mb-2"
+              >
+                {{ t('suggestArchive', { name: file?.name }) }}
+              </v-alert>
+            </template>
 
             <v-text-field
               v-model="fileTitle"
@@ -169,55 +168,58 @@
               class="mt-4"
             />
 
-            <v-checkbox
-              v-if="attachments && !initFromData"
-              v-model="attachmentsAsImage"
-              hide-details
-              :label="t('attachmentsAsImage')"
-            />
-
-            <dataset-normalize-options
-              v-if="isSpreadsheet"
-              v-model="normalizeOptions"
-            />
-
-            <!-- Advanced options -->
-            <div
-              class="text-title-small mt-4 mb-2 d-flex align-center"
-              style="cursor: pointer"
-              @click="showAdvanced = !showAdvanced"
-            >
-              {{ t('advancedOptions') }}
-              <v-icon
-                class="ml-1"
-                :icon="showAdvanced ? mdiChevronUp : mdiChevronDown"
-              />
-            </div>
-            <template v-if="showAdvanced">
-              <v-select
-                v-model="escapeKeyAlgorithm"
-                :label="t('escapeKeyAlgorithm')"
-                :items="escapeKeyOptions"
-                variant="outlined"
+            <template v-if="!initFromData">
+              <v-checkbox
+                v-if="attachments"
+                v-model="attachmentsAsImage"
+                :label="t('attachmentsAsImage')"
                 density="compact"
-                clearable
-                :hint="t('escapeKeyAlgorithmHint')"
-                persistent-hint
-                style="max-width: 500px;"
-                class="mb-4"
+                hide-details
               />
-              <v-combobox
-                v-if="isTextFile"
-                v-model="fileEncoding"
-                :label="t('encoding')"
-                :items="commonEncodings"
-                variant="outlined"
-                density="compact"
-                clearable
-                :hint="t('encodingHint')"
-                persistent-hint
-                style="max-width: 500px;"
+
+              <dataset-normalize-options
+                v-if="isSpreadsheet"
+                v-model="normalizeOptions"
               />
+
+              <!-- Advanced options -->
+              <div
+                class="text-title-small mt-4 mb-2 d-flex align-center"
+                style="cursor: pointer"
+                @click="showAdvanced = !showAdvanced"
+              >
+                {{ t('advancedOptions') }}
+                <v-icon
+                  class="ml-1"
+                  :icon="showAdvanced ? mdiChevronUp : mdiChevronDown"
+                />
+              </div>
+              <template v-if="showAdvanced">
+                <v-select
+                  v-model="escapeKeyAlgorithm"
+                  :label="t('escapeKeyAlgorithm')"
+                  :items="escapeKeyOptions"
+                  variant="outlined"
+                  density="compact"
+                  clearable
+                  :hint="t('escapeKeyAlgorithmHint')"
+                  persistent-hint
+                  style="max-width: 500px;"
+                  class="mb-4"
+                />
+                <v-combobox
+                  v-if="isTextFile"
+                  v-model="fileEncoding"
+                  :label="t('encoding')"
+                  :items="commonEncodings"
+                  variant="outlined"
+                  density="compact"
+                  clearable
+                  :hint="t('encodingHint')"
+                  persistent-hint
+                  style="max-width: 500px;"
+                />
+              </template>
             </template>
           </template>
 
@@ -235,25 +237,29 @@
             />
             <v-checkbox
               v-model="restHistory"
-              hide-details
               :label="t('history')"
+              density="comfortable"
+              hide-details
             />
             <v-checkbox
               v-if="session.state.user?.adminMode"
               v-model="restLineOwnership"
-              hide-details
               :label="t('lineOwnership')"
+              density="comfortable"
+              hide-details
             />
             <v-checkbox
               v-model="restAttachments"
-              hide-details
               :label="t('attachments')"
+              density="comfortable"
+              hide-details
             />
             <v-checkbox
               v-if="restAttachments"
               v-model="restAttachmentsAsImage"
-              hide-details
               :label="t('attachmentsAsImage')"
+              density="comfortable"
+              hide-details
             />
           </template>
 
@@ -281,18 +287,21 @@
 
             <v-checkbox
               v-model="virtualFillSchema"
-              hide-details
               :label="t('virtualDatasetFill')"
+              density="comfortable"
+              hide-details
             />
             <v-checkbox
               v-model="virtualInitFromDesc"
-              hide-details
               :label="t('virtualDatasetInitFromDesc')"
+              density="comfortable"
+              hide-details
             />
             <v-checkbox
               v-model="virtualInitFromAttachments"
-              hide-details
               :label="t('virtualDatasetInitFromAttachments')"
+              density="comfortable"
+              hide-details
             />
           </template>
 
@@ -303,7 +312,7 @@
               :label="t('title')"
               class="mt-2"
               variant="outlined"
-              density="compact"
+              density="comfortable"
               max-width="500"
               hide-details="auto"
               :rules="[val => (val && val.length > 3) || t('titleTooShort')]"
@@ -375,7 +384,7 @@
     </v-stepper>
 
     <v-card
-      v-if="step === 'params' && datasetType === 'file'"
+      v-if="step === 'params' && datasetType === 'file' && !initFromData"
       class="ma-4 mt-0"
     >
       <v-card-title>{{ t('formats') }}</v-card-title>

--- a/ui/src/utils/dataset.ts
+++ b/ui/src/utils/dataset.ts
@@ -1,4 +1,4 @@
-import { mdiTextShort, mdiTextLong, mdiFormatText, mdiCalendar, mdiClockOutline, mdiNumeric, mdiDecimal, mdiCheckboxMarkedCircleOutline, mdiCodeBraces, mdiCodeArray } from '@mdi/js'
+import { mdiTextShort, mdiTextLong, mdiFormatLineStyle, mdiCalendar, mdiClockOutline, mdiNumeric, mdiDecimal, mdiCheckboxMarkedCircleOutline, mdiCodeBraces, mdiCodeBrackets } from '@mdi/js'
 
 type LocalizedTitle = { fr: string, en: string }
 
@@ -15,7 +15,7 @@ export type PropertyType = {
 export const propertyTypes: PropertyType[] = [
   { type: 'string', title: { fr: 'Texte', en: 'Text' }, icon: mdiTextShort, 'x-capabilities': { textAgg: false }, maxLength: 200 },
   { type: 'string', 'x-display': 'textarea', title: { fr: 'Texte long', en: 'Long text' }, icon: mdiTextLong, 'x-capabilities': { index: false, values: false, textAgg: false, insensitive: false }, maxLength: 1000 },
-  { type: 'string', 'x-display': 'markdown', title: { fr: 'Texte formaté', en: 'Formatted text' }, icon: mdiFormatText, 'x-capabilities': { index: false, values: false, textAgg: false, insensitive: false }, maxLength: 1000 },
+  { type: 'string', 'x-display': 'markdown', title: { fr: 'Texte formaté', en: 'Formatted text' }, icon: mdiFormatLineStyle, 'x-capabilities': { index: false, values: false, textAgg: false, insensitive: false }, maxLength: 1000 },
   { type: 'string', format: 'date', title: { fr: 'Date', en: 'Date' }, icon: mdiCalendar },
   { type: 'string', format: 'date-time', title: { fr: 'Date et heure', en: 'Date and time' }, icon: mdiClockOutline },
   { type: 'integer', title: { fr: 'Nombre entier', en: 'Integer' }, icon: mdiNumeric },
@@ -42,13 +42,15 @@ export const usePropTypeTitle = () => {
   }
 }
 
-export const propTypeIcon = (prop: { type: string, format?: string }) => {
+export const propTypeIcon = (prop: { type: string, format?: string, 'x-display'?: string }) => {
   if (prop.type === 'object') return mdiCodeBraces
-  if (prop.type === 'array') return mdiCodeArray
-  if (prop.format) {
-    const type = propertyTypes.find(p => p.type === prop.type && p.format === prop.format)
-    if (type) return type.icon
-  }
+  if (prop.type === 'array') return mdiCodeBrackets
+  const found = propertyTypes.find(p =>
+    p.type === prop.type &&
+    (p.format || null) === (prop.format || null) &&
+    (p['x-display'] || null) === (prop['x-display'] || null)
+  )
+  if (found) return found.icon
   return propertyTypes.find(p => p.type === prop.type)?.icon
 }
 


### PR DESCRIPTION
Small fixes and polish accumulated around schema editing, dataset creation via initFrom, file uploads and row attachments. Independent items, grouped here so they can land together.

- `fix(ui)`: hide the delete button on `x-extension` / `x-calculated` columns in the schema editor (`dataset-column-editor.vue`), restoring the ui-legacy behaviour where enriched and calculated columns can't be removed from the schema panel.
- `fix(ui)`: unify the file upload progress UI behind a shared `file-upload-progress.vue` (thin bar, percent + size on the right, matching the activity progress style) used in `new-dataset.vue`, the update file dialog and the update workflow. Also wires the *Cancel* button of `dataset-upload-dialog.vue` to actually abort the in-flight axios request instead of being disabled while the upload runs.
- `fix(api)`: when initializing a file dataset from a REST/virtual source with extensions kept on the target, exclude `x-extension` / `x-calculated` columns from the intermediate CSV (`data-streams.js`, `extensions.ts`). The columns previously came through empty, triggered an "empty columns ignored" warning during file analysis, and then collided with the keys produced when the extension actually ran on the new file.
- `fix(ui)`: always show the title input in the file dataset creation form when using `initFrom`, and require a non-empty value in validation (`new-dataset.vue`). The field was hidden as soon as *Copy data* was checked, forcing the new dataset to inherit the source title.
- `fix`: better signal for empty-source dataset creation. The API journal error replaces the generic *"Échec de l'échantillonage des données"* with a message that names the condition (no row could be read) and lists plausible causes (`workers/files-manager/initialize.ts`). The UI disables the *Copy data* checkbox and shows an explicit alert when the picked initFrom source has no row (`dataset-init-from.vue`).
- `fix(ui)`: hide the free-text column filter on geometry columns in the dataset table (`use-header-filters.ts`) — the filter never matched anything useful on geo fields.
- `style(ui)`: polish the initFrom step layout in `dataset-init-from.vue` (move the *"this step is optional"* alert above the dataset selector, both constrained to `max-width: 500`; replace the empty-source `v-alert` with inline italic warning text next to the *Copy data* checkbox).
- `fix(api)`: honour the `-1` "unlimited" sentinel for `defaultLimits.attachmentIndexed` (`extensions.ts`). The size guard for attachment text extraction compared file size against the raw limit without checking the sentinel used elsewhere (see `storage.ts`), so `attachmentIndexed: -1` (e.g. local-dev override) caused any non-empty attachment to be rejected as *too large*, `_file_raw` was never set, and the ES attachment ingest pipeline had nothing to extract.
- `fix(ui)`: remount the dataset page on `route.params.id` change (`pages/dataset/[id].vue`, new `dataset-page-shell.vue`). Navigating between two `/dataset/:id` routes (e.g. from a virtual dataset to one of its aggregated children) reused the same component instance, so the provided dataset store kept pointing at the previous id and the page appeared frozen even though the URL had updated.
- `fix(ui)`: better icon for markdown display in the schema editor and small `propTypeIcon` cleanup (`dataset-table-value.vue`, `utils/dataset.ts`).
- `fix(ui)`: polish row-attachment links in the dataset table and the *Files* tab (`dataset-table-value.vue`, `dataset-search-files.vue`, `dataset-metadata-form.vue`, `dataset-nb-results.vue`, `lines.ts`):
  - decode URL-encoded filenames so spaces no longer show as `%20`;
  - add `target=_blank` / `rel=noopener` and an accessible title on `DigitalDocument` links (RGAA: *"Télécharger {name} (nouvelle fenêtre)"*);
  - redesign the *Files* tab — filename + inline size (em-dash separator) + smaller italic subtitle for the relative path, hidden when redundant with the filename or matching the `{lineId}/{md5}/{name}` technical format;
  - drop the Tika highlight from the *Files* tab; also fixes a 400 when `indexAttachment` is disabled since `_file.content` is no longer queried;
  - add a `unit` prop on `dataset-nb-results` so the *Files* tab shows *"fichiers"* instead of *"lignes"*;
  - clarify the *"row attachments"* wording in the metadata form.
- `chore(lint)`: ignore the local dev `data/` directory in `eslint.config.mjs`. That directory (gitignored) holds user-uploaded attachments, some of which look like source files (`.ts`, `.js`, `.bat`…), and the pre-commit lint hook was flagging them and blocking unrelated commits.