### PR TITLE
fix(ui): server-side search for org selector on superadmin agents page

### DIFF
--- a/ui/src/pages/admin/agents.vue
+++ b/ui/src/pages/admin/agents.vue
@@ -6,13 +6,18 @@
       </h2>
       <v-autocomplete
         v-model="selectedOwner"
+        v-model:search="search"
         :items="owners"
         item-title="name"
         :item-value="(o: any) => o"
         :label="t('org')"
         :loading="ownersFetch.loading.value"
+        :no-filter="true"
+        :return-object="true"
+        :placeholder="t('searchName')"
         density="compact"
         hide-details
+        hide-no-data
         max-width="300"
         variant="outlined"
       />
@@ -38,9 +43,11 @@
 fr:
   agents: Agents
   org: Organisation
+  searchName: Saisissez un nom d'organisation
 en:
   agents: Agents
   org: Organization
+  searchName: Search an organization name
 </i18n>
 
 <script setup lang="ts">
@@ -53,12 +60,15 @@ const { stateChangeAdapter, onMessage } = useDFramePage()
 
 const selectedOwner = ref<{ type: string, id: string, name: string } | null>(null)
 
-const ownersFetch = useFetch<{ results: { type: string, id: string, name: string }[] }>($sitePath + '/simple-directory/api/accounts', {
-  query: computed(() => ({ type: 'organization', size: 1000 })), watch: false
-})
-ownersFetch.refresh()
+const search = ref('')
+const query = () => ({ type: 'organization', q: search.value, size: 20 })
+const ownersFetch = useFetch<{ results: { type: string, id: string, name: string }[] }>($sitePath + '/simple-directory/api/accounts', { query })
 
 const owners = computed(() => {
-  return ownersFetch.data.value?.results ?? []
+  const results = ownersFetch.data.value?.results ?? []
+  if (selectedOwner.value && !results.find(o => o.id === selectedOwner.value!.id && o.type === selectedOwner.value!.type)) {
+    return [selectedOwner.value, ...results]
+  }
+  return results
 })
 </script>


### PR DESCRIPTION
On the superadmin `/admin/agents` page, the organization selector was preloading a fixed `size=1000` list from `/simple-directory/api/accounts` and filtering client-side, so any org beyond the first 1000 was unreachable.

Switch it to server-side search: bind `v-model:search` to a reactive `q` query parameter, set `:no-filter="true"`, and drop the page size to 20. The currently selected owner is re-injected in front of the results when missing, so its label stays visible after the user keeps typing.

**Why:** make every organization reachable from the selector, regardless of total count.

**Regression risks:**
- No debounce — each keystroke triggers a request. Acceptable on this superadmin-only page; flag if the same pattern gets copied to a higher-traffic surface.
- Initial focus (empty `q`) now shows 20 orgs instead of 1000; intentional, but a visual change for superadmins used to scrolling the full list.
