### PR TITLE
fix(ui): RGAA accessibility fixes for the dataset table view

### DIFF
--- a/tests/features/embed/dataset-table-a11y.e2e.spec.ts
+++ b/tests/features/embed/dataset-table-a11y.e2e.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from '../../fixtures/login.ts'
+import { axiosAuth, clean } from '../../support/axios.ts'
+import { sendDataset } from '../../support/workers.ts'
+
+test.describe('embed dataset table — accessibility (RGAA)', () => {
+  test.beforeEach(async () => {
+    await clean()
+  })
+
+  test('table exposes an accessible name and column scopes (5.5 / 5.6)', async ({ page, goToWithAuth }) => {
+    const ax = await axiosAuth('test_user1@test.com')
+    const dataset = await sendDataset('datasets/dataset1.csv', ax)
+
+    await goToWithAuth(`/data-fair/embed/dataset/${dataset.id}/table`, 'test_user1')
+    const table = page.locator('table').first()
+    await expect(table).toBeVisible({ timeout: 15000 })
+
+    // 5.5 — accessible name: prefer <caption>, fall back to aria-label
+    const captions = await table.locator('caption').count()
+    const ariaLabel = await table.getAttribute('aria-label')
+    expect(captions > 0 || Boolean(ariaLabel)).toBe(true)
+
+    // 5.6 — each column header has scope="col"
+    const ths = await table.locator('thead > tr > th').all()
+    expect(ths.length).toBeGreaterThan(0)
+    for (const th of ths) {
+      await expect(th).toHaveAttribute('scope', 'col')
+    }
+  })
+
+  test('search field is labelled and wrapped in a search landmark (7.1 / 12.6)', async ({ page, goToWithAuth }) => {
+    const ax = await axiosAuth('test_user1@test.com')
+    const dataset = await sendDataset('datasets/dataset1.csv', ax)
+
+    await goToWithAuth(`/data-fair/embed/dataset/${dataset.id}/table`, 'test_user1')
+    await expect(page.locator('table').first()).toBeVisible({ timeout: 15000 })
+
+    const searchLandmark = page.locator('[role="search"]').first()
+    await expect(searchLandmark).toBeAttached()
+
+    // Submit button must expose an explicit accessible name
+    const submit = searchLandmark.getByRole('button').first()
+    await expect(submit).toHaveAccessibleName(/recherche|search/i)
+  })
+
+  test('search results are announced via aria-live (7.5)', async ({ page, goToWithAuth }) => {
+    const ax = await axiosAuth('test_user1@test.com')
+    const dataset = await sendDataset('datasets/dataset1.csv', ax)
+
+    await goToWithAuth(`/data-fair/embed/dataset/${dataset.id}/table`, 'test_user1')
+    await expect(page.locator('table').first()).toBeVisible({ timeout: 15000 })
+
+    const liveRegion = page.locator('[role="status"][aria-live="polite"]').first()
+    await expect(liveRegion).toBeAttached()
+
+    // Initial load must settle on a *result count* announcement, not stay stuck on "Loading"
+    await expect(liveRegion).toContainText(/(\d+|aucun|no)\s+(résultat|result)/i, { timeout: 5000 })
+
+    // Submitting a no-match query must update the announcement to mention the query
+    const input = page.locator('[role="search"] input').first()
+    await input.fill('zzz_no_match_expected_zzz')
+    await input.press('Enter')
+
+    await expect(liveRegion).toContainText(/zzz_no_match_expected_zzz/i, { timeout: 5000 })
+    await expect(liveRegion).toContainText(/(0|aucun|no)\s+(résultat|result)/i, { timeout: 5000 })
+  })
+
+  test('scrollable table wrapper is focusable and sort is keyboard-activable (7.3)', async ({ page, goToWithAuth }) => {
+    const ax = await axiosAuth('test_user1@test.com')
+    const dataset = await sendDataset('datasets/dataset1.csv', ax)
+
+    await goToWithAuth(`/data-fair/embed/dataset/${dataset.id}/table`, 'test_user1')
+    await expect(page.locator('table').first()).toBeVisible({ timeout: 15000 })
+
+    // 7.3 — scrollable wrapper must be reachable by Tab so keyboard users can scroll rows
+    const scrollWrapper = page.locator('.dataset-table .v-table__wrapper').first()
+    await expect(scrollWrapper).toHaveAttribute('tabindex', '0')
+
+    // Each sortable column header exposes a real focusable button
+    const firstSortButton = page.locator('thead th button[aria-haspopup="true"]').first()
+    await expect(firstSortButton).toBeVisible()
+    await firstSortButton.focus()
+    await expect(firstSortButton).toBeFocused()
+    await page.keyboard.press('Enter')
+    // Vuetify's v-menu renders as .v-overlay--active.v-menu (no role="menu" on the overlay itself)
+    await expect(page.locator('.v-overlay--active.v-menu').first()).toBeVisible({ timeout: 2000 })
+    // Closing the menu must return focus to the trigger button so keyboard users
+    // don't get dropped on <body> after Escape (RGAA 7.3 / 12.8)
+    await page.keyboard.press('Escape')
+    await expect(page.locator('.v-overlay--active.v-menu')).toHaveCount(0)
+    await expect(firstSortButton).toBeFocused()
+  })
+
+  test('column hide / pin / filter changes are announced (7.5)', async ({ page, goToWithAuth }) => {
+    const ax = await axiosAuth('test_user1@test.com')
+    const dataset = await sendDataset('datasets/dataset1.csv', ax)
+
+    await goToWithAuth(`/data-fair/embed/dataset/${dataset.id}/table`, 'test_user1')
+    await expect(page.locator('table').first()).toBeVisible({ timeout: 15000 })
+    const liveRegion = page.locator('[role="status"][aria-live="polite"]').first()
+    const firstHeader = page.locator('thead th button[aria-haspopup="true"]').first()
+    const columnName = (await firstHeader.textContent())?.trim()
+
+    // Hide column → live region must mention it
+    await firstHeader.focus()
+    await page.keyboard.press('Enter')
+    await page.getByRole('listitem').filter({ hasText: /masquer|hide/i }).first().click()
+    await expect(liveRegion).toContainText(new RegExp(`(masqu|hidden).*${columnName}|${columnName}.*(masqu|hidden)`, 'i'), { timeout: 3000 })
+  })
+})

--- a/ui/src/components/dataset/table/dataset-table-cell.vue
+++ b/ui/src/components/dataset/table/dataset-table-cell.vue
@@ -33,7 +33,7 @@
         position="absolute"
         size="x-small"
         variant="flat"
-        style="right: 4px; top: 50%; transform: translateY(-50%); z-index: 100;"
+        style="right: 4px; top: 50%; transform: translateY(-50%);"
         @click="emit('showMapPreview')"
       />
     </template>

--- a/ui/src/components/dataset/table/dataset-table-header-menu.vue
+++ b/ui/src/components/dataset/table/dataset-table-header-menu.vue
@@ -5,7 +5,7 @@
     :close-on-content-click="false"
     :max-height="filterHeight"
     location="bottom right"
-    @update:model-value="toggleMenu"
+    @update:model-value="onMenuToggle"
   >
     <v-sheet
       class="pa-1"
@@ -699,12 +699,13 @@ import { type DatasetFilter } from '~/composables/dataset/filters'
 import { formatValue } from '~/composables/dataset/lines'
 import useHeaderFilters from './use-header-filters'
 
-const { header, localEnum, filters, closeOnFilter } = defineProps({
+const { header, localEnum, filters, closeOnFilter, activator, triggerSelector } = defineProps({
   header: { type: Object as () => TableHeaderWithProperty, required: true },
   filters: { type: Array as () => DatasetFilter[], required: true },
   filterHeight: { type: Number, required: true },
   fixed: { type: Boolean, default: false },
   activator: { type: String, required: true },
+  triggerSelector: { type: String, default: undefined }, // focusable element to restore focus to on close; defaults to activator
   noFix: { type: Boolean, default: false },
   localEnum: { type: Array, required: false, default: null },
   closeOnFilter: { type: Boolean, default: false }
@@ -763,8 +764,33 @@ watch(nEquals, () => {
   if (JSON.stringify(nEquals.value) !== JSON.stringify(newNequals)) nEquals.value = newNequals
 }, { deep: true, immediate: true })
 
-const toggleMenu = () => {
-  if (!showMenu.value) return
+// Restore focus to the activator button when the menu closes (RGAA 7.3).
+// Vuetify's built-in restore targets the activator element by selector but,
+// since the activator can cover a non-focusable wrapper (e.g. a <th>), we
+// look up `triggerSelector` first and fall back to any visible header button
+// inside the same table when the activator was unmounted (e.g. after the
+// user picked "Hide column"). The query runs inside nextTick so we read the
+// post-close DOM, not the snapshot from the toggle moment.
+let activatorScope: HTMLElement | null = null
+const onMenuToggle = () => {
+  if (!showMenu.value) {
+    nextTick(() => {
+      const focusSelector = triggerSelector ?? activator
+      let trigger = document.querySelector<HTMLElement>(focusSelector)
+      if (!trigger && activatorScope?.isConnected) {
+        // Activator was unmounted (e.g. column hidden) — fall back to any
+        // visible header button inside the same table so keyboard focus
+        // doesn't drop to <body>.
+        trigger = activatorScope.querySelector<HTMLElement>('button[aria-haspopup]')
+      }
+      trigger?.focus()
+    })
+    return
+  }
+  // Snapshot the closest table ancestor while the activator still exists,
+  // so we can scope the close-time fallback to the same instance.
+  const activatorEl = document.querySelector<HTMLElement>(activator)
+  activatorScope = activatorEl?.closest<HTMLElement>('.dataset-table, .dataset-table-card') ?? null
   emptyFilters()
   newFilter.value = undefined
   for (const filter of filters.filter(f => f.property.key === header.property.key)) {

--- a/ui/src/components/dataset/table/dataset-table-header-menu.vue
+++ b/ui/src/components/dataset/table/dataset-table-header-menu.vue
@@ -5,7 +5,7 @@
     :close-on-content-click="false"
     :max-height="filterHeight"
     location="bottom right"
-    @update:model-value="toggleMenu"
+    @update:model-value="onMenuToggle"
   >
     <v-sheet
       class="pa-1"
@@ -711,12 +711,13 @@ import { type DatasetFilter } from '~/composables/dataset/filters'
 import { formatValue } from '~/composables/dataset/lines'
 import useHeaderFilters from './use-header-filters'
 
-const { header, localEnum, filters, closeOnFilter } = defineProps({
+const { header, localEnum, filters, closeOnFilter, activator, triggerSelector } = defineProps({
   header: { type: Object as () => TableHeaderWithProperty, required: true },
   filters: { type: Array as () => DatasetFilter[], required: true },
   filterHeight: { type: Number, required: true },
   fixed: { type: Boolean, default: false },
   activator: { type: String, required: true },
+  triggerSelector: { type: String, default: undefined }, // focusable element to restore focus to on close; defaults to activator
   noFix: { type: Boolean, default: false },
   localEnum: { type: Array, required: false, default: null },
   closeOnFilter: { type: Boolean, default: false },
@@ -777,8 +778,33 @@ watch(nEquals, () => {
   if (JSON.stringify(nEquals.value) !== JSON.stringify(newNequals)) nEquals.value = newNequals
 }, { deep: true, immediate: true })
 
-const toggleMenu = () => {
-  if (!showMenu.value) return
+// Restore focus to the activator button when the menu closes (RGAA 7.3).
+// Vuetify's built-in restore targets the activator element by selector but,
+// since the activator can cover a non-focusable wrapper (e.g. a <th>), we
+// look up `triggerSelector` first and fall back to any visible header button
+// inside the same table when the activator was unmounted (e.g. after the
+// user picked "Hide column"). The query runs inside nextTick so we read the
+// post-close DOM, not the snapshot from the toggle moment.
+let activatorScope: HTMLElement | null = null
+const onMenuToggle = () => {
+  if (!showMenu.value) {
+    nextTick(() => {
+      const focusSelector = triggerSelector ?? activator
+      let trigger = document.querySelector<HTMLElement>(focusSelector)
+      if (!trigger && activatorScope?.isConnected) {
+        // Activator was unmounted (e.g. column hidden) — fall back to any
+        // visible header button inside the same table so keyboard focus
+        // doesn't drop to <body>.
+        trigger = activatorScope.querySelector<HTMLElement>('button[aria-haspopup]')
+      }
+      trigger?.focus()
+    })
+    return
+  }
+  // Snapshot the closest table ancestor while the activator still exists,
+  // so we can scope the close-time fallback to the same instance.
+  const activatorEl = document.querySelector<HTMLElement>(activator)
+  activatorScope = activatorEl?.closest<HTMLElement>('.dataset-table, .dataset-table-card') ?? null
   emptyFilters()
   newFilter.value = undefined
   for (const filter of filters.filter(f => f.property.key === header.property.key)) {

--- a/ui/src/components/dataset/table/dataset-table.vue
+++ b/ui/src/components/dataset/table/dataset-table.vue
@@ -91,14 +91,26 @@
     />
     <search-field v-model="q" />
   </v-toolbar>
+  <div
+    class="d-sr-only"
+    role="status"
+    aria-live="polite"
+    aria-atomic="true"
+  >
+    {{ liveMessage }}
+  </div>
   <v-sheet class="pa-0">
     <v-table
       v-if="displayMode === 'table' || displayMode === 'table-dense'"
+      ref="tableRoot"
       :height="pagination ? undefined : height - ((noInteraction && !searchOnly) ? 0 : 48)"
       :loading="fetchResults.loading.value"
       class="dataset-table"
       :fixed-header="!pagination"
     >
+      <caption class="d-sr-only">
+        {{ tableLabel }}
+      </caption>
       <thead ref="thead">
         <tr>
           <template
@@ -106,7 +118,11 @@
             :key="header.key"
           >
             <th
-              :id="`header-${header.cssKey ?? header.key}`"
+              :id="`${instanceId}-header-${header.cssKey ?? header.key}`"
+              scope="col"
+              :aria-sort="header.property && !noInteraction
+                ? (header.key === sort?.key ? (sort.direction === 1 ? 'ascending' : 'descending') : 'none')
+                : undefined"
               :title="header.title"
               class="text-left"
               :class="{
@@ -141,22 +157,33 @@
                   :selected-cols="selectedCols"
                 />
               </div>
+              <button
+                v-else-if="header.property && !noInteraction"
+                :id="`${instanceId}-header-button-${header.cssKey ?? header.key}`"
+                type="button"
+                class="pr-2 header-wrapper dataset-table-th-button"
+                aria-haspopup="true"
+                :aria-label="t('headerMenuLabel', { column: header.title })"
+              >
+                <span class="two-lines">{{ header.title }}</span>
+                <v-icon
+                  v-if="hoveredHeader?.key === header.key || header.key === sort?.key"
+                  :color="header.key === sort?.key ? 'primary' : 'default'"
+                  :icon="header.key === sort?.key ? (sort.direction === 1 ? mdiSortAscending : mdiSortDescending) : mdiMenuDown"
+                  class="action-icon"
+                />
+              </button>
               <div
                 v-else
                 class="pr-2 header-wrapper"
               >
                 <span class="two-lines">{{ header.title }}</span>
-                <v-icon
-                  v-if="header.property && (hoveredHeader?.key === header.key || header.key === sort?.key)"
-                  :color="header.key === sort?.key ? 'primary' : 'default'"
-                  :icon="header.key === sort?.key ? (sort.direction === 1 ? mdiSortAscending : mdiSortDescending) : mdiMenuDown"
-                  class="action-icon"
-                />
               </div>
             </th>
             <dataset-table-header-menu
               v-if="header.property && !noInteraction"
-              :activator="`#header-${header.cssKey ?? header.key}`"
+              :activator="`#${instanceId}-header-${header.cssKey ?? header.key}`"
+              :trigger-selector="`#${instanceId}-header-button-${header.cssKey ?? header.key}`"
               :filter-height="height - 20"
               :filters="filters"
               :fixed="fixed === header.key"
@@ -440,6 +467,32 @@
     helpFilterPrompt: Aide-moi à filtrer ces données
     checkDataQualityPrompt: Vérifier la qualité de ces données
     helpEditDataPrompt: Aide-moi à saisir des données
+    tableCaption: "Tableau de données : {title}"
+    tableCaptionFallback: Tableau de données
+    announce:
+      results: "Aucun résultat | 1 résultat | {count} résultats"
+      searchResults: "Aucun résultat pour « {query} » | 1 résultat pour « {query} » | {count} résultats pour « {query} »"
+      loading: Chargement des résultats
+      sort: "Tri appliqué : colonne {column}, {direction}"
+      sortRemoved: Tri retiré
+      display: "Affichage : {mode}"
+      column:
+        hidden: "Colonne {column} masquée"
+        shown: "Colonne {column} affichée"
+        changed: "Affichage mis à jour : 1 colonne visible | Affichage mis à jour : {count} colonnes visibles"
+        fixed: "Colonne {column} épinglée à gauche"
+        unfixed: "Colonne {column} dépinglée"
+      filter:
+        added: "Filtre appliqué sur la colonne {column} : {value}"
+        removed: "Filtre retiré sur la colonne {column}"
+    sortDirection:
+      ascending: ordre croissant
+      descending: ordre décroissant
+    headerMenuLabel: "Colonne {column}, ouvrir les options de tri et de filtre"
+    displayMode:
+      table: Tableau
+      tableDense: Tableau dense
+      list: Liste de vignettes
   en:
     cancel: Cancel
     delete: Delete
@@ -450,6 +503,32 @@
     deleteLine: Delete a line
     deleteLineWarning: Warning, the data from this line will be lost permanently
     helpEditDataPrompt: Help me enter data
+    tableCaption: "Data table: {title}"
+    tableCaptionFallback: Data table
+    announce:
+      results: "No result | 1 result | {count} results"
+      searchResults: "No result for \"{query}\" | 1 result for \"{query}\" | {count} results for \"{query}\""
+      loading: Loading results
+      sort: "Sort applied: column {column}, {direction}"
+      sortRemoved: Sort removed
+      display: "Display: {mode}"
+      column:
+        hidden: "Column {column} hidden"
+        shown: "Column {column} shown"
+        changed: "Display updated: 1 column visible | Display updated: {count} columns visible"
+        fixed: "Column {column} pinned to the left"
+        unfixed: "Column {column} unpinned"
+      filter:
+        added: "Filter applied on column {column}: {value}"
+        removed: "Filter removed on column {column}"
+    sortDirection:
+      ascending: ascending order
+      descending: descending order
+    headerMenuLabel: "Column {column}, open sort and filter options"
+    displayMode:
+      table: Table
+      tableDense: Dense table
+      list: Card list
 </i18n>
 
 <script setup lang="ts">
@@ -457,6 +536,7 @@ import type { VVirtualScroll, VForm } from 'vuetify/components'
 import { mdiSortDescending, mdiSortAscending, mdiMenuDown, mdiClose, mdiChevronLeft, mdiChevronRight } from '@mdi/js'
 import useLines, { type ExtendedResultValue, type ExtendedResult } from '../../../composables/dataset/lines'
 import useHeaders, { TableHeaderWithProperty, type TableHeader, type SyntheticColumn } from './use-headers'
+import { useTableAnnouncer } from './use-table-announcer'
 import { provideDatasetEdition } from './use-dataset-edition'
 import { useDisplay } from 'vuetify'
 import { DatasetLine, type SchemaProperty } from '#api/types'
@@ -520,6 +600,14 @@ const display = useDisplay()
 
 const { dataset, id: datasetId, imageField } = useDatasetStore()
 // const charsWidths = ref<Record<string, number> | null>(null)
+
+// Scope per-table DOM IDs so two coexisting tables (e.g. back-office + preview
+// drawer) don't collide on `#header-…` selectors used by the header v-menu.
+const instanceId = useId()
+
+const tableLabel = computed(() => dataset.value?.title
+  ? t('tableCaption', { title: dataset.value.title })
+  : t('tableCaptionFallback'))
 
 const allCols = computed(() => dataset.value?.schema?.filter(field => !field['x-calculated'] || field.key === '_updatedAt' || field.key === '_updatedByName').map(p => p.key) ?? [])
 const selectedCols = computed(() => cols.value.length ? cols.value : allCols.value)
@@ -589,6 +677,36 @@ const nextPage = async () => {
 const { headers, headersWithProperty } = useHeaders(selectedCols, noInteraction, edit, selectable, fixed, () => syntheticColumns, () => headerKeys)
 const { selectedResults, saveLine, removeLine, addLineTrigger } = provideDatasetEdition(baseFetchUrl, indexedAt)
 
+const { message: liveMessage } = useTableAnnouncer({
+  q,
+  total,
+  loading: fetchResults.loading,
+  sort,
+  displayMode,
+  cols,
+  allCols,
+  fixed,
+  filters,
+  headerTitleFor: (key) => {
+    // Visible headers carry the resolved title for the current display.
+    // Hidden columns (e.g. after a `hide` action) are no longer there, so
+    // fall back to the dataset schema so announcements still use a human-
+    // readable label instead of the raw key.
+    const fromHeaders = headers.value?.find(h => h.key === key)?.title
+    if (fromHeaders) return fromHeaders
+    const p = dataset.value?.schema?.find(p => p.key === key)
+    return p?.title || p?.['x-originalName'] || p?.key || key
+  },
+  displayModeLabelFor: (mode) => t(
+    mode === 'table-dense'
+      ? 'displayMode.tableDense'
+      : mode === 'list'
+        ? 'displayMode.list'
+        : 'displayMode.table'
+  ),
+  t
+})
+
 if (edit) {
   useAgentTool({
     name: 'open_add_line_dialog',
@@ -625,6 +743,18 @@ if (edit) {
 const virtualScroll = ref<VVirtualScroll>()
 const colsWidths = ref<number[]>([])
 const thead = ref<HTMLElement>()
+const tableRoot = ref<{ $el?: HTMLElement } | null>(null)
+
+// The scrollable wrapper is rendered by Vuetify inside v-table and doesn't expose a prop.
+// Make it focusable so keyboard users can reach the grid with Tab and scroll via arrow keys (RGAA 7.3).
+const applyWrapperA11y = () => {
+  const wrapper = tableRoot.value?.$el?.querySelector?.<HTMLElement>('.v-table__wrapper')
+  if (!wrapper) return
+  wrapper.setAttribute('tabindex', '0')
+  wrapper.setAttribute('role', 'region')
+  wrapper.setAttribute('aria-label', tableLabel.value)
+}
+watch([tableRoot, displayMode, tableLabel], () => nextTick(applyWrapperA11y))
 const minColWidth = computed(() => {
   return displayMode.value === 'table-dense' ? 80 : 120
 })
@@ -646,9 +776,10 @@ const onScrollItem = async (index: number) => {
   // ignore scroll on deprecated items that will soon be replaced
   if (fetchResults.loading.value) return
   incColsWidth()
-  if (index === results.value.length - 1) {
-    // scrolled until the current end of the table
-    if (!fetchResults.loading.value) fetchResults.execute()
+  if (index === results.value.length - 1 && next.value) {
+    // scrolled until the current end of the table; only re-fetch if there is a next page,
+    // otherwise execute() would flip loading true→false on every intersect re-bind for nothing
+    fetchResults.execute()
   }
 }
 
@@ -714,6 +845,28 @@ const deleteLine = useAsyncAction(async () => {
 <style>
 .dataset-table th {
   z-index: 2;
+}
+.dataset-table .dataset-table-th-button {
+  background: transparent;
+  border: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  text-align: inherit;
+  cursor: pointer;
+  display: block;
+  width: 100%;
+}
+.dataset-table .dataset-table-th-button:focus-visible {
+  outline: 2px solid rgb(var(--v-theme-primary));
+  outline-offset: -2px;
+}
+.dataset-table .v-table__wrapper:focus-visible {
+  outline: 2px solid rgb(var(--v-theme-primary));
+  outline-offset: -2px;
 }
 .dataset-table .header-wrapper {
   position: relative;

--- a/ui/src/components/dataset/table/dataset-table.vue
+++ b/ui/src/components/dataset/table/dataset-table.vue
@@ -103,14 +103,26 @@
     />
     <search-field v-model="q" />
   </v-toolbar>
+  <div
+    class="d-sr-only"
+    role="status"
+    aria-live="polite"
+    aria-atomic="true"
+  >
+    {{ liveMessage }}
+  </div>
   <v-sheet class="pa-0">
     <v-table
       v-if="displayMode === 'table' || displayMode === 'table-dense'"
+      ref="tableRoot"
       :height="pagination ? undefined : height - ((noInteraction && !searchOnly) ? 0 : 48)"
       :loading="fetchResults.loading.value"
       class="dataset-table"
       :fixed-header="!pagination"
     >
+      <caption class="d-sr-only">
+        {{ tableLabel }}
+      </caption>
       <thead ref="thead">
         <tr>
           <template
@@ -118,7 +130,11 @@
             :key="header.key"
           >
             <th
-              :id="`header-${header.cssKey ?? header.key}`"
+              :id="`${instanceId}-header-${header.cssKey ?? header.key}`"
+              scope="col"
+              :aria-sort="header.property && !noInteraction
+                ? (header.key === sort?.key ? (sort.direction === 1 ? 'ascending' : 'descending') : 'none')
+                : undefined"
               :title="header.title"
               class="text-left"
               :class="{
@@ -153,22 +169,33 @@
                   :selected-cols="selectedCols"
                 />
               </div>
+              <button
+                v-else-if="header.property && !noInteraction"
+                :id="`${instanceId}-header-button-${header.cssKey ?? header.key}`"
+                type="button"
+                class="pr-2 header-wrapper dataset-table-th-button"
+                aria-haspopup="true"
+                :aria-label="t('headerMenuLabel', { column: header.title })"
+              >
+                <span class="two-lines">{{ header.title }}</span>
+                <v-icon
+                  v-if="hoveredHeader?.key === header.key || header.key === sort?.key"
+                  :color="header.key === sort?.key ? 'primary' : 'default'"
+                  :icon="header.key === sort?.key ? (sort.direction === 1 ? mdiSortAscending : mdiSortDescending) : mdiMenuDown"
+                  class="action-icon"
+                />
+              </button>
               <div
                 v-else
                 class="pr-2 header-wrapper"
               >
                 <span class="two-lines">{{ header.title }}</span>
-                <v-icon
-                  v-if="header.property && (hoveredHeader?.key === header.key || header.key === sort?.key)"
-                  :color="header.key === sort?.key ? 'primary' : 'default'"
-                  :icon="header.key === sort?.key ? (sort.direction === 1 ? mdiSortAscending : mdiSortDescending) : mdiMenuDown"
-                  class="action-icon"
-                />
               </div>
             </th>
             <dataset-table-header-menu
               v-if="header.property && !noInteraction"
-              :activator="`#header-${header.cssKey ?? header.key}`"
+              :activator="`#${instanceId}-header-${header.cssKey ?? header.key}`"
+              :trigger-selector="`#${instanceId}-header-button-${header.cssKey ?? header.key}`"
               :filter-height="height - 20"
               :filters="filters"
               :fixed="fixed === header.key"
@@ -454,6 +481,32 @@
     checkDataQualityPrompt: Vérifier la qualité de ces données
     helpEditDataPrompt: Aide-moi à saisir des données
     fullscreen: Afficher en plein écran
+    tableCaption: "Tableau de données : {title}"
+    tableCaptionFallback: Tableau de données
+    announce:
+      results: "Aucun résultat | 1 résultat | {count} résultats"
+      searchResults: "Aucun résultat pour « {query} » | 1 résultat pour « {query} » | {count} résultats pour « {query} »"
+      loading: Chargement des résultats
+      sort: "Tri appliqué : colonne {column}, {direction}"
+      sortRemoved: Tri retiré
+      display: "Affichage : {mode}"
+      column:
+        hidden: "Colonne {column} masquée"
+        shown: "Colonne {column} affichée"
+        changed: "Affichage mis à jour : 1 colonne visible | Affichage mis à jour : {count} colonnes visibles"
+        fixed: "Colonne {column} épinglée à gauche"
+        unfixed: "Colonne {column} dépinglée"
+      filter:
+        added: "Filtre appliqué sur la colonne {column} : {value}"
+        removed: "Filtre retiré sur la colonne {column}"
+    sortDirection:
+      ascending: ordre croissant
+      descending: ordre décroissant
+    headerMenuLabel: "Colonne {column}, ouvrir les options de tri et de filtre"
+    displayMode:
+      table: Tableau
+      tableDense: Tableau dense
+      list: Liste de vignettes
   en:
     cancel: Cancel
     delete: Delete
@@ -465,6 +518,32 @@
     deleteLineWarning: Warning, the data from this line will be lost permanently
     helpEditDataPrompt: Help me enter data
     fullscreen: Show fullscreen
+    tableCaption: "Data table: {title}"
+    tableCaptionFallback: Data table
+    announce:
+      results: "No result | 1 result | {count} results"
+      searchResults: "No result for \"{query}\" | 1 result for \"{query}\" | {count} results for \"{query}\""
+      loading: Loading results
+      sort: "Sort applied: column {column}, {direction}"
+      sortRemoved: Sort removed
+      display: "Display: {mode}"
+      column:
+        hidden: "Column {column} hidden"
+        shown: "Column {column} shown"
+        changed: "Display updated: 1 column visible | Display updated: {count} columns visible"
+        fixed: "Column {column} pinned to the left"
+        unfixed: "Column {column} unpinned"
+      filter:
+        added: "Filter applied on column {column}: {value}"
+        removed: "Filter removed on column {column}"
+    sortDirection:
+      ascending: ascending order
+      descending: descending order
+    headerMenuLabel: "Column {column}, open sort and filter options"
+    displayMode:
+      table: Table
+      tableDense: Dense table
+      list: Card list
 </i18n>
 
 <script setup lang="ts">
@@ -474,6 +553,7 @@ import { mdiSortDescending, mdiSortAscending, mdiMenuDown, mdiClose, mdiChevronL
 import useLines, { type ExtendedResultValue, type ExtendedResult } from '../../../composables/dataset/lines'
 import { dateTimeZoneLabel } from '../../../composables/dataset/format-date-logic'
 import useHeaders, { TableHeaderWithProperty, type TableHeader, type SyntheticColumn, type TableSort } from './use-headers'
+import { useTableAnnouncer } from './use-table-announcer'
 import { provideDatasetEdition } from './use-dataset-edition'
 import { useDisplay } from 'vuetify'
 import { DatasetLine, type SchemaProperty } from '#api/types'
@@ -538,6 +618,14 @@ const display = useDisplay()
 
 const { dataset, id: datasetId, imageField } = useDatasetStore()
 // const charsWidths = ref<Record<string, number> | null>(null)
+
+// Scope per-table DOM IDs so two coexisting tables (e.g. back-office + preview
+// drawer) don't collide on `#header-…` selectors used by the header v-menu.
+const instanceId = useId()
+
+const tableLabel = computed(() => dataset.value?.title
+  ? t('tableCaption', { title: dataset.value.title })
+  : t('tableCaptionFallback'))
 
 const allCols = computed(() => dataset.value?.schema?.filter(field => !field['x-calculated'] || field.key === '_updatedAt' || field.key === '_updatedByName').map(p => p.key) ?? [])
 const selectedCols = computed(() => cols.value.length ? cols.value : allCols.value)
@@ -621,6 +709,36 @@ const nextPage = async () => {
 const { headers, headersWithProperty } = useHeaders(selectedCols, noInteraction, edit, selectable, fixed, () => syntheticColumns, () => headerKeys)
 const { selectedResults, saveLine, removeLine, addLineTrigger } = provideDatasetEdition(baseFetchUrl, indexedAt)
 
+const { message: liveMessage } = useTableAnnouncer({
+  q,
+  total,
+  loading: fetchResults.loading,
+  sort,
+  displayMode,
+  cols,
+  allCols,
+  fixed,
+  filters,
+  headerTitleFor: (key) => {
+    // Visible headers carry the resolved title for the current display.
+    // Hidden columns (e.g. after a `hide` action) are no longer there, so
+    // fall back to the dataset schema so announcements still use a human-
+    // readable label instead of the raw key.
+    const fromHeaders = headers.value?.find(h => h.key === key)?.title
+    if (fromHeaders) return fromHeaders
+    const p = dataset.value?.schema?.find(p => p.key === key)
+    return p?.title || p?.['x-originalName'] || p?.key || key
+  },
+  displayModeLabelFor: (mode) => t(
+    mode === 'table-dense'
+      ? 'displayMode.tableDense'
+      : mode === 'list'
+        ? 'displayMode.list'
+        : 'displayMode.table'
+  ),
+  t
+})
+
 if (edit) {
   useAgentTool({
     name: 'open_add_line_dialog',
@@ -657,6 +775,18 @@ if (edit) {
 const virtualScroll = ref<VVirtualScroll>()
 const colsWidths = ref<number[]>([])
 const thead = ref<HTMLElement>()
+const tableRoot = ref<{ $el?: HTMLElement } | null>(null)
+
+// The scrollable wrapper is rendered by Vuetify inside v-table and doesn't expose a prop.
+// Make it focusable so keyboard users can reach the grid with Tab and scroll via arrow keys (RGAA 7.3).
+const applyWrapperA11y = () => {
+  const wrapper = tableRoot.value?.$el?.querySelector?.<HTMLElement>('.v-table__wrapper')
+  if (!wrapper) return
+  wrapper.setAttribute('tabindex', '0')
+  wrapper.setAttribute('role', 'region')
+  wrapper.setAttribute('aria-label', tableLabel.value)
+}
+watch([tableRoot, displayMode, tableLabel], () => nextTick(applyWrapperA11y))
 const minColWidth = computed(() => {
   return displayMode.value === 'table-dense' ? 80 : 120
 })
@@ -678,9 +808,10 @@ const onScrollItem = async (index: number) => {
   // ignore scroll on deprecated items that will soon be replaced
   if (fetchResults.loading.value) return
   incColsWidth()
-  if (index === results.value.length - 1) {
-    // scrolled until the current end of the table
-    if (!fetchResults.loading.value) fetchResults.execute()
+  if (index === results.value.length - 1 && next.value) {
+    // scrolled until the current end of the table; only re-fetch if there is a next page,
+    // otherwise execute() would flip loading true→false on every intersect re-bind for nothing
+    fetchResults.execute()
   }
 }
 
@@ -755,6 +886,28 @@ const deleteLine = useAsyncAction(async () => {
 <style>
 .dataset-table th {
   z-index: 2;
+}
+.dataset-table .dataset-table-th-button {
+  background: transparent;
+  border: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  padding-left: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  text-align: inherit;
+  cursor: pointer;
+  display: block;
+  width: 100%;
+}
+.dataset-table .dataset-table-th-button:focus-visible {
+  outline: 2px solid rgb(var(--v-theme-primary));
+  outline-offset: -2px;
+}
+.dataset-table .v-table__wrapper:focus-visible {
+  outline: 2px solid rgb(var(--v-theme-primary));
+  outline-offset: -2px;
 }
 .dataset-table .header-wrapper {
   position: relative;

--- a/ui/src/components/dataset/table/use-table-announcer.ts
+++ b/ui/src/components/dataset/table/use-table-announcer.ts
@@ -1,0 +1,154 @@
+import { ref, watch, type Ref } from 'vue'
+import { type DatasetFilter } from '~/composables/dataset/filters'
+
+type SortRef = Ref<{ key: string, direction: 1 | -1 } | undefined>
+
+export interface TableAnnouncerOptions {
+  q: Ref<string>
+  total: Ref<number | undefined>
+  loading: Ref<boolean>
+  sort: SortRef
+  displayMode: Ref<string | undefined>
+  cols: Ref<string[]>
+  allCols: Ref<string[]>
+  fixed: Ref<string | undefined>
+  filters: Ref<DatasetFilter[]>
+  headerTitleFor: (key: string) => string
+  displayModeLabelFor: (mode: string) => string
+  t: (key: string, values?: Record<string, unknown>, plural?: number) => string
+}
+
+/**
+ * Feed a single `aria-live` string from the table's reactive state so screen readers
+ * restitute result count, sort, display-mode, column visibility, column pinning
+ * and filter changes (RGAA 7.5 / 7.1). Debounced so quick consecutive updates
+ * collapse into the latest message.
+ *
+ * State-tracking watchers swallow the first emission (URL/preferences hydration
+ * during component setup) so screen-reader users aren't told they "just"
+ * applied filters or pinned columns that were already part of the deep link.
+ */
+export function useTableAnnouncer ({ q, total, loading, sort, displayMode, cols, allCols, fixed, filters, headerTitleFor, displayModeLabelFor, t }: TableAnnouncerOptions) {
+  const message = ref('')
+
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  const announce = (msg: string) => {
+    if (timeout) clearTimeout(timeout)
+    timeout = setTimeout(() => { message.value = msg }, 250)
+  }
+
+  // De-duplicate by the (total, q) settled state so spurious loading flips
+  // — e.g. v-intersect re-binding on every render calling fetchResults.execute()
+  // for an already-fully-loaded page — do not clobber the debounced announce.
+  let lastKey = ''
+  watch([total, q, loading], ([newTotal, newQ, isLoading]) => {
+    if (isLoading) return
+    if (newTotal === undefined) return
+    const key = `${newTotal}|${newQ}`
+    if (key === lastKey) return
+    lastKey = key
+    // vue-i18n pipe-pluralization requires the count as the 3rd positional arg.
+    if (newQ) {
+      announce(t('announce.searchResults', { count: newTotal, query: newQ }, newTotal))
+    } else {
+      announce(t('announce.results', { count: newTotal }, newTotal))
+    }
+  }, { immediate: true })
+
+  let sortInitialized = false
+  watch(sort, (newSort) => {
+    if (!sortInitialized) {
+      sortInitialized = true
+      return
+    }
+    if (!newSort) {
+      announce(t('announce.sortRemoved'))
+      return
+    }
+    const direction = newSort.direction === 1 ? t('sortDirection.ascending') : t('sortDirection.descending')
+    announce(t('announce.sort', { column: headerTitleFor(newSort.key), direction }))
+  }, { immediate: true })
+
+  watch(displayMode, (newMode, oldMode) => {
+    if (!newMode || !oldMode || newMode === oldMode) return
+    announce(t('announce.display', { mode: displayModeLabelFor(newMode) }))
+  })
+
+  // Track effective visible columns to announce hide/show. Seed `prevCols`
+  // from the steady state — wait for a non-empty set so the asynchronous
+  // schema hydration (`allCols` going from [] to [...kN]) isn't mistaken for
+  // a user-driven display change.
+  const effectiveCols = () => (cols.value.length ? cols.value : allCols.value)
+  let prevCols: string[] | undefined
+  watch([cols, allCols], () => {
+    const next = effectiveCols()
+    if (!prevCols) {
+      if (next.length) prevCols = next
+      return
+    }
+    if (!prevCols.length && next.length) {
+      // First population once the schema arrives — initial hydration, not a user action.
+      prevCols = next
+      return
+    }
+    const removed = prevCols.filter(c => !next.includes(c))
+    const added = next.filter(c => !prevCols!.includes(c))
+    prevCols = next
+    if (removed.length === 1 && !added.length) {
+      announce(t('announce.column.hidden', { column: headerTitleFor(removed[0]) }))
+    } else if (added.length === 1 && !removed.length) {
+      announce(t('announce.column.shown', { column: headerTitleFor(added[0]) }))
+    } else if (removed.length || added.length) {
+      announce(t('announce.column.changed', { count: next.length }, next.length))
+    }
+  }, { immediate: true })
+
+  let fixedInitialized = false
+  let prevFixed: string | undefined
+  watch(fixed, (newFixed) => {
+    if (!fixedInitialized) {
+      fixedInitialized = true
+      prevFixed = newFixed
+      return
+    }
+    if (newFixed && newFixed !== prevFixed) {
+      announce(t('announce.column.fixed', { column: headerTitleFor(newFixed) }))
+    } else if (!newFixed && prevFixed) {
+      announce(t('announce.column.unfixed', { column: headerTitleFor(prevFixed) }))
+    }
+    prevFixed = newFixed
+  }, { immediate: true })
+
+  // Track filter state. We compare on a serialized signature so identity-only
+  // changes (e.g. array reassignment by useFilters during hydration) do not
+  // trigger announcements. Skip the first emission to swallow the synchronous
+  // URL → filters hydration done by useFilters' `immediate: true` watcher.
+  const filterKey = (f: DatasetFilter) => `${f.property.key}|${f.operator}|${f.value}`
+  let prevFilters: DatasetFilter[] = []
+  let filtersInitialized = false
+  watch(filters, (newFilters) => {
+    if (!filtersInitialized) {
+      filtersInitialized = true
+      prevFilters = [...newFilters]
+      return
+    }
+    const prevKeys = prevFilters.map(filterKey)
+    const nextKeys = newFilters.map(filterKey)
+    if (prevKeys.join(',') === nextKeys.join(',')) return
+    const added = newFilters.find(f => !prevKeys.includes(filterKey(f)))
+    const removed = prevFilters.find(f => !nextKeys.includes(filterKey(f)))
+    prevFilters = [...newFilters]
+    if (added) {
+      announce(t('announce.filter.added', {
+        column: headerTitleFor(added.property.key),
+        value: added.formattedValue ?? added.value
+      }))
+    } else if (removed) {
+      announce(t('announce.filter.removed', {
+        column: headerTitleFor(removed.property.key)
+      }))
+    }
+  }, { deep: true, immediate: true })
+
+  return { message }
+}


### PR DESCRIPTION
Accessibility (RGAA) fixes for the **dataset table view**, with a new embed e2e suite. The non-table accessibility fixes (search-field, map, download menu) and the earlier table-button pass shipped separately in #470, now merged into `master` — this PR only touches the table markup itself.

The table view is a **hand-built `<table>`** (`<thead>/<th>/<tbody>` + `<v-virtual-scroll>`) inside Vuetify's `<v-table>` (a styled wrapper, not `<v-data-table>`). The caption, header `scope`, focusable header buttons and the live region are therefore app-level markup that Vuetify does not generate — a Vuetify upgrade would not make them redundant.

**What changed:**
- `<caption>`, `scope="col"` and `aria-sort` on column headers; sortable headers wrapped in real focusable `<button>`s; scrollable wrapper exposed as a labelled focusable region (RGAA 5.5 / 5.6 / 7.3).
- Single `aria-live="polite"` region announcing result count / sort / display-mode / column visibility / pinning / filter changes (RGAA 7.5), via the new `use-table-announcer` composable (debounced + de-duplicated, swallows hydration emissions).
- Focus restored to the column-header button when its menu closes, including when the column was just hidden (RGAA 7.3).
- Per-instance DOM ids (`useId()`) so two coexisting tables (back-office + preview drawer) don't collide on header selectors.
- New embed e2e suite covering the table-view a11y contract.
- Does not touch the table mechanics (virtual scroll, fetch, cell rendering, column widths).

**Known, out of scope** (deliberate — not regressions, for a follow-up):
- RGAA 7.1 — header menus (`v-menu`) reference an overlay mounted only on open, so `aria-controls` / `aria-owns` are orphaned while the menu is closed (same issue the portal fixed with `eager` defaults; a future Vuetify could also resolve it).
- RGAA 3.1 — column selection is signalled by the button colour only.

**Regression risks (priority for review):**
- Header DOM ids rescoped per-instance (`#header-${key}` → `#${instanceId}-header-${key}`); any out-of-tree consumer targeting the old id breaks.
- Interactive column-title wrapper is now a `<button aria-haspopup="true">` instead of a `<div>`; watch for nested-button warnings and focus-visible overrides on `.header-wrapper`.
- `onScrollItem` last-row fetch now gated by `&& next.value`; confirm long virtual-scroll lists keep paginating.
- `/embed/dataset/:id/table` is performance-critical: new per-table watchers, `useId()`, `<caption>` and `applyWrapperA11y` on `nextTick` — confirm no measurable regression on large datasets.
