### PR TITLE
feat(agent): page_guidance tool + _c_ prefix for filter URLs

### DIFF
--- a/agent-tools/_utils.ts
+++ b/agent-tools/_utils.ts
@@ -43,12 +43,17 @@ export { datasetIdProperty }
 
 /**
  * Build the filter-relevant query params from common tool input params.
- * Returns a URL query string (e.g. "nom_search=Jean&geo_distance=2.35,48.85,10km").
+ * Returns a URL query string (e.g. "nom_search=Jean&_c_geo_distance=2.35,48.85,10km").
  * Excludes pagination (size, page) and tool-specific params (metric, field, etc.).
+ *
+ * `q`, `bbox`, `geo_distance` and `date_match` are emitted with the `_c_` prefix
+ * (concept filters) so they survive the table/map URL sync, which only forwards
+ * `_c_`-prefixed params through `useConceptFilters`. The API accepts both forms
+ * interchangeably.
  */
 export function buildFilterQueryString (params: { q?: string, filters?: Record<string, any>, sort?: string, select?: string, bbox?: string, geoDistance?: string, dateMatch?: string }): string | undefined {
   const searchParams = new URLSearchParams()
-  if (params.q) searchParams.set('q', params.q)
+  if (params.q) searchParams.set('_c_q', params.q)
   if (params.filters) {
     for (const [key, value] of Object.entries(params.filters)) searchParams.set(key, String(value))
   }
@@ -57,9 +62,9 @@ export function buildFilterQueryString (params: { q?: string, filters?: Record<s
     if (normalized) searchParams.set('sort', normalized)
   }
   if (params.select) searchParams.set('select', params.select)
-  if (params.bbox) searchParams.set('bbox', params.bbox)
-  if (params.geoDistance) searchParams.set('geo_distance', params.geoDistance)
-  if (params.dateMatch) searchParams.set('date_match', params.dateMatch)
+  if (params.bbox) searchParams.set('_c_bbox', params.bbox)
+  if (params.geoDistance) searchParams.set('_c_geo_distance', params.geoDistance)
+  if (params.dateMatch) searchParams.set('_c_date_match', params.dateMatch)
   const qs = searchParams.toString()
   return qs || undefined
 }

--- a/docs/architecture/agent-integration.md
+++ b/docs/architecture/agent-integration.md
@@ -304,8 +304,9 @@ The user types directly in the chat drawer. The agent has access to all globally
 | `describe_processing` | Connectors | R | `agent/connector-tools.ts` |
 | `list_catalogs` | Connectors | R | `agent/connector-tools.ts` |
 | `describe_catalog` | Connectors | R | `agent/connector-tools.ts` |
+| `page_guidance` | Page guidance | R | `dataset/agent-page-guidance-tools.ts` (dataset detail page) |
 
-All source paths are relative to `ui/src/composables/` unless otherwise noted. **W*** = client-side state only (no server write). Connector tools are conditional on integration flags.
+All source paths are relative to `ui/src/composables/` unless otherwise noted. **W*** = client-side state only (no server write). Connector tools are conditional on integration flags. **`page_guidance`** is a page-scoped fallback tool: each page that registers it (currently only the dataset detail page) carries its own essential anti-misroute facts in the tool description and a full page structure / interaction guide in the returned content. The agent is instructed to call it only when unsure how to help the user on the current page.
 
 ## 6. Subagent Reference
 

--- a/tests/features/agent-tools/filter-query-string.unit.spec.ts
+++ b/tests/features/agent-tools/filter-query-string.unit.spec.ts
@@ -1,0 +1,60 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { buildFilterQueryString } from '../../../agent-tools/_utils.ts'
+
+test.describe('buildFilterQueryString', () => {
+  test('returns undefined when no params', () => {
+    assert.equal(buildFilterQueryString({}), undefined)
+  })
+
+  test('emits _c_q for full-text search (so URL sync to table/map works)', () => {
+    const qs = buildFilterQueryString({ q: 'Paris' })
+    assert.equal(qs, '_c_q=Paris')
+  })
+
+  test('emits _c_bbox / _c_geo_distance / _c_date_match', () => {
+    const qs = buildFilterQueryString({
+      bbox: '-2.5,43,3,47',
+      geoDistance: '2.35,48.85,10km',
+      dateMatch: '2024-01-01'
+    })
+    const params = new URLSearchParams(qs)
+    assert.equal(params.get('_c_bbox'), '-2.5,43,3,47')
+    assert.equal(params.get('_c_geo_distance'), '2.35,48.85,10km')
+    assert.equal(params.get('_c_date_match'), '2024-01-01')
+    assert.equal(params.get('bbox'), null)
+    assert.equal(params.get('geo_distance'), null)
+    assert.equal(params.get('date_match'), null)
+  })
+
+  test('column filters keep their suffix form (no _c_ prefix)', () => {
+    const qs = buildFilterQueryString({ filters: { nom_search: 'Jean', age_lte: '30' } })
+    const params = new URLSearchParams(qs)
+    assert.equal(params.get('nom_search'), 'Jean')
+    assert.equal(params.get('age_lte'), '30')
+  })
+
+  test('strips bare _geo_distance from sort and omits the param when empty', () => {
+    const qs = buildFilterQueryString({ sort: '_geo_distance' })
+    assert.equal(qs, undefined)
+  })
+
+  test('keeps sort/select unchanged', () => {
+    const qs = buildFilterQueryString({ sort: 'name,-age', select: 'a,b' })
+    const params = new URLSearchParams(qs)
+    assert.equal(params.get('sort'), 'name,-age')
+    assert.equal(params.get('select'), 'a,b')
+  })
+
+  test('combines everything into a URL-safe string', () => {
+    const qs = buildFilterQueryString({
+      q: 'hello',
+      filters: { status_eq: 'active' },
+      geoDistance: '2.35,48.85,10km'
+    })
+    const params = new URLSearchParams(qs)
+    assert.equal(params.get('_c_q'), 'hello')
+    assert.equal(params.get('status_eq'), 'active')
+    assert.equal(params.get('_c_geo_distance'), '2.35,48.85,10km')
+  })
+})

--- a/ui/src/composables/agent/navigation-tools.ts
+++ b/ui/src/composables/agent/navigation-tools.ts
@@ -77,7 +77,7 @@ export function useAgentNavigationTools ({ route, router, navigationGroups, brea
         '**Detail pages** (require an ID, use list_datasets or list_applications to find IDs):\n' +
         '- Dataset overview: /dataset/{id}\n' +
         '- Dataset data: /dataset/{id}/data\n' +
-        '- Dataset table: /dataset/{id}/table — accepts filter query params (same format as search_data filters: column_key + suffix like nom_search, age_lte, ville_eq). Also accepts q (full-text search), sort, select, bbox, geo_distance, date_match. Use the filterQuery from dataset_data subagent Context directly as the query parameter.\n' +
+        '- Dataset table: /dataset/{id}/table — accepts filter query params (same format as search_data filters: column_key + suffix like nom_search, age_lte, ville_eq). Also accepts _c_q (full-text search), sort, select, _c_bbox, _c_geo_distance, _c_date_match. The `_c_` prefix on q/bbox/geo_distance/date_match is required for URL sync. Use the filterQuery from dataset_data subagent Context directly as the query parameter.\n' +
         '- Dataset map: /dataset/{id}/map — for geolocalized datasets, accepts the same filter query params as the table page\n' +
         '- Dataset files: /dataset/{id}/files\n' +
         '- Edit dataset data: /dataset/{id}/edit-data\n' +
@@ -123,7 +123,7 @@ export function useAgentNavigationTools ({ route, router, navigationGroups, brea
         },
         query: {
           type: 'string' as const,
-          description: 'Optional query string to append to the URL (without leading "?"). For dataset table pages, use the filterQuery from the dataset_data subagent Context. Example: "nom_search=Jean&age_lte=30&q=Paris"'
+          description: 'Optional query string to append to the URL (without leading "?"). For dataset table pages, use the filterQuery from the dataset_data subagent Context. Example: "nom_search=Jean&age_lte=30&_c_q=Paris"'
         }
       },
       required: ['path'] as const

--- a/ui/src/composables/dataset/agent-page-guidance-tools.ts
+++ b/ui/src/composables/dataset/agent-page-guidance-tools.ts
@@ -1,0 +1,63 @@
+import type { Ref } from 'vue'
+import { useAgentTool } from '@data-fair/lib-vue-agents'
+import { createAgentTranslator } from '~/composables/agent/utils'
+
+const messages: Record<string, Record<string, string>> = {
+  fr: { pageGuidance: 'Guide de la page' },
+  en: { pageGuidance: 'Page guide' }
+}
+
+// Always-on description, read on every turn. Keep concise; the rich content
+// is in the returned guide, called on demand when the agent is unsure.
+const description =
+  'Page guide for the dataset detail page — registered only while the user ' +
+  'is viewing that page, so its presence in your tool list signals the ' +
+  'current location. Returns the page structure (sections, tabs, and agent ' +
+  'help buttons not in the global tool list). Call only when unsure how to ' +
+  'help the user here; if another tool obviously fits the need, use it.'
+
+// Section/tab descriptions are co-located with the page's `sections` computed
+// so they evolve together with structural and permission-conditional logic.
+// This composable is a thin renderer.
+export type GuidedTab = { key: string, title: string, agentDesc?: string }
+export type GuidedSection = { title: string, agentDesc?: string, tabs?: GuidedTab[] }
+export type GuidedSections = Record<string, GuidedSection>
+
+function buildGuidance (sections: GuidedSections): string {
+  const lines: string[] = [
+    '# Dataset detail page',
+    '',
+    'Collapsible sections; some have tabs. Only sections and tabs currently visible to this user are listed.',
+    ''
+  ]
+
+  for (const section of Object.values(sections)) {
+    const tabsWithDesc = section.tabs?.filter(t => t.agentDesc) ?? []
+    if (!section.agentDesc && !tabsWithDesc.length) continue
+    lines.push(`## ${section.title}`)
+    if (section.agentDesc) lines.push(section.agentDesc)
+    for (const tab of tabsWithDesc) {
+      lines.push(`- **${tab.title}** — ${tab.agentDesc}`)
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n').trimEnd()
+}
+
+export function useAgentDatasetPageGuidance (locale: Ref<string>, sections: Ref<GuidedSections>) {
+  const t = createAgentTranslator(messages, locale)
+
+  useAgentTool({
+    name: 'page_guidance',
+    description,
+    annotations: { title: t('pageGuidance'), readOnlyHint: true },
+    inputSchema: { type: 'object' as const, properties: {} },
+    execute: async () => ({
+      content: [{
+        type: 'text' as const,
+        text: buildGuidance(sections.value)
+      }]
+    })
+  })
+}

--- a/ui/src/layouts/default.vue
+++ b/ui/src/layouts/default.vue
@@ -87,14 +87,14 @@ Consignes :
 - Réponds dans la langue de l'utilisateur
 - Sois concis et précis
 - Utilise fréquemment l'outil getCurrentLocation pour comprendre le positionnement de l'utilisateur dans l'interface
-- Quand tu effectues une recherche ou un filtrage de données dans un jeu de données, propose systématiquement à l'utilisateur de naviguer vers une vue filtrée. Le sous-agent dataset_data inclut dans sa section Context un champ filterQuery (query string URL) et un champ columns (colonnes pertinentes). Utilise l'outil navigate avec la filterQuery comme paramètre query en y ajoutant select=col1,col2,col3 à partir des clés de columns. Propose la vue tableau /dataset/{id}/table, et si les données sont géolocalisées (présence de bbox, geo_distance dans la filterQuery, ou colonnes géographiques dans columns) propose également la vue carte /dataset/{id}/map.`,
+- Quand tu effectues une recherche ou un filtrage de données dans un jeu de données, propose systématiquement à l'utilisateur de naviguer vers une vue filtrée. Le sous-agent dataset_data inclut dans sa section Context un champ filterQuery (query string URL) et un champ columns (colonnes pertinentes). Utilise l'outil navigate avec la filterQuery comme paramètre query en y ajoutant select=col1,col2,col3 à partir des clés de columns. Propose la vue tableau /dataset/{id}/table, et si les données sont géolocalisées (présence de _c_bbox, _c_geo_distance dans la filterQuery, ou colonnes géographiques dans columns) propose également la vue carte /dataset/{id}/map.`,
   en: `You are the AI assistant for Data Fair, a platform for managing and publishing private or open data. You help users navigate the interface, explore datasets, query data, configure visualization applications, and manage metadata.
 
 Guidelines:
 - Respond in the user's language
 - Be concise and precise
 - Frequently use the tool getCurrentLocation to understand the positioning of the user in the UI.
-- When you search or filter data from a dataset, always offer to navigate the user to a filtered view. The dataset_data subagent includes in its Context section a filterQuery field (URL query string) and a columns field (relevant columns). Use the navigate tool with the filterQuery as the query parameter, adding select=col1,col2,col3 from the columns keys. Offer the table view /dataset/{id}/table, and if the data is geolocalized (presence of bbox, geo_distance in the filterQuery, or geographic columns in columns) also offer the map view /dataset/{id}/map.`
+- When you search or filter data from a dataset, always offer to navigate the user to a filtered view. The dataset_data subagent includes in its Context section a filterQuery field (URL query string) and a columns field (relevant columns). Use the navigate tool with the filterQuery as the query parameter, adding select=col1,col2,col3 from the columns keys. Offer the table view /dataset/{id}/table, and if the data is geolocalized (presence of _c_bbox, _c_geo_distance in the filterQuery, or geographic columns in columns) also offer the map view /dataset/{id}/map.`
 }
 
 const agentSystemPrompt = computed(() => agentSystemPrompts[locale.value] ?? agentSystemPrompts.en)

--- a/ui/src/pages/dataset/[id]/index.vue
+++ b/ui/src/pages/dataset/[id]/index.vue
@@ -1038,7 +1038,7 @@ const sections = computedDeepDiff(() => {
       { key: 'table', title: t('table'), icon: mdiTable, agentDesc: 'Paginated table of the rows with toolbar: free-text search (`q`), faceted filters, column selector, download menu (CSV/XLSX/Parquet/…), display-mode switch. Two help buttons: **Filter help** → `dataset_data` subagent (then `navigate` applies the filterQuery as URL query params); **Check quality** → `data_quality_checker` subagent (6-step audit: completeness, uniqueness, outliers, format consistency, distribution anomalies).' }
     ]
     if (d.bbox) {
-      explorationTabs.push({ key: 'map', title: t('map'), icon: mdiMap, agentDesc: 'Interactive map of geolocalized rows. Accepts the same filter query params as the table tab (including `bbox` and `geo_distance`).' })
+      explorationTabs.push({ key: 'map', title: t('map'), icon: mdiMap, agentDesc: 'Interactive map of geolocalized rows. Accepts the same filter query params as the table tab (including `_c_bbox` and `_c_geo_distance`).' })
     }
     if (digitalDocumentField.value) {
       explorationTabs.push({ key: 'files', title: t('files'), icon: mdiContentCopy, agentDesc: 'Browse the digital-document files attached to rows (when the schema has a documentURI / file field).' })

--- a/ui/src/pages/dataset/[id]/index.vue
+++ b/ui/src/pages/dataset/[id]/index.vue
@@ -686,6 +686,7 @@ import { useAgentDatasetChangesSummaryTools } from '~/composables/dataset/agent-
 import { useAgentExpressionTools } from '~/composables/dataset/agent-expression-tools'
 import { useAgentSchemaAnnotationTools } from '~/composables/dataset/agent-schema-annotation-tools'
 import { useAgentPropertyConfigTools } from '~/composables/dataset/agent-property-config-tools'
+import { useAgentDatasetPageGuidance } from '~/composables/dataset/agent-page-guidance-tools'
 import { hasInvalidExprEvalExtension } from '~/composables/dataset/expr-eval-validation'
 import { useDatasetsMetadata } from '~/composables/dataset/use-metadata'
 
@@ -959,12 +960,13 @@ useLeaveGuard(metadataEditFetch.hasDiff, { locale })
 const sections = computedDeepDiff(() => {
   if (!dataset.value) return {}
   const d = dataset.value
-  const result: Record<string, { title: string, tabs?: any[], subtitle?: string }> = {}
+  const result: Record<string, { title: string, tabs?: any[], subtitle?: string, agentDesc?: string }> = {}
 
   // Informations section
   result.informations = {
     title: t('informations'),
-    subtitle: t('informationsSubtitle')
+    subtitle: t('informationsSubtitle'),
+    agentDesc: 'Read-only summary of the dataset: owner, record count, source file (for file datasets), key dates (creation, last data update, last metadata update), processing status. No edit controls here — descriptive metadata is edited in the Metadata section below.'
   }
 
   // Structure section (new)
@@ -973,7 +975,8 @@ const sections = computedDeepDiff(() => {
       key: 'schema',
       title: t('schema'),
       icon: mdiTableCog,
-      color: schemaHasDiff.value ? 'accent' : undefined
+      color: schemaHasDiff.value ? 'accent' : undefined,
+      agentDesc: 'Columns list with their types, formats and indexing capabilities. For REST datasets: add/remove columns and set the primary key. Optional geo projection selector. Optionally a "conformsTo" editor at the top to declare schemas the dataset conforms to. Toolbar help buttons: **Annotate schema** (suggest titles/descriptions) → `schema_annotator`; **Configure properties** (type overrides, indexing capabilities) → `property_config_advisor`.'
     }]
 
     if (!d.isVirtual && !d.isMetaOnly) {
@@ -981,7 +984,8 @@ const sections = computedDeepDiff(() => {
         key: 'extensions',
         title: t('extensions'),
         icon: mdiPuzzle,
-        color: extensionsHasDiff.value ? 'accent' : undefined
+        color: extensionsHasDiff.value ? 'accent' : undefined,
+        agentDesc: '**Column-value transformations and row enrichments live here.** Two extension types: (a) remote-service extensions calling external REST APIs (geocoding, SIRENE lookup, geo enrichment, etc.); (b) expr-eval calculated columns (PAD_LEFT, CONCAT, SUBSTRING, REPLACE, TRANSFORM_DATE, MD5, JSON_PARSE, …). Add via the "Add extension" menu. For expr-eval, opening an extension card\'s edit dialog reveals the expression input with a help button next to it → `expression_helper` subagent (writes and tests the expression against sample data).'
       })
     }
 
@@ -990,7 +994,8 @@ const sections = computedDeepDiff(() => {
         key: 'rest-config',
         title: t('restConfig'),
         icon: mdiAllInclusive,
-        color: restHasDiff.value ? 'accent' : undefined
+        color: restHasDiff.value ? 'accent' : undefined,
+        agentDesc: 'Settings specific to REST datasets: row history (revisions), per-row TTL (auto-deletion after N days), history TTL, and whether to track the user who last updated each row.'
       })
     }
 
@@ -999,7 +1004,8 @@ const sections = computedDeepDiff(() => {
         key: 'virtual',
         title: t('virtual'),
         icon: mdiPictureInPictureBottomRightOutline,
-        color: virtualHasDiff.value ? 'accent' : undefined
+        color: virtualHasDiff.value ? 'accent' : undefined,
+        agentDesc: 'Configuration of a virtual dataset: pick child datasets, choose which of their columns to expose, and define row-level filters (in/nin) that restrict the visible rows.'
       })
     }
 
@@ -1009,82 +1015,83 @@ const sections = computedDeepDiff(() => {
         title: t('masterData'),
         icon: mdiStarFourPoints,
         color: !masterDataFormValid.value ? 'error' : (masterDataHasDiff.value ? 'accent' : undefined),
-        appendIcon: !masterDataFormValid.value ? mdiAlertCircle : undefined
+        appendIcon: !masterDataFormValid.value ? mdiAlertCircle : undefined,
+        agentDesc: 'Expose this dataset as a master-data source (reusable as reference data via remote-service extensions on other datasets). Help button "Configure master data" → opens an agent that delegates the form filling to a VJSF subagent.'
       })
     }
 
-    result.structure = { title: t('structure'), tabs: structureTabs }
+    result.structure = { title: t('structure'), tabs: structureTabs, agentDesc: 'Structural definition of the dataset: column schema, calculated-column / remote-service extensions, and storage-mode configuration. Saving structural changes may trigger a reindex.' }
   }
 
   // Metadata section
-  const metadataTabs = [
-    { key: 'informations', title: t('informations'), icon: mdiInformation, color: metadataEditFetch.hasDiff.value ? 'accent' : undefined }
+  const metadataTabs: any[] = [
+    { key: 'informations', title: t('informations'), icon: mdiInformation, color: metadataEditFetch.hasDiff.value ? 'accent' : undefined, agentDesc: 'Edit form for descriptive metadata: title, summary, description (markdown), license, origin, image, topics, keywords, creator, frequency, spatial/temporal coverage, modification date, related datasets, conformsTo schemas. Two in-form help buttons: next to the summary → `dataset_summarizer` subagent (generates a ≤300 char summary from sample data); next to the description → `dataset_description_writer` subagent (generates 500-2000 char markdown).' }
   ]
   if (!d.draftReason) {
-    metadataTabs.push({ key: 'attachments', title: t('attachments'), icon: mdiAttachment, color: undefined })
+    metadataTabs.push({ key: 'attachments', title: t('attachments'), icon: mdiAttachment, color: undefined, agentDesc: 'Upload/edit/delete file attachments for the dataset (PDF references, supporting docs, etc.). An attachment can optionally be set as the dataset thumbnail.' })
   }
-  result.metadata = { title: t('metadata'), tabs: metadataTabs }
+  result.metadata = { title: t('metadata'), tabs: metadataTabs, agentDesc: 'Descriptive metadata edition. Save / cancel buttons in the section header. When there are unsaved changes a **Summarize changes** button also appears in the header → `dataset_changes_summarizer` subagent (produces a <500 char plain-text summary of the diff).' }
 
   // Exploration section (direct component tabs)
   if (d.finalizedAt && !d.isMetaOnly) {
-    const explorationTabs = [
-      { key: 'table', title: t('table'), icon: mdiTable }
+    const explorationTabs: any[] = [
+      { key: 'table', title: t('table'), icon: mdiTable, agentDesc: 'Paginated table of the rows with toolbar: free-text search (`q`), faceted filters, column selector, download menu (CSV/XLSX/Parquet/…), display-mode switch. Two help buttons: **Filter help** → `dataset_data` subagent (then `navigate` applies the filterQuery as URL query params); **Check quality** → `data_quality_checker` subagent (6-step audit: completeness, uniqueness, outliers, format consistency, distribution anomalies).' }
     ]
     if (d.bbox) {
-      explorationTabs.push({ key: 'map', title: t('map'), icon: mdiMap })
+      explorationTabs.push({ key: 'map', title: t('map'), icon: mdiMap, agentDesc: 'Interactive map of geolocalized rows. Accepts the same filter query params as the table tab (including `bbox` and `geo_distance`).' })
     }
     if (digitalDocumentField.value) {
-      explorationTabs.push({ key: 'files', title: t('files'), icon: mdiContentCopy })
+      explorationTabs.push({ key: 'files', title: t('files'), icon: mdiContentCopy, agentDesc: 'Browse the digital-document files attached to rows (when the schema has a documentURI / file field).' })
     }
     if (imageField.value) {
-      explorationTabs.push({ key: 'thumbnails', title: t('thumbnails'), icon: mdiImage })
+      explorationTabs.push({ key: 'thumbnails', title: t('thumbnails'), icon: mdiImage, agentDesc: 'Thumbnail grid of the row images (when the schema has an image field).' })
     }
     if (d.rest?.history) {
-      explorationTabs.push({ key: 'revisions', title: t('revisions'), icon: mdiHistory })
+      explorationTabs.push({ key: 'revisions', title: t('revisions'), icon: mdiHistory, agentDesc: 'Per-row revision history. Visible only for REST datasets that have history enabled in the Structure → REST config tab.' })
     }
     if (!d.draftReason || d.draftReason.key === 'file-updated') {
-      explorationTabs.push({ key: 'applications', title: t('applications'), icon: mdiImageMultiple })
+      explorationTabs.push({ key: 'applications', title: t('applications'), icon: mdiImageMultiple, agentDesc: 'Visualization applications already configured on top of this dataset, with a "+" button to create a new one.' })
     }
     if (explorationTabs.length) {
-      result.exploration = { title: t('exploration'), tabs: explorationTabs }
+      result.exploration = { title: t('exploration'), tabs: explorationTabs, agentDesc: 'Browse and explore the dataset content.' }
     }
   }
 
   // Share section
   if (!d.draftReason || d.draftReason.key === 'file-updated') {
-    const shareTabs = []
+    const shareTabs: any[] = []
     if (can('getPermissions').value) {
-      shareTabs.push({ key: 'permissions', title: t('permissions'), icon: mdiSecurity })
+      shareTabs.push({ key: 'permissions', title: t('permissions'), icon: mdiSecurity, agentDesc: 'Grant read / write / admin permissions to specific users, organisations, departments or partners, or open access to "anyone".' })
     }
     if (can('setReadApiKey').value) {
-      shareTabs.push({ key: 'readApiKey', title: t('readApiKey'), icon: mdiKey })
+      shareTabs.push({ key: 'readApiKey', title: t('readApiKey'), icon: mdiKey, agentDesc: 'Generate and manage a read-only API key — for embedding or programmatic access without a user session.' })
     }
-    shareTabs.push({ key: 'publication-sites', title: t('publicationSites'), icon: mdiPresentation })
+    shareTabs.push({ key: 'publication-sites', title: t('publicationSites'), icon: mdiPresentation, agentDesc: 'Publish or unpublish this dataset on the organisation\'s data portals (open or limited audience).' })
     if ($uiConfig.catalogsIntegration && accountRole.value === 'admin') {
-      shareTabs.push({ key: 'catalog-publications', title: t('catalogPublications'), icon: mdiTransitConnection })
+      shareTabs.push({ key: 'catalog-publications', title: t('catalogPublications'), icon: mdiTransitConnection, agentDesc: 'Publish this dataset to external catalogs (data.gouv.fr, CKAN, etc.). Rendered as a d-frame from the catalogs service — admin-only.' })
     }
     if (d.finalizedAt) {
-      shareTabs.push({ key: 'integration', title: t('integration'), icon: mdiCodeTags })
+      shareTabs.push({ key: 'integration', title: t('integration'), icon: mdiCodeTags, agentDesc: 'Ready-to-copy iframe snippets and JS embed code to integrate this dataset\'s table / map into external pages.' })
     }
     if (shareTabs.length) {
-      result.share = { title: t('share'), tabs: shareTabs }
+      result.share = { title: t('share'), tabs: shareTabs, agentDesc: 'Access control and publication settings for this dataset.' }
     }
   }
 
   // Activity section
-  const activityTabs = []
+  const activityTabs: any[] = []
   if (can('readJournal').value && !d.isMetaOnly) {
-    activityTabs.push({ key: 'journal', title: t('journal'), icon: mdiCalendarText })
+    activityTabs.push({ key: 'journal', title: t('journal'), icon: mdiCalendarText, agentDesc: 'Chronological processing journal: ingestion, indexing, extension execution, errors. The natural first place to look when investigating why a dataset is stuck or in error state.' })
   }
   if ($uiConfig.eventsIntegration) {
     if (can('readJournal').value) {
-      activityTabs.push({ key: 'traceability', title: t('traceability'), icon: mdiClipboardTextClock })
+      activityTabs.push({ key: 'traceability', title: t('traceability'), icon: mdiClipboardTextClock, agentDesc: 'Audit trail of user actions on this dataset (who did what, when).' })
     }
-    activityTabs.push({ key: 'notifications', title: t('notifications'), icon: mdiBell })
+    activityTabs.push({ key: 'notifications', title: t('notifications'), icon: mdiBell, agentDesc: 'Subscribe the current user to in-app / email notifications for events on this dataset (errors, publication, etc.).' })
     if (can('setPermissions').value) {
-      activityTabs.push({ key: 'webhooks', title: t('webhooks'), icon: mdiWebhook })
+      activityTabs.push({ key: 'webhooks', title: t('webhooks'), icon: mdiWebhook, agentDesc: 'Configure outbound HTTP webhooks fired on dataset events.' })
     }
-    result.activity = { title: t('tracking'), tabs: activityTabs }
+    result.activity = { title: t('tracking'), tabs: activityTabs, agentDesc: 'Logs, audit trail, notifications and webhooks for this dataset.' }
   }
 
   // Diagnose section (superadmin only)
@@ -1096,13 +1103,14 @@ const sections = computedDeepDiff(() => {
         { key: 'elasticsearch', title: t('diagnoseTabEs'), icon: mdiDatabaseSearch },
         { key: 'locks', title: t('diagnoseTabLocks'), icon: mdiLock },
         { key: 'rawJson', title: t('diagnoseTabRaw'), icon: mdiCodeJson }
-      ]
+      ],
+      agentDesc: 'Superadmin-only diagnostics: Elasticsearch index state, internal locks held on the dataset, and the raw JSON document as stored in MongoDB. Use to investigate stuck or corrupt datasets.'
     }
   }
 
   // Danger zone section
   if (can('changeOwner').value || canDeleteAllLines.value || can('delete').value) {
-    result.dangerZone = { title: t('dangerZone'), tabs: [] }
+    result.dangerZone = { title: t('dangerZone'), tabs: [], agentDesc: 'Irreversible operations: change owner, delete all lines (REST), delete the entire dataset. Always let the user perform these themselves — never trigger them programmatically.' }
   }
 
   return result
@@ -1114,4 +1122,6 @@ const tocSections = computed(() => {
     title: s.title
   }))
 })
+
+useAgentDatasetPageGuidance(locale, sections)
 </script>


### PR DESCRIPTION
Two agent-integration improvements bundled because they share the same surface area.

**1. `page_guidance` tool on the dataset detail page** — Registers a per-page agent tool that returns a structured description of the page's currently-visible sections and tabs (including the agent help buttons that are not in the global tool list). Tool presence itself signals the agent that the user is on this page; the rich body is fetched on demand when the agent is unsure how to help. Each `sections` entry now carries an `agentDesc` string, co-located with the page's permission-conditional `computed` so structural changes stay in sync with the description the agent reads.

**2. Fix: `_c_` prefix for `q` / `bbox` / `geo_distance` / `date_match` in `buildFilterQueryString`** — The agent's `filterQuery` is passed verbatim to the `navigate` tool to filter `/dataset/{id}/table` and `/map`. Those views forward only `_c_`-prefixed params through `useConceptFilters`, so a generated `?geo_distance=...` URL was silently dropped (the bare forms only worked as API params). The API accepts both forms, so the change is URL-only. Reported by a user who got a non-filtering map link from the agent.

**Regression risks:**
- `buildFilterQueryString` wire format changed; any fixture, snapshot, or chat log that pattern-matches on the old bare names will miss the `_c_`-prefixed output. No in-repo consumers besides the agent.
- `sections` shape on the dataset detail page gained an optional `agentDesc` field, and several tab arrays are now typed `any[]` (was inferred). No consumer behavior changes, but type safety on tab shape inside `[id]/index.vue` is looser.
- `page_guidance` is registered on every visit to the dataset detail page — small but constant addition to the agent's tool list there.
- The FR/EN system prompts in `layouts/default.vue` were updated to advertise the `_c_` form; verify there's no cached/server-side variant of the system prompt still recommending the bare form.
