### PR TITLE
fix(ui): include department portals in publication-sites facet labels

### DIFF
--- a/ui/src/components/application/application-facets.vue
+++ b/ui/src/components/application/application-facets.vue
@@ -163,7 +163,7 @@ const session = useSession()
 const publicationSitesById = ref<Record<string, any>>({})
 const pubSitesPath = computed(() => {
   const a = session.account.value
-  return a ? $apiPath + '/settings/' + a.type + '/' + a.id + '/publication-sites' : null
+  return a ? $apiPath + '/settings/' + a.type + '/' + a.id + ':*/publication-sites' : null
 })
 const pubSitesFetch = useFetch<any[]>(() => pubSitesPath.value)
 watch(() => pubSitesFetch.data.value, (sites) => {

--- a/ui/src/components/dataset/dataset-facets.vue
+++ b/ui/src/components/dataset/dataset-facets.vue
@@ -227,7 +227,7 @@ const session = useSession()
 const publicationSitesById = ref<Record<string, any>>({})
 const pubSitesPath = computed(() => {
   const a = session.account.value
-  return a ? $apiPath + '/settings/' + a.type + '/' + a.id + '/publication-sites' : null
+  return a ? $apiPath + '/settings/' + a.type + '/' + a.id + ':*/publication-sites' : null
 })
 const pubSitesFetch = useFetch<any[]>(() => pubSitesPath.value)
 watch(() => pubSitesFetch.data.value, (sites) => {


### PR DESCRIPTION
Append `:*` to the `publication-sites` settings URL in the dataset and application facet panels so titles of department-owned portals resolve. Without it, those portals fall back to displaying their raw id.

**Why:** restore the `ui-legacy` behavior on this endpoint — the new UI was hitting `/settings/{type}/{id}/publication-sites` without the department wildcard, while `ui-legacy` has always used `/settings/{type}/{id}:*/publication-sites`. Not a behavior change, just a missing piece of the legacy contract.

**Regression risks:** the response now includes department portals' sites — same payload shape as `ui-legacy`, no consumer here ever relied on the trimmed-down version.
