### PR TITLE
feat(api-keys): email owners and admins before API key expiration

### DIFF
--- a/api/config/custom-environment-variables.cjs
+++ b/api/config/custom-environment-variables.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   port: 'PORT',
   mode: 'MODE',
+  apiKeysExpirationCron: 'API_KEYS_EXPIRATION_CRON',
   publicUrl: 'PUBLIC_URL',
   oldPublicUrl: 'OLD_PUBLIC_URL',
   wsPublicUrl: 'WS_PUBLIC_URL',
@@ -109,6 +110,7 @@ module.exports = {
     limits: 'SECRET_LIMITS',
     catalogs: 'SECRET_CATALOGS',
     events: 'SECRET_EVENTS',
+    sendMails: 'SECRET_SENDMAILS',
     ignoreRateLimiting: 'SECRET_IGNORE_RATE_LIMITING'
   },
   brand: {

--- a/api/config/default.cjs
+++ b/api/config/default.cjs
@@ -185,6 +185,7 @@ module.exports = {
     catalogs: null,
     notifications: null, // DEPRECATED
     events: null,
+    sendMails: null,
     ignoreRateLimiting: null
   },
   locks: {
@@ -308,5 +309,6 @@ module.exports = {
   remoteAttachmentCacheDuration: 1000 * 5,
   extensionUpdateDelay: 600,
   compatODS: false,
-  apiKeysMaxDuration: 2 * 365 // in days
+  apiKeysMaxDuration: 2 * 365, // in days
+  apiKeysExpirationCron: '0 3 * * *', // daily at 3 AM, scan apiKeys expireAt and notify J-3 / J
 }

--- a/api/config/development.cjs
+++ b/api/config/development.cjs
@@ -100,7 +100,8 @@ module.exports = {
     identities: 'identities-test-key',
     limits: 'limits-test-key',
     events: 'secret-notifications',
-    catalogs: 'secret-catalogs'
+    catalogs: 'secret-catalogs',
+    sendMails: 'testkey'
   },
   nuxtBuild: {
     active: false

--- a/api/config/type/schema.json
+++ b/api/config/type/schema.json
@@ -52,7 +52,8 @@
     "assertImmutable",
     "remoteAttachmentCacheDuration",
     "extensionUpdateDelay",
-    "apiKeysMaxDuration"
+    "apiKeysMaxDuration",
+    "apiKeysExpirationCron"
   ],
   "properties": {
     "mode": {
@@ -274,6 +275,7 @@
         "catalogs": { "type": ["string", "null"] },
         "notifications": { "type": ["string", "null"] },
         "events": { "type": ["string", "null"] },
+        "sendMails": { "type": ["string", "null"] },
         "ignoreRateLimiting": { "type": ["string", "null"] }
       }
     },
@@ -460,6 +462,9 @@
     },
     "apiKeysMaxDuration": {
       "type": "number"
+    },
+    "apiKeysExpirationCron": {
+      "type": "string"
     }
   },
   "$defs": {

--- a/api/i18n/messages/en.json
+++ b/api/i18n/messages/en.json
@@ -180,5 +180,17 @@
 				"body": "The application {{label}} has been published on {{publicationSite}} in the topic {{topic}}."
 			}
 		}
+	},
+	"mails": {
+		"api-key": {
+			"expiring": {
+				"subject": "Your API key {{title}} is about to expire",
+				"text": "API key {{title}} expires on {{expireAt}}."
+			},
+			"expired": {
+				"subject": "Your API key {{title}} expires on {{expireAt}}",
+				"text": "API key {{title}} expires on {{expireAt}}."
+			}
+		}
 	}
 }

--- a/api/i18n/messages/fr.json
+++ b/api/i18n/messages/fr.json
@@ -182,5 +182,17 @@
 				"body": "L'application {{label}} a été publiée sur {{publicationSite}} dans la thématique {{topic}}."
 			}
 		}
+	},
+	"mails": {
+		"api-key": {
+			"expiring": {
+				"subject": "Votre clé d'API {{title}} expire bientôt",
+				"text": "La clé d'API {{title}} arrive à expiration le {{expireAt}}."
+			},
+			"expired": {
+				"subject": "Votre clé d'API {{title}} arrive à expiration",
+				"text": "La clé d'API {{title}} arrive à expiration le {{expireAt}}."
+			}
+		}
 	}
 }

--- a/api/package.json
+++ b/api/package.json
@@ -88,6 +88,7 @@
     "multer": "^1.4.5-lts.1",
     "nanoid": "^5.0.9",
     "ngeohash": "^0.6.3",
+    "node-cron": "^4.2.1",
     "node-dir": "^0.1.17",
     "number-abbreviate": "^2.0.0",
     "object-hash": "^3.0.0",

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -262,6 +262,8 @@ export const run = async () => {
       internalError('workers-loop-error', error)
       throw error
     })
+    const apiKeysExpirationWorker = await import('./settings/api-keys-expiration-worker.ts')
+    apiKeysExpirationWorker.start()
   }
 
   if (config.mode.includes('server')) {
@@ -324,6 +326,7 @@ export const stop = async () => {
 
   if (config.mode.includes('worker')) {
     await (await import('./workers/index.ts')).stop()
+    await (await import('./settings/api-keys-expiration-worker.ts')).stop()
   }
 
   await locks.stop()

--- a/api/src/misc/routers/test-env.ts
+++ b/api/src/misc/routers/test-env.ts
@@ -218,6 +218,28 @@ router.post('/rest-collection-update-one/:datasetId', async (req, res, next) => 
   }
 })
 
+// Update one document in the settings collection (for injecting internal fields in tests)
+router.post('/settings-update-one', async (req, res, next) => {
+  try {
+    const { filter, update } = req.body
+    await mongo.settings.updateOne(filter, update)
+    res.json({ ok: true })
+  } catch (err) {
+    next(err)
+  }
+})
+
+// Trigger the api-keys expiration cron task on demand (test-only)
+router.post('/api-keys-expiration/run', async (req, res, next) => {
+  try {
+    const { task } = await import('../../settings/api-keys-expiration-worker.ts')
+    await task()
+    res.json({ ok: true })
+  } catch (err) {
+    next(err)
+  }
+})
+
 // Count ES indices matching a dataset prefix
 router.get('/dataset-es-indices-count/:datasetId', async (req, res, next) => {
   try {

--- a/api/src/misc/utils/mails.ts
+++ b/api/src/misc/utils/mails.ts
@@ -15,14 +15,17 @@ export type Mail = {
 
 /**
  * Send a mail through simple-directory's internal /api/mails endpoint.
- * Fire-and-forget: failures are reported via internalError, never thrown,
- * so a mail outage cannot break the cron task.
+ * Failures are reported via internalError and never thrown, so a mail outage
+ * cannot break the cron task. Returns true only when the mail actually went
+ * out, so callers can avoid recording a notification that was never sent.
  */
-export const sendMail = async (mail: Mail) => {
+export const sendMail = async (mail: Mail): Promise<boolean> => {
   const directoryUrl = config.privateDirectoryUrl || config.directoryUrl
   try {
     await axios.post(directoryUrl + '/api/mails', mail, { params: { key: config.secretKeys.sendMails } })
+    return true
   } catch (err) {
     internalError('send-mail', err)
+    return false
   }
 }

--- a/api/src/misc/utils/mails.ts
+++ b/api/src/misc/utils/mails.ts
@@ -1,0 +1,28 @@
+import axios from './axios.js'
+import config from '#config'
+import { internalError } from '@data-fair/lib-node/observer.js'
+
+export type MailRecipient =
+  | string
+  | { type: 'user' | 'organization', id: string, role?: string, department?: string }
+
+export type Mail = {
+  to: MailRecipient[]
+  subject: string
+  text: string
+  html?: string
+}
+
+/**
+ * Send a mail through simple-directory's internal /api/mails endpoint.
+ * Fire-and-forget: failures are reported via internalError, never thrown,
+ * so a mail outage cannot break the cron task.
+ */
+export const sendMail = async (mail: Mail) => {
+  const directoryUrl = config.privateDirectoryUrl || config.directoryUrl
+  try {
+    await axios.post(directoryUrl + '/api/mails', mail, { params: { key: config.secretKeys.sendMails } })
+  } catch (err) {
+    internalError('send-mail', err)
+  }
+}

--- a/api/src/settings/api-keys-expiration-milestones.ts
+++ b/api/src/settings/api-keys-expiration-milestones.ts
@@ -15,10 +15,11 @@ export const milestoneFlag: Record<Milestone, FlagField> = {
  * comparison on that format is chronological.
  *
  * - 'expiring' : strictly in the future, within 3 days (today < expireAt <= today+3)
- * - 'expired'  : the expiry day or later (expireAt <= today)
- *   Note: 'expired' fires on the expiry day itself (expireAt <= now), deliberately superseding
- *   the previous worker behaviour that announced expiry only the day after; the day-of mail uses
- *   forward-looking wording ("arrive à expiration"), so this is correct.
+ * - 'expired'  : the expiry day itself, and only that day (expireAt === today)
+ *   The day-of mail uses forward-looking wording ("arrive à expiration"), so firing on the
+ *   expiry day is correct. We deliberately do NOT notify keys that expired in the past: on a
+ *   fresh deploy (or after the send secret is enabled) this avoids a backlog of mails for keys
+ *   that expired long ago, and a key still gets at least its J-3 warning beforehand.
  *
  * Anti-spam: a key expiring today yields only 'expired' (never 'expiring').
  */
@@ -30,6 +31,6 @@ export const computeDueMilestones = (
   const j3 = dayjs(now).add(3, 'day').format('YYYY-MM-DD')
   const due: Milestone[] = []
   if (apiKey.expireAt > now && apiKey.expireAt <= j3 && !apiKey.notifiedJ3At) due.push('expiring')
-  if (apiKey.expireAt <= now && !apiKey.notifiedJAt) due.push('expired')
+  if (apiKey.expireAt === now && !apiKey.notifiedJAt) due.push('expired')
   return due
 }

--- a/api/src/settings/api-keys-expiration-milestones.ts
+++ b/api/src/settings/api-keys-expiration-milestones.ts
@@ -1,0 +1,35 @@
+import dayjs from 'dayjs'
+
+export type Milestone = 'expiring' | 'expired'
+export type FlagField = 'notifiedJ3At' | 'notifiedJAt'
+
+// which dedup flag guards which milestone
+export const milestoneFlag: Record<Milestone, FlagField> = {
+  expiring: 'notifiedJ3At',
+  expired: 'notifiedJAt'
+}
+
+/**
+ * Decide which expiration mails are due for an api key on day `now` (YYYY-MM-DD).
+ * Pure: no DB, no mail, no clock. `expireAt` is a YYYY-MM-DD string; lexical
+ * comparison on that format is chronological.
+ *
+ * - 'expiring' : strictly in the future, within 3 days (today < expireAt <= today+3)
+ * - 'expired'  : the expiry day or later (expireAt <= today)
+ *   Note: 'expired' fires on the expiry day itself (expireAt <= now), deliberately superseding
+ *   the previous worker behaviour that announced expiry only the day after; the day-of mail uses
+ *   forward-looking wording ("arrive à expiration"), so this is correct.
+ *
+ * Anti-spam: a key expiring today yields only 'expired' (never 'expiring').
+ */
+export const computeDueMilestones = (
+  apiKey: { expireAt?: string, notifiedJ3At?: string, notifiedJAt?: string },
+  now: string
+): Milestone[] => {
+  if (!apiKey.expireAt) return []
+  const j3 = dayjs(now).add(3, 'day').format('YYYY-MM-DD')
+  const due: Milestone[] = []
+  if (apiKey.expireAt > now && apiKey.expireAt <= j3 && !apiKey.notifiedJ3At) due.push('expiring')
+  if (apiKey.expireAt <= now && !apiKey.notifiedJAt) due.push('expired')
+  return due
+}

--- a/api/src/settings/api-keys-expiration-worker.ts
+++ b/api/src/settings/api-keys-expiration-worker.ts
@@ -1,0 +1,106 @@
+import cron, { type ScheduledTask } from 'node-cron'
+import dayjs from 'dayjs'
+import i18n from 'i18n'
+import Debug from 'debug'
+import locks from '@data-fair/lib-node/locks.js'
+import { internalError } from '@data-fair/lib-node/observer.js'
+import config from '#config'
+import mongo from '#mongo'
+import { sendMail, type MailRecipient } from '../misc/utils/mails.ts'
+import { type Milestone, milestoneFlag, computeDueMilestones } from './api-keys-expiration-milestones.ts'
+
+const debug = Debug('api-keys-expiration')
+
+let stopped = false
+let taskPromise: Promise<void> | undefined
+let scheduledTask: ScheduledTask | undefined
+
+// settings docs store type/id/department at the root
+const buildRecipients = (settingsDoc: any): MailRecipient[] => {
+  if (settingsDoc.type === 'user') return [{ type: 'user', id: settingsDoc.id }]
+  const base = { type: 'organization' as const, id: settingsDoc.id, role: 'admin' }
+  if (settingsDoc.department) {
+    // department admins + root org admins (disjoint sets)
+    return [{ ...base, department: settingsDoc.department }, { ...base }]
+  }
+  return [base]
+}
+
+const renderMail = (milestone: Milestone, apiKey: { title: string, expireAt: string }, to: MailRecipient[]) => {
+  const locale = config.i18n.defaultLocale
+  const params = { title: apiKey.title, expireAt: apiKey.expireAt }
+  const subject = i18n.__({ phrase: `mails.api-key.${milestone}.subject`, locale }, params)
+  const text = i18n.__({ phrase: `mails.api-key.${milestone}.text`, locale }, params)
+  return { to, subject, text, html: `<p>${text}</p>` }
+}
+
+const tryEmit = async (
+  settingsDoc: any,
+  apiKey: { id: string, title: string, expireAt: string },
+  milestone: Milestone
+) => {
+  const flag = milestoneFlag[milestone]
+  // atomic conditional set — wins exactly one race across all data-fair pods
+  const res = await mongo.settings.updateOne(
+    { _id: settingsDoc._id },
+    { $set: { [`apiKeys.$[k].${flag}`]: new Date().toISOString() } },
+    { arrayFilters: [{ 'k.id': apiKey.id, [`k.${flag}`]: { $exists: false } }] }
+  )
+  if (res.modifiedCount !== 1) return // another pod already emitted this milestone
+  await sendMail(renderMail(milestone, apiKey, buildRecipients(settingsDoc)))
+}
+
+const runOnce = async () => {
+  const now = dayjs().format('YYYY-MM-DD')
+  const j3 = dayjs().add(3, 'day').format('YYYY-MM-DD')
+  // cheap pre-filter; computeDueMilestones is the authoritative decision
+  const cursor = mongo.settings.find({
+    apiKeys: {
+      $elemMatch: {
+        expireAt: { $exists: true, $lte: j3 },
+        $or: [{ notifiedJ3At: { $exists: false } }, { notifiedJAt: { $exists: false } }]
+      }
+    }
+  })
+  for await (const settingsDoc of cursor) {
+    for (const apiKey of (settingsDoc as any).apiKeys ?? []) {
+      if (!apiKey.id || !apiKey.expireAt) continue
+      for (const milestone of computeDueMilestones(apiKey, now)) {
+        await tryEmit(settingsDoc, apiKey, milestone)
+      }
+    }
+  }
+}
+
+export const task = async () => {
+  if (stopped) return
+  try {
+    debug('run api-keys expiration cron task')
+    await locks.acquire('api-keys-expiration-task')
+    try {
+      await runOnce()
+    } finally {
+      await locks.release('api-keys-expiration-task')
+    }
+    debug('api-keys expiration cron task done')
+  } catch (err) {
+    internalError('api-keys-expiration-cron', err)
+  }
+}
+
+export const start = () => {
+  scheduledTask = cron.schedule(config.apiKeysExpirationCron, () => {
+    if (taskPromise) {
+      console.warn('api-keys-expiration task already running')
+      return
+    }
+    taskPromise = task()
+    taskPromise.finally(() => { taskPromise = undefined })
+  })
+}
+
+export const stop = async () => {
+  stopped = true
+  scheduledTask?.stop()
+  if (taskPromise) await taskPromise
+}

--- a/api/src/settings/api-keys-expiration-worker.ts
+++ b/api/src/settings/api-keys-expiration-worker.ts
@@ -40,24 +40,29 @@ const tryEmit = async (
   milestone: Milestone
 ) => {
   const flag = milestoneFlag[milestone]
-  // atomic conditional set — wins exactly one race across all data-fair pods
-  const res = await mongo.settings.updateOne(
+  // send first: a failed mail must not flag the key as notified (it retries next run).
+  // The task-level lock guarantees a single pod runs at a time, so sending before the
+  // flag is set cannot duplicate mails; the arrayFilter guard below keeps idempotency
+  // across runs/retries.
+  const sent = await sendMail(renderMail(milestone, apiKey, buildRecipients(settingsDoc)))
+  if (!sent) return
+  await mongo.settings.updateOne(
     { _id: settingsDoc._id },
     { $set: { [`apiKeys.$[k].${flag}`]: new Date().toISOString() } },
     { arrayFilters: [{ 'k.id': apiKey.id, [`k.${flag}`]: { $exists: false } }] }
   )
-  if (res.modifiedCount !== 1) return // another pod already emitted this milestone
-  await sendMail(renderMail(milestone, apiKey, buildRecipients(settingsDoc)))
 }
 
 const runOnce = async () => {
   const now = dayjs().format('YYYY-MM-DD')
   const j3 = dayjs().add(3, 'day').format('YYYY-MM-DD')
-  // cheap pre-filter; computeDueMilestones is the authoritative decision
+  // cheap pre-filter; computeDueMilestones is the authoritative decision.
+  // Lower bound `>= now` skips keys that expired in the past — we never notify those
+  // anymore, so there is no point scanning them on every run.
   const cursor = mongo.settings.find({
     apiKeys: {
       $elemMatch: {
-        expireAt: { $exists: true, $lte: j3 },
+        expireAt: { $exists: true, $gte: now, $lte: j3 },
         $or: [{ notifiedJ3At: { $exists: false } }, { notifiedJAt: { $exists: false } }]
       }
     }
@@ -76,7 +81,11 @@ export const task = async () => {
   if (stopped) return
   try {
     debug('run api-keys expiration cron task')
-    await locks.acquire('api-keys-expiration-task')
+    const ack = await locks.acquire('api-keys-expiration-task')
+    if (!ack) {
+      debug('another pod holds the api-keys-expiration lock, skipping this run')
+      return
+    }
     try {
       await runOnce()
     } finally {

--- a/api/src/settings/router.ts
+++ b/api/src/settings/router.ts
@@ -99,6 +99,8 @@ function cleanSettings (settings: Settings | DepartmentSettings) {
   if (settings.apiKeys) {
     for (const apiKey of settings.apiKeys) {
       delete apiKey.key
+      delete apiKey.notifiedJ3At
+      delete apiKey.notifiedJAt
     }
   }
   // @ts-ignore
@@ -161,6 +163,11 @@ const writeSettings = async (req: SettingsRequest, existingSettings: Settings | 
       throw httpError(403, 'Attempt to write an api key secret')
     }
 
+    if (apiKey.notifiedJ3At !== undefined || apiKey.notifiedJAt !== undefined) {
+      eventsLog.alert('df.apikeys.writeflag', 'a user attempted to write an api key internal notification flag', { req, account: req.owner })
+      throw httpError(400, 'API key notification flags are internal and not user-writable')
+    }
+
     if (!apiKey.id) {
       // creating a new key
 
@@ -219,7 +226,11 @@ const writeSettings = async (req: SettingsRequest, existingSettings: Settings | 
       } else {
         eventsLog.warn('df.apikeys.missingKey', `an API ${apiKey.id} key seems to be missing its internal secret`, { req, account: req.owner })
       }
-      if (!equal(existingApiKey, apiKey)) {
+      // notifiedJ3At / notifiedJAt are internal flags set by the expiration worker; they are
+      // stripped from API responses and never sent back by the user, so exclude them from the
+      // immutability comparison (otherwise any key the worker has notified becomes un-resavable).
+      const { notifiedJ3At: _nj3, notifiedJAt: _nj, ...comparableExistingApiKey } = existingApiKey as any
+      if (!equal(comparableExistingApiKey, apiKey)) {
         eventsLog.alert('df.apikeys.mutate', `a user tried to mutate an existing api key ${existingApiKey.title} (${existingApiKey.id})`, { req, account: req.owner })
         throw httpError(400, 'existing API keys are immutable')
       }

--- a/api/types/settings/schema.js
+++ b/api/types/settings/schema.js
@@ -239,6 +239,18 @@ export default {
           },
           clearKey: {
             type: 'string'
+          },
+          notifiedJ3At: {
+            type: 'string',
+            format: 'date-time',
+            readOnly: true,
+            description: 'Internal — timestamp set when the J-3 expiration notification was emitted. Not user-writable.'
+          },
+          notifiedJAt: {
+            type: 'string',
+            format: 'date-time',
+            readOnly: true,
+            description: 'Internal — timestamp set when the J-day expiration notification was emitted. Not user-writable.'
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,7 @@
         "multer": "^1.4.5-lts.1",
         "nanoid": "^5.0.9",
         "ngeohash": "^0.6.3",
+        "node-cron": "^4.2.1",
         "node-dir": "^0.1.17",
         "number-abbreviate": "^2.0.0",
         "object-hash": "^3.0.0",
@@ -17374,6 +17375,15 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/node-dir": {
       "version": "0.1.17",

--- a/tests/features/settings/api-keys-expiration-milestones.unit.spec.ts
+++ b/tests/features/settings/api-keys-expiration-milestones.unit.spec.ts
@@ -27,8 +27,12 @@ test.describe('computeDueMilestones', () => {
     assert.deepEqual(computeDueMilestones({ expireAt: NOW }, NOW), ['expired'])
   })
 
-  test('already expired (yesterday) -> only expired', () => {
-    assert.deepEqual(computeDueMilestones({ expireAt: plus(-1) }, NOW), ['expired'])
+  test('already expired (yesterday) -> nothing (we never notify the past)', () => {
+    assert.deepEqual(computeDueMilestones({ expireAt: plus(-1) }, NOW), [])
+  })
+
+  test('expired long ago -> nothing', () => {
+    assert.deepEqual(computeDueMilestones({ expireAt: plus(-30) }, NOW), [])
   })
 
   test('expires in 10 days -> nothing', () => {
@@ -42,9 +46,9 @@ test.describe('computeDueMilestones', () => {
     )
   })
 
-  test('expired already notified -> nothing', () => {
+  test('expires today but day-of already notified -> nothing', () => {
     assert.deepEqual(
-      computeDueMilestones({ expireAt: plus(-1), notifiedJAt: '2026-06-02T03:00:00.000Z' }, NOW),
+      computeDueMilestones({ expireAt: NOW, notifiedJAt: '2026-06-02T03:00:00.000Z' }, NOW),
       []
     )
   })

--- a/tests/features/settings/api-keys-expiration-milestones.unit.spec.ts
+++ b/tests/features/settings/api-keys-expiration-milestones.unit.spec.ts
@@ -1,0 +1,58 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import dayjs from 'dayjs'
+import { computeDueMilestones } from '../../../api/src/settings/api-keys-expiration-milestones.ts'
+
+const NOW = '2026-06-02'
+const plus = (n: number) => dayjs(NOW).add(n, 'day').format('YYYY-MM-DD')
+
+test.describe('computeDueMilestones', () => {
+  test('no expireAt -> nothing', () => {
+    assert.deepEqual(computeDueMilestones({}, NOW), [])
+  })
+
+  test('expires in 3 days -> only expiring', () => {
+    assert.deepEqual(computeDueMilestones({ expireAt: plus(3) }, NOW), ['expiring'])
+  })
+
+  test('expires in 4 days -> nothing (just outside the window)', () => {
+    assert.deepEqual(computeDueMilestones({ expireAt: plus(4) }, NOW), [])
+  })
+
+  test('expires in 1 day -> only expiring', () => {
+    assert.deepEqual(computeDueMilestones({ expireAt: plus(1) }, NOW), ['expiring'])
+  })
+
+  test('expires today -> only expired (anti-spam: no expiring)', () => {
+    assert.deepEqual(computeDueMilestones({ expireAt: NOW }, NOW), ['expired'])
+  })
+
+  test('already expired (yesterday) -> only expired', () => {
+    assert.deepEqual(computeDueMilestones({ expireAt: plus(-1) }, NOW), ['expired'])
+  })
+
+  test('expires in 10 days -> nothing', () => {
+    assert.deepEqual(computeDueMilestones({ expireAt: plus(10) }, NOW), [])
+  })
+
+  test('expiring already notified -> nothing', () => {
+    assert.deepEqual(
+      computeDueMilestones({ expireAt: plus(2), notifiedJ3At: '2026-06-01T03:00:00.000Z' }, NOW),
+      []
+    )
+  })
+
+  test('expired already notified -> nothing', () => {
+    assert.deepEqual(
+      computeDueMilestones({ expireAt: plus(-1), notifiedJAt: '2026-06-02T03:00:00.000Z' }, NOW),
+      []
+    )
+  })
+
+  test('expiring notified but now also expired -> expired only', () => {
+    assert.deepEqual(
+      computeDueMilestones({ expireAt: NOW, notifiedJ3At: '2026-05-30T03:00:00.000Z' }, NOW),
+      ['expired']
+    )
+  })
+})

--- a/tests/features/settings/settings.api.spec.ts
+++ b/tests/features/settings/settings.api.spec.ts
@@ -1,6 +1,7 @@
 import { test } from '@playwright/test'
 import assert from 'node:assert/strict'
-import { axiosAuth, clean, checkPendingTasks } from '../../support/axios.ts'
+import dayjs from 'dayjs'
+import { axiosAuth, clean, checkPendingTasks, anonymousAx, apiUrl } from '../../support/axios.ts'
 
 const testUser1 = await axiosAuth('test_user1@test.com')
 const testUser1Org = await axiosAuth('test_user1@test.com', 'test_org1')
@@ -63,5 +64,60 @@ test.describe('settings API', () => {
     assert.equal(res.data.name, 'Test Org 1 - dep1')
     assert.equal(res.data.department, 'dep1')
     assert.deepEqual(res.data.apiKeys[0].title, 'Api key 1')
+  })
+
+  test('cannot write notifiedJ3At from the api', async () => {
+    await assert.rejects(
+      testUser1.put('/api/v1/settings/user/test_user1', {
+        apiKeys: [{
+          title: 'k2',
+          scopes: ['datasets-read'],
+          expireAt: dayjs().add(1, 'year').format('YYYY-MM-DD'),
+          notifiedJ3At: '2026-05-20T00:00:00.000Z'
+        }]
+      }),
+      (err: any) => err.status === 400
+    )
+  })
+
+  test('notifiedJ3At / notifiedJAt are not returned in the API response', async () => {
+    // Create an API key
+    await testUser1.put('/api/v1/settings/user/test_user1', {
+      apiKeys: [{ title: 'k1', scopes: ['datasets-read'], expireAt: dayjs().add(1, 'year').format('YYYY-MM-DD') }]
+    })
+
+    // Write the internal flags directly to mongo (simulating what the worker does)
+    await anonymousAx.post(`${apiUrl}/api/v1/test-env/settings-update-one`, {
+      filter: { type: 'user', id: 'test_user1' },
+      update: { $set: { 'apiKeys.0.notifiedJ3At': '2026-05-20T00:00:00.000Z' } }
+    })
+
+    // Read via the API
+    const res = await testUser1.get('/api/v1/settings/user/test_user1')
+    assert.equal(res.status, 200)
+    assert.ok(res.data.apiKeys?.[0], 'apiKey present')
+    assert.equal(res.data.apiKeys[0].notifiedJ3At, undefined, 'notifiedJ3At not exposed')
+    assert.equal(res.data.apiKeys[0].notifiedJAt, undefined, 'notifiedJAt not exposed')
+  })
+
+  test('can still re-save settings after the worker set an expiration flag on a key', async () => {
+    // create a key
+    const created = (await testUser1.put('/api/v1/settings/user/test_user1', {
+      apiKeys: [{ title: 'k-flag', scopes: ['datasets-read'], expireAt: dayjs().add(10, 'day').format('YYYY-MM-DD') }]
+    })).data
+    const key = created.apiKeys.find((k: any) => k.title === 'k-flag')
+    assert.ok(key?.id)
+
+    // simulate the expiration worker having set the internal flag directly in mongo
+    await anonymousAx.post(`${apiUrl}/api/v1/test-env/settings-update-one`, {
+      filter: { type: 'user', id: 'test_user1' },
+      update: { $set: { 'apiKeys.0.notifiedJ3At': '2026-05-20T00:00:00.000Z' } }
+    })
+
+    // re-read (flags are stripped) and re-save the same settings — must NOT 400 'immutable'
+    const reread = (await testUser1.get('/api/v1/settings/user/test_user1')).data
+    assert.equal(reread.apiKeys[0].notifiedJ3At, undefined)
+    const resave = await testUser1.put('/api/v1/settings/user/test_user1', { apiKeys: reread.apiKeys })
+    assert.equal(resave.status, 200)
   })
 })

--- a/ui/src/components/settings/settings-api-keys.vue
+++ b/ui/src/components/settings/settings-api-keys.vue
@@ -168,7 +168,7 @@
             v-if="apiKey.expireAt"
             class="mb-4"
           >
-            {{ t('expireAt') }} : {{ dayjs(new Date(apiKey.expireAt)).format('l') }}
+            {{ t('expireAt') }} : {{ dayjs(new Date(apiKey.expireAt)).format('L') }}
           </p>
         </v-card-text>
 


### PR DESCRIPTION
Notify API key owners by email before their keys expire, instead of going through the events service.

A daily `node-cron` worker (worker mode, 3 AM via `apiKeysExpirationCron`) scans the `settings` collection and emails — through simple-directory's internal `POST /api/mails` — when a key is about to expire (a single warning in the 3 days before) or reaches its expiry day itself. No events topics, no subscriptions, no in-app subscription embed.

**Why:** the previous events-based design (per-key subscription + embed + auto-subscribe) was more complex than the need. A direct email to the owner / org admins is simpler and requires no user action.

**What changed:**
- New worker `api/src/settings/api-keys-expiration-worker.ts` backed by a pure, unit-tested `computeDueMilestones` (anti-spam: a key expiring the same day gets only the day-of mail, never the 3-day warning).
- New `api/src/misc/utils/mails.ts` (mirrors `events`' mail call) and `secretKeys.sendMails` config (env `SECRET_SENDMAILS`; `testkey` in dev).
- Recipients: user key → the user; org key → org admins; department key → department admins **and** root org admins.
- Per-key dedup via internal `notifiedJ3At` / `notifiedJAt` flags — stripped from API responses, rejected on write, and excluded from the api-key immutability check.
- Mail templates under `mails.api-key.*`, rendered in the instance default locale.
- UI: removed the per-key subscription bell/embed and reverted the settings auto-subscribe; kept the `format('L')` date tweak.

**Post-review robustness:**
- A failed mail must **not** flag a key as notified. `sendMail` now reports whether the mail actually went out, and the worker sends **before** writing the flag, only flagging on success — a mail outage (e.g. `SECRET_SENDMAILS` not yet enabled, SD down) simply retries on the next run.
- The `expired` milestone now fires **only on the expiry day itself** (`expireAt === now`), never for keys that expired in the past. This avoids a backlog of mails when the send secret is first enabled, so no upgrade script is needed — a key still gets its J-3 warning beforehand. The worker pre-filter gained a `>= now` lower bound so dead keys are no longer scanned.
- The worker now honors `locks.acquire`'s return value (`if (!ack) return`, previously ignored). With the single running pod this guarantees, the send-then-flag ordering cannot duplicate mails; the per-key `arrayFilters` guard keeps idempotency across runs/retries.

**Regression risks:**
- **Settings immutability:** the worker mutates stored keys (the notification flags); these are now excluded from the immutability comparison in `writeSettings`, otherwise every settings save after a key's first notification would 400. Covered by a dedicated regression test.
- **Deployment:** requires `SECRET_SENDMAILS` set (shared with simple-directory's `secretKeys.sendMails`); without it `/api/mails` returns 403 and no mail is sent (logged via `internalError`, non-fatal, and the key is not flagged).
- The daily cron scans the whole `settings` collection (small — one doc per account), no dedicated index.
- One mail body per send → a single locale (instance default) for all recipients of an org.
- The test-only endpoints `/api/v1/test-env/{settings-update-one,api-keys-expiration/run}` are mounted only under `NODE_ENV=development`.

**Tests:** unit coverage of the anti-spam matrix (incl. past-expiry cases); API guards (internal flags not writable / not exposed) + the immutability regression test. Mail rendering/delivery validated manually via maildev.
