### PR TITLE
feat: conformsTo dataset metadata + edit UI + initFrom inheritance

### DIFF
--- a/api/doc/datasets/patch-req/schema.js
+++ b/api/doc/datasets/patch-req/schema.js
@@ -6,7 +6,7 @@ export const patchKeys = [
   'image', 'extensions', 'publications', 'publicationSites', 'requestedPublicationSites',
   'virtual', 'rest', 'extras', 'attachmentsAsImage', 'projection', 'attachments',
   'topics', 'relatedDatasets', 'thumbnails', 'masterData', 'primaryKey', 'exports', 'spatial',
-  'temporal', 'frequency', 'creator', 'modified', 'keywords', 'analysis',
+  'temporal', 'frequency', 'creator', 'modified', 'keywords', 'conformsTo', 'analysis',
   'readApiKey', 'nonBlockingValidation', 'customMetadata'
 ]
 const body = jsonSchema(datasetSchema)

--- a/api/src/datasets/service.js
+++ b/api/src/datasets/service.js
@@ -44,7 +44,8 @@ const filterFields = {
 }
 const facetFields = {
   ...filterFields,
-  topics: 'topics'
+  topics: 'topics',
+  conformsTo: 'conformsTo'
 }
 const sumsFields = { count: 'count' }
 const nullFacetFields = ['publicationSites']

--- a/api/src/misc/utils/find.js
+++ b/api/src/misc/utils/find.js
@@ -387,6 +387,16 @@ export const facetsQuery = (reqQuery, sessionState, resourceType, facetFields = 
         facet.push({ $group: { _id: { [f]: '$base-application', id: '$id' } } })
         facet.push({ $project: { [f]: '$_id.' + f, _id: 0 } })
         facet.push({ $sortByCount: '$' + f })
+      } else if (f === 'conformsTo') {
+        // conformsTo is a single object per dataset (not an array) — group by its triple
+        facet.push({ $match: { conformsTo: { $exists: true } } })
+        facet.push({
+          $group: {
+            _id: { title: '$conformsTo.title', version: '$conformsTo.version', url: '$conformsTo.url' },
+            count: { $sum: 1 }
+          }
+        })
+        facet.push({ $sort: { count: -1 } })
       } else if (f === 'topics') {
         facet.push({
           $unwind: {

--- a/api/src/workers/files-manager/initialize.ts
+++ b/api/src/workers/files-manager/initialize.ts
@@ -100,6 +100,7 @@ export default async function (dataset: DatasetInternal) {
       if (parentDataset.attachmentsAsImage) patch.attachmentsAsImage = parentDataset.attachmentsAsImage
       if (parentDataset.timeZone) patch.timeZone = parentDataset.timeZone
       if (parentDataset.projection) patch.projection = parentDataset.projection
+      if (parentDataset.conformsTo) patch.conformsTo = parentDataset.conformsTo
     }
 
     if (dataset.initFrom.parts.includes('extensions')) {

--- a/api/types/dataset/schema.js
+++ b/api/types/dataset/schema.js
@@ -487,6 +487,25 @@ const datasetProperties = {
       }
     }
   },
+  conformsTo: {
+    type: 'object',
+    description: 'Reference to an external schema or standard the dataset conforms to.',
+    additionalProperties: false,
+    properties: {
+      title: {
+        type: 'string',
+        description: 'Short title of the schema / standard.'
+      },
+      version: {
+        type: 'string',
+        description: 'Version of the schema / standard.'
+      },
+      url: {
+        type: 'string',
+        description: 'URL of the schema / standard specification.'
+      }
+    }
+  },
   license: {
     type: 'object',
     additionalProperties: false,

--- a/api/types/settings/schema.js
+++ b/api/types/settings/schema.js
@@ -446,6 +446,26 @@ export default {
             }
           }
         },
+        conformsTo: {
+          type: 'object',
+          properties: {
+            active: {
+              title: 'Schéma',
+              type: 'boolean',
+              default: false,
+              layout: { cols: 6 }
+            },
+            title: {
+              title: 'Libellé personnalisé',
+              type: 'string',
+              layout: {
+                if: 'parent.data.active',
+                cols: 6,
+                props: { variant: 'outlined', placeholder: 'Schéma' }
+              }
+            }
+          }
+        },
         custom: {
           type: 'array',
           title: 'Métadonnées spécifiques',

--- a/tests/features/datasets/conforms-to.api.spec.ts
+++ b/tests/features/datasets/conforms-to.api.spec.ts
@@ -1,0 +1,155 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { axiosAuth, clean, checkPendingTasks } from '../../support/axios.ts'
+import { waitForFinalize } from '../../support/workers.ts'
+
+const u1 = await axiosAuth('test_user1@test.com')
+
+test.describe('dataset conformsTo metadata', () => {
+  test.beforeEach(async () => { await clean() })
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === 'passed') await checkPendingTasks()
+  })
+
+  test('persists a full conformsTo object via PATCH', async () => {
+    const id = 'conforms-1'
+    await u1.post('/api/v1/datasets/' + id, {
+      isMetaOnly: true,
+      title: id
+    })
+    const body = {
+      conformsTo: { title: 'My Schema', version: '1.0.0', url: 'https://example.com/schema.json' }
+    }
+    const patched = await u1.patch('/api/v1/datasets/' + id, body)
+    assert.deepEqual(patched.data.conformsTo, body.conformsTo)
+
+    const fetched = await u1.get('/api/v1/datasets/' + id)
+    assert.deepEqual(fetched.data.conformsTo, body.conformsTo)
+  })
+
+  test('clears conformsTo via PATCH with null', async () => {
+    const id = 'conforms-clear'
+    await u1.post('/api/v1/datasets/' + id, { isMetaOnly: true, title: id })
+    await u1.patch('/api/v1/datasets/' + id, {
+      conformsTo: { title: 'Schema A', version: '1.0', url: 'https://example.com/a.json' }
+    })
+    // Patch with null triggers $unset in mongo (api/src/datasets/service.js:517).
+    // The PATCH response still echoes the null (in-memory Object.assign), but
+    // the persisted dataset has the field unset — verify via a fresh GET.
+    await u1.patch('/api/v1/datasets/' + id, { conformsTo: null })
+    const fetched = await u1.get('/api/v1/datasets/' + id)
+    assert.equal(fetched.data.conformsTo, undefined)
+  })
+
+  test('persists a partial conformsTo (title + url only)', async () => {
+    const id = 'conforms-2'
+    await u1.post('/api/v1/datasets/' + id, { isMetaOnly: true, title: id })
+    const body = { conformsTo: { title: 'Half Schema', url: 'https://example.com/half.json' } }
+    const patched = await u1.patch('/api/v1/datasets/' + id, body)
+    assert.equal(patched.data.conformsTo.title, 'Half Schema')
+    assert.equal(patched.data.conformsTo.url, 'https://example.com/half.json')
+    assert.equal(patched.data.conformsTo.version, undefined)
+  })
+
+  test('conformsTo facet returns distinct triples for the owner', async () => {
+    // Seed three datasets with two distinct triples (one duplicated)
+    await u1.post('/api/v1/datasets/conforms-a1', { isMetaOnly: true, title: 'a1' })
+    await u1.patch('/api/v1/datasets/conforms-a1', {
+      conformsTo: { title: 'Schema A', version: '1.0', url: 'https://example.com/a.json' }
+    })
+    await u1.post('/api/v1/datasets/conforms-a2', { isMetaOnly: true, title: 'a2' })
+    await u1.patch('/api/v1/datasets/conforms-a2', {
+      conformsTo: { title: 'Schema A', version: '1.0', url: 'https://example.com/a.json' } // duplicate
+    })
+    await u1.post('/api/v1/datasets/conforms-b', { isMetaOnly: true, title: 'b' })
+    await u1.patch('/api/v1/datasets/conforms-b', {
+      conformsTo: { title: 'Schema B', version: '2.1', url: 'https://example.com/b.json' }
+    })
+    // One dataset without conformsTo — must NOT appear
+    await u1.post('/api/v1/datasets/conforms-empty', { isMetaOnly: true, title: 'empty' })
+
+    // axiosAuth('test_user1@test.com') creates datasets owned by { type: 'user', id: 'test_user1' }
+    const res = await u1.get('/api/v1/datasets?size=0&facets=conformsTo&owner=user:test_user1')
+    const triples = (res.data.facets?.conformsTo ?? []).map((f: any) => f.value)
+    assert.equal(triples.length, 2)
+    const titles = triples.map((t: any) => t.title).sort()
+    assert.deepEqual(titles, ['Schema A', 'Schema B'])
+  })
+
+  test('conformsTo facet does not leak triples from another user', async () => {
+    // user2 seeds a private schema reference
+    const u2 = await axiosAuth('test_user2@test.com')
+    await u2.post('/api/v1/datasets/conforms-u2', { isMetaOnly: true, title: 'u2 dataset' })
+    await u2.patch('/api/v1/datasets/conforms-u2', {
+      conformsTo: { title: 'Private Schema', version: '1.0', url: 'https://example.com/private.json' }
+    })
+
+    // user1 querying their own org must not see user2's triple
+    const res = await u1.get('/api/v1/datasets?size=0&facets=conformsTo&owner=user:test_user1')
+    const titles = (res.data.facets?.conformsTo ?? []).map((f: any) => f.value.title)
+    assert.ok(!titles.includes('Private Schema'))
+  })
+
+  test('initFrom with parts: schema inherits conformsTo from source', async () => {
+    // Seed a reference dataset with conformsTo. We don't wait for the parent
+    // to finalize — REST datasets with no data finalize too fast for the WS
+    // subscription to catch the event; we only need the parent document in
+    // Mongo before the init-from worker runs on the child.
+    await u1.post('/api/v1/datasets/conforms-ref', { isRest: true, title: 'Reference', schema: [{ key: 'a', type: 'string' }] })
+    await u1.patch('/api/v1/datasets/conforms-ref', {
+      conformsTo: { title: 'Inherited Schema', version: '1.0', url: 'https://example.com/inherit.json' }
+    })
+
+    // Create a new dataset via initFrom, picking up the schema part
+    const createRes = await u1.post('/api/v1/datasets', {
+      isRest: true,
+      title: 'Inheritor',
+      initFrom: { dataset: 'conforms-ref', parts: ['schema'] }
+    })
+    const newId = createRes.data.id
+    await waitForFinalize(u1, newId)
+
+    const fetched = await u1.get('/api/v1/datasets/' + newId)
+    assert.deepEqual(fetched.data.conformsTo, {
+      title: 'Inherited Schema',
+      version: '1.0',
+      url: 'https://example.com/inherit.json'
+    })
+  })
+
+  test('initFrom WITHOUT schema part does NOT inherit conformsTo', async () => {
+    await u1.post('/api/v1/datasets/conforms-ref2', { isRest: true, title: 'Ref2', schema: [{ key: 'a', type: 'string' }] })
+    await u1.patch('/api/v1/datasets/conforms-ref2', {
+      conformsTo: { title: 'Not Inherited', url: 'https://example.com/notinherit.json' }
+    })
+
+    const createRes = await u1.post('/api/v1/datasets', {
+      isRest: true,
+      title: 'Non-inheritor',
+      initFrom: { dataset: 'conforms-ref2', parts: ['description'] }
+    })
+    const newId = createRes.data.id
+    await waitForFinalize(u1, newId)
+
+    const fetched = await u1.get('/api/v1/datasets/' + newId)
+    assert.equal(fetched.data.conformsTo, undefined)
+  })
+
+  test('initFrom with parts: schema inherits partial conformsTo (title only)', async () => {
+    await u1.post('/api/v1/datasets/conforms-ref3', { isRest: true, title: 'Ref3', schema: [{ key: 'a', type: 'string' }] })
+    await u1.patch('/api/v1/datasets/conforms-ref3', {
+      conformsTo: { title: 'Partial Schema' }
+    })
+
+    const createRes = await u1.post('/api/v1/datasets', {
+      isRest: true,
+      title: 'Inheritor3',
+      initFrom: { dataset: 'conforms-ref3', parts: ['schema'] }
+    })
+    const newId = createRes.data.id
+    await waitForFinalize(u1, newId)
+
+    const fetched = await u1.get('/api/v1/datasets/' + newId)
+    assert.deepEqual(fetched.data.conformsTo, { title: 'Partial Schema' })
+  })
+})

--- a/tests/features/datasets/upload/init-from.api.spec.ts
+++ b/tests/features/datasets/upload/init-from.api.spec.ts
@@ -343,4 +343,30 @@ test.describe('Datasets with auto-initialization from another one', () => {
     assert.equal(initFromDataset.owner.department, 'dep1')
     assert.equal(initFromDataset.count, 2)
   })
+
+  test('Inherit conformsTo from a public reference dataset across accounts', async () => {
+    // user1 publishes a reference dataset and marks it as conforming to an external schema
+    const ref = await sendDataset('datasets/dataset1.csv', testUser1)
+    await testUser1.patch(`/api/v1/datasets/${ref.id}`, {
+      conformsTo: { title: 'Public Reference Schema', version: '1.0', url: 'https://example.com/ref.json' }
+    })
+    // make it publicly readable so any other account can use it as an initFrom source
+    await testUser1.put(`/api/v1/datasets/${ref.id}/permissions`, [{ classes: ['read'] }])
+
+    // user5 (different account) creates a new dataset initialized from the reference
+    const res = await testUser5.post('/api/v1/datasets', {
+      isRest: true,
+      title: 'inherited across accounts',
+      initFrom: { dataset: ref.id, parts: ['schema'] }
+    })
+    assert.equal(res.status, 201)
+    const inherited = await waitForFinalize(testUser5, res.data.id)
+    assert.equal(inherited.owner.type, 'user')
+    assert.equal(inherited.owner.id, 'test_user5')
+    assert.deepEqual(inherited.conformsTo, {
+      title: 'Public Reference Schema',
+      version: '1.0',
+      url: 'https://example.com/ref.json'
+    })
+  })
 })

--- a/ui/src/components/dataset/schema/dataset-conforms-to-edit.vue
+++ b/ui/src/components/dataset/schema/dataset-conforms-to-edit.vue
@@ -1,0 +1,178 @@
+<template>
+  <v-row
+    v-if="active"
+    class="ma-0 mb-4"
+    dense
+  >
+    <v-col
+      cols="12"
+      md="8"
+      lg="4"
+    >
+      <v-combobox
+        v-model="localValue.title"
+        :items="titleItems"
+        :label="t('title')"
+        :disabled="disabled"
+        :base-color="fieldColor('title')"
+        :color="fieldColor('title')"
+        :loading="loading"
+        clearable
+        hide-details="auto"
+        density="comfortable"
+        variant="outlined"
+        @update:focused="onAnyFocus"
+        @update:model-value="emitChange"
+      />
+    </v-col>
+    <v-col
+      cols="12"
+      md="4"
+      lg="2"
+    >
+      <v-combobox
+        v-model="localValue.version"
+        :items="versionItems"
+        :label="t('version')"
+        :disabled="disabled"
+        :base-color="fieldColor('version')"
+        :color="fieldColor('version')"
+        :loading="loading"
+        hide-details="auto"
+        density="comfortable"
+        variant="outlined"
+        @update:focused="onAnyFocus"
+        @update:model-value="emitChange"
+      />
+    </v-col>
+    <v-col
+      cols="12"
+      lg="6"
+    >
+      <v-combobox
+        v-model="localValue.url"
+        :items="urlItems"
+        :label="t('url')"
+        :disabled="disabled"
+        :base-color="fieldColor('url')"
+        :color="fieldColor('url')"
+        :loading="loading"
+        clearable
+        hide-details="auto"
+        density="comfortable"
+        variant="outlined"
+        type="url"
+        @update:focused="onAnyFocus"
+        @update:model-value="emitChange"
+      />
+    </v-col>
+  </v-row>
+</template>
+
+<i18n lang="yaml">
+fr:
+  title: Titre
+  version: Version
+  url: URL
+en:
+  title: Title
+  version: Version
+  url: URL
+</i18n>
+
+<script setup lang="ts">
+import equal from 'fast-deep-equal'
+import { $apiPath } from '~/context'
+
+type Triple = { title?: string | null, version?: string | null, url?: string | null }
+
+const props = defineProps<{
+  modelValue?: Triple | null
+  originalValue?: Triple | null
+  owner?: { type: string, id: string } | null
+  active: boolean
+  disabled?: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: Triple | null): void
+}>()
+
+const { t } = useI18n()
+
+const localValue = ref<Triple>({
+  title: props.modelValue?.title ?? null,
+  version: props.modelValue?.version ?? null,
+  url: props.modelValue?.url ?? null
+})
+
+const toCanonical = (v: Triple): Triple | null => {
+  const clean: Triple = {}
+  if (v.title) clean.title = v.title
+  if (v.version) clean.version = v.version
+  if (v.url) clean.url = v.url
+  return Object.keys(clean).length ? clean : null
+}
+
+watch(() => props.modelValue, (v) => {
+  if (!equal(v, toCanonical(localValue.value))) {
+    localValue.value = {
+      title: v?.title ?? null,
+      version: v?.version ?? null,
+      url: v?.url ?? null
+    }
+  }
+})
+
+const emitChange = () => {
+  emit('update:modelValue', toCanonical(localValue.value))
+}
+
+const fieldColor = (field: keyof Triple): string | undefined => {
+  if (!props.originalValue && !localValue.value[field]) return undefined
+  const original = props.originalValue?.[field] ?? ''
+  const current = localValue.value[field] ?? ''
+  return original !== current ? 'accent' : undefined
+}
+
+// --- Suggestions ---
+
+const triples = ref<Triple[]>([])
+const loading = ref(false)
+let fetched = false
+
+const onAnyFocus = async (focused: boolean) => {
+  if (!focused || fetched || !props.owner) return
+  fetched = true
+  loading.value = true
+  try {
+    const ownerParam = `${props.owner.type}:${props.owner.id}`
+    const res = await $fetch<{ facets?: { conformsTo?: { value: Triple, count: number }[] } }>(`${$apiPath}/datasets`, {
+      query: { size: 0, facets: 'conformsTo', owner: ownerParam }
+    })
+    triples.value = (res?.facets?.conformsTo ?? []).map(f => f.value)
+  } catch (e) {
+    console.error('Failed to fetch conformsTo suggestions', e)
+  }
+  loading.value = false
+}
+
+const unique = (arr: (string | null | undefined)[]): string[] => {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const v of arr) {
+    if (v && !seen.has(v)) { seen.add(v); out.push(v) }
+  }
+  return out
+}
+
+const matchesTitle = (triple: Triple) => !localValue.value.title || triple.title === localValue.value.title
+const matchesUrl = (triple: Triple) => !localValue.value.url || triple.url === localValue.value.url
+
+const titleItems = computed(() => unique(triples.value.filter(matchesUrl).map(t => t.title)))
+const urlItems = computed(() => unique(triples.value.filter(matchesTitle).map(t => t.url)))
+const versionItems = computed(() => {
+  if (!localValue.value.title && !localValue.value.url) return []
+  return unique(triples.value.filter(matchesTitle).filter(matchesUrl).map(t => t.version))
+})
+</script>

--- a/ui/src/components/dataset/schema/dataset-conforms-to-edit.vue
+++ b/ui/src/components/dataset/schema/dataset-conforms-to-edit.vue
@@ -16,7 +16,7 @@
         :disabled="disabled"
         :base-color="fieldColor('title')"
         :color="fieldColor('title')"
-        :loading="loading"
+        :loading="fetchSuggestions.loading.value"
         clearable
         hide-details="auto"
         density="comfortable"
@@ -37,7 +37,7 @@
         :disabled="disabled"
         :base-color="fieldColor('version')"
         :color="fieldColor('version')"
-        :loading="loading"
+        :loading="fetchSuggestions.loading.value"
         hide-details="auto"
         density="comfortable"
         variant="outlined"
@@ -56,7 +56,7 @@
         :disabled="disabled"
         :base-color="fieldColor('url')"
         :color="fieldColor('url')"
-        :loading="loading"
+        :loading="fetchSuggestions.loading.value"
         clearable
         hide-details="auto"
         density="comfortable"
@@ -74,10 +74,12 @@ fr:
   title: Titre du schéma de référence
   version: Version
   url: URL
+  fetchSuggestionsError: Erreur lors du chargement des suggestions de schémas
 en:
   title: Title of the reference schema
   version: Version
   url: URL
+  fetchSuggestionsError: Failed to load schema suggestions
 </i18n>
 
 <script setup lang="ts">
@@ -138,23 +140,21 @@ const fieldColor = (field: keyof Triple): string | undefined => {
 // --- Suggestions ---
 
 const triples = ref<Triple[]>([])
-const loading = ref(false)
 let fetched = false
 
-const onAnyFocus = async (focused: boolean) => {
+const fetchSuggestions = useAsyncAction(async () => {
+  if (!props.owner) return
+  const ownerParam = `${props.owner.type}:${props.owner.id}`
+  const res = await $fetch<{ facets?: { conformsTo?: { value: Triple, count: number }[] } }>(`${$apiPath}/datasets`, {
+    query: { size: 0, facets: 'conformsTo', owner: ownerParam }
+  })
+  triples.value = (res?.facets?.conformsTo ?? []).map(f => f.value)
+}, { error: t('fetchSuggestionsError') })
+
+const onAnyFocus = (focused: boolean) => {
   if (!focused || fetched || !props.owner) return
   fetched = true
-  loading.value = true
-  try {
-    const ownerParam = `${props.owner.type}:${props.owner.id}`
-    const res = await $fetch<{ facets?: { conformsTo?: { value: Triple, count: number }[] } }>(`${$apiPath}/datasets`, {
-      query: { size: 0, facets: 'conformsTo', owner: ownerParam }
-    })
-    triples.value = (res?.facets?.conformsTo ?? []).map(f => f.value)
-  } catch (e) {
-    console.error('Failed to fetch conformsTo suggestions', e)
-  }
-  loading.value = false
+  fetchSuggestions.execute()
 }
 
 const unique = (arr: (string | null | undefined)[]): string[] => {

--- a/ui/src/components/dataset/schema/dataset-conforms-to-edit.vue
+++ b/ui/src/components/dataset/schema/dataset-conforms-to-edit.vue
@@ -71,11 +71,11 @@
 
 <i18n lang="yaml">
 fr:
-  title: Titre
+  title: Titre du schéma de référence
   version: Version
   url: URL
 en:
-  title: Title
+  title: Title of the reference schema
   version: Version
   url: URL
 </i18n>

--- a/ui/src/components/dataset/schema/dataset-schema-edit.vue
+++ b/ui/src/components/dataset/schema/dataset-schema-edit.vue
@@ -1,4 +1,14 @@
 <template>
+  <dataset-conforms-to-edit
+    v-if="conformsToActive"
+    :model-value="conformsTo ?? null"
+    :original-value="originalConformsTo ?? null"
+    :owner="owner ?? null"
+    :active="!!conformsToActive"
+    :disabled="!can('writeDescription')"
+    @update:model-value="v => emit('update:conformsTo', v)"
+  />
+
   <div class="d-flex align-center flex-wrap ga-2 mb-2">
     <h3
       v-if="editableColumns.length"
@@ -117,17 +127,24 @@ const coordXUri = 'http://data.ign.fr/def/geometrie#coordX'
 const coordYUri = 'http://data.ign.fr/def/geometrie#coordY'
 const projectGeomUri = 'http://data.ign.fr/def/geometrie#Geometry'
 
+type ConformsTo = { title?: string | null, version?: string | null, url?: string | null }
+
 const props = defineProps<{
   modelValue: SchemaProperty[]
   originalSchema?: SchemaProperty[]
   primaryKey?: string[]
   projection?: { title?: string, code?: string } | null
+  conformsTo?: ConformsTo | null
+  originalConformsTo?: ConformsTo | null
+  owner?: { type: string, id: string } | null
+  conformsToActive?: boolean
 }>()
 
 const emit = defineEmits<{
   'update:modelValue': [value: SchemaProperty[]]
   'update:primaryKey': [value: string[]]
   'update:projection': [value: { title?: string, code?: string } | null]
+  'update:conformsTo': [value: ConformsTo | null]
 }>()
 
 const { t } = useI18n()

--- a/ui/src/pages/dataset/[id]/index.vue
+++ b/ui/src/pages/dataset/[id]/index.vue
@@ -56,8 +56,13 @@
             :original-schema="structureEditFetch.serverData.value?.schema"
             :primary-key="structureEditFetch.data.value.primaryKey"
             :projection="structureEditFetch.data.value.projection ?? null"
+            :conforms-to="structureEditFetch.data.value.conformsTo ?? null"
+            :original-conforms-to="structureEditFetch.serverData.value?.conformsTo ?? null"
+            :owner="dataset?.owner ?? null"
+            :conforms-to-active="!!datasetsMetadata?.conformsTo?.active"
             @update:primary-key="pk => { if (structureEditFetch.data.value) structureEditFetch.data.value.primaryKey = pk }"
             @update:projection="p => { if (structureEditFetch.data.value) structureEditFetch.data.value.projection = p }"
+            @update:conforms-to="c => { if (structureEditFetch.data.value) structureEditFetch.data.value.conformsTo = c }"
           />
         </v-tabs-window-item>
 
@@ -682,6 +687,7 @@ import { useAgentExpressionTools } from '~/composables/dataset/agent-expression-
 import { useAgentSchemaAnnotationTools } from '~/composables/dataset/agent-schema-annotation-tools'
 import { useAgentPropertyConfigTools } from '~/composables/dataset/agent-property-config-tools'
 import { hasInvalidExprEvalExtension } from '~/composables/dataset/expr-eval-validation'
+import { useDatasetsMetadata } from '~/composables/dataset/use-metadata'
 
 const { t, locale } = useI18n()
 const route = useRoute<'/dataset/[id]/'>()
@@ -707,6 +713,8 @@ watch(shareTab, (tab) => {
 
 const store = useDatasetStore()
 const { dataset, journal, journalFetch, taskProgress, taskProgressFetch, applicationsFetch, publishedDatasetFetch, digitalDocumentField, imageField, can, id, remove, permissions, permissionsFetch, savePermissions, applyEditFetchSnapshot } = store
+
+const { datasetsMetadata } = useDatasetsMetadata(computed(() => dataset.value?.owner))
 
 const onSavePermissions = async (newPermissions: import('#api/types').Permission[]) => {
   await savePermissions(newPermissions)
@@ -892,7 +900,10 @@ const schemaHasDiff = computed(() => {
   const d = structureEditFetch.data.value
   const s = structureEditFetch.serverData.value
   if (!d || !s) return false
-  return !equal(d.schema, s.schema) || !equal(d.primaryKey, s.primaryKey) || !equal(d.projection, s.projection)
+  return !equal(d.schema, s.schema) ||
+    !equal(d.primaryKey, s.primaryKey) ||
+    !equal(d.projection, s.projection) ||
+    !equal(d.conformsTo, s.conformsTo)
 })
 
 const extensionsHasDiff = computed(() => {

--- a/ui/src/pages/settings.vue
+++ b/ui/src/pages/settings.vue
@@ -446,7 +446,7 @@ const settings = settingsEditFetch.data
 function normalizeSettings (s: any) {
   if (!s) return
   const dm = s.datasetsMetadata = s.datasetsMetadata || {}
-  for (const key of ['spatial', 'temporal', 'frequency', 'creator', 'modified', 'keywords']) {
+  for (const key of ['spatial', 'temporal', 'frequency', 'creator', 'modified', 'keywords', 'conformsTo']) {
     if (!dm[key]) dm[key] = { active: false }
   }
 }


### PR DESCRIPTION
First two iterations of the schema-references roadmap: a new optional dataset metadata field `conformsTo` (DCAT `dct:conformsTo`) and the wiring that turns it into a working schema-governance pattern when a dataset is copied from a reference one.

- `feat(api)`: add the optional `dataset.conformsTo = { title?, version?, url? }` (named `conformsTo` rather than `schema` to avoid clashing with the existing column list). Property added to the dataset JSON schema and the PATCH allow-list. New org-level toggle `settings.datasetsMetadata.conformsTo` gates the editor in the UI without erasing stored values. Distinct triples are surfaced via the standard facets system at `GET /datasets?facets=conformsTo&owner=type:id` (same pattern as topics / base-application, extended to support structured-object facets). Tests cover PATCH persistence (full + partial + null-clear), facet shape, and cross-user isolation.
- `feat(api)`: inherit `conformsTo` when a new dataset is created via `initFrom` with `parts: ['schema']` — alongside the already-implicit primaryKey / projection / timeZone / attachmentsAsImage. This is the link that makes "copying a reference dataset" automatically declare the same schema reference. Negative case (`parts: ['description']` → no inheritance) is covered too.
- `feat(ui)`: 3-input subform (Titre / Version / URL) at the top of *Structure → Schémas*, shown only when the org has the `conformsTo` metadata active. Cross-field suggestions: on first focus the form fetches the distinct triples from the facet endpoint and filters client-side — picking a title narrows the URL choices to matching triples and vice versa; version stays empty until either title or URL is set, then intersects on both. Bindings flow through the existing `structureEditFetch` patch pipeline and the existing *Save* button picks up the change via `schemaHasDiff`. Emits `null` when all three fields are cleared so the PATCH carries the key and triggers `$unset` server-side.
- `refactor(ui)`: the suggestions fetch goes through `useAsyncAction` so failures surface as standard UI notifs (`fetchSuggestionsError`) and the loading state follows the convention used by sibling components.
- `feat(i18n)`: relabel the title field to *Titre du schéma de référence* / *Title of the reference schema* so it cannot be confused with the dataset's own title.

Out of scope for this PR (iter 3 & 4 of the roadmap): consistency check across datasets sharing the same `conformsTo`, and shareable apps/dashboards filtered by `conformsTo`.

## Regression risks to verify

- `dataset-schema-edit.vue` becomes a multi-root Vue 3 template (the `<dataset-conforms-to-edit>` sibling sits above the existing `<div>`). No inherited attrs today, but any future `class=`/`style=` passed to the component will trigger a Vue fragment warning.
- `PATCH conformsTo: null` returns `null` in the response (in-memory `Object.assign`) but persists a `$unset` — the next GET returns `undefined`. Consistent with other nullable fields, called out so a consumer relying on the PATCH response for cache refresh stays aware of it.
- `useDatasetsMetadata` is now instantiated on the dataset page mount, adding a settings fetch per dataset view.
- The new facet groups on the strict triple — non-normalized versions (e.g. `"1.0"` vs `"1.0.0"`) appear as distinct suggestions.