### PR TITLE
fix(api): 403 on dataset thumbnails when embed table is opened with an application key

### DIFF
--- a/api/src/datasets/router.js
+++ b/api/src/datasets/router.js
@@ -1468,11 +1468,11 @@ router.post(
   }
 )
 
-router.get('/:datasetId/thumbnail', readDataset({ fillDescendants: true }), apiKeyMiddlewareRead, permissions.middleware('readDescription', 'read'), async (req, res, next) => {
+router.get('/:datasetId/thumbnail', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, permissions.middleware('readDescription', 'read'), async (req, res, next) => {
   if (!req.dataset.image) return res.status(404).send("dataset doesn't have an image")
   await getThumbnail(req, res, req.dataset.image)
 })
-router.get('/:datasetId/thumbnail/:thumbnailId', readDataset({ fillDescendants: true }), apiKeyMiddlewareRead, permissions.middleware('readLines', 'read'), async (req, res, next) => {
+router.get('/:datasetId/thumbnail/:thumbnailId', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, permissions.middleware('readLines', 'read'), async (req, res, next) => {
   const url = Buffer.from(req.params.thumbnailId, 'hex').toString()
   if (req.dataset.attachmentsAsImage && url.startsWith('/attachments/')) {
     if (req.dataset.isVirtual) {


### PR DESCRIPTION
## Problem

The dataset embed table, when opened with an application-key URL (`/data-fair/embed/dataset/<appKey>:<datasetId>/table`), renders rows fine but every per-row thumbnail comes back as `403`. The table itself works because `/datasets/:id/lines` and `/datasets/:id/attachments/*` already wire the `applicationKey` middleware that converts the embed-page referer into a `bypassPermissions` — the two `/datasets/:id/thumbnail[/...]` routes did not, so the `<img src=…/thumbnail/…>` requests fell straight through to the regular `readLines` / `readDescription` permission check and were denied.

## Fix

Add the `applicationKey` middleware to `/datasets/:id/thumbnail` and `/datasets/:id/thumbnail/:thumbnailId`, in the same position as on `/lines` and `/attachments/*` (right after `readDataset`, before `apiKeyMiddlewareRead`).

Strictly additive — `applicationKey` short-circuits with `next()` when there is no referer, so the existing assertion that an anonymous request without referer still gets `403` on a thumbnail (`tests/features/datasets/upload/datasets-features.api.spec.ts`) is preserved.