### PR TITLE
feat(agent): service-releases assistant on /admin/info

### DIFF
--- a/docs/architecture/agent-integration.md
+++ b/docs/architecture/agent-integration.md
@@ -11,7 +11,7 @@ The integration follows a **browser-side tool exposure** pattern: the main appli
 - **Tools execute in the browser**: all tool logic runs client-side in the main application frame, with the user's session and permissions. The agent service never directly accesses the Data Fair API.
 - **Bilingual**: all tool annotations, subagent prompts, and the system prompt support French and English.
 - **Progressive activation**: the feature is gated behind an environment variable, an organization setting, and responsive UI rules.
-- **Read-heavy, write-light**: of 34 tools, only 7 perform writes (navigate, set_expression, set_dataset_summary, set_dataset_description, set_property_config, open_add_line_dialog, open_edit_line_dialog). The creation wizard tools manipulate client-side form state only — no server-side writes.
+- **Read-heavy, write-light**: of 36 tools, only 7 perform writes (navigate, set_expression, set_dataset_summary, set_dataset_description, set_property_config, open_add_line_dialog, open_edit_line_dialog). The creation wizard tools manipulate client-side form state only — no server-side writes.
 
 ### Activation flow
 
@@ -35,7 +35,7 @@ graph TB
             FS["Frame Server<br/>(BroadcastChannel)"]
             TR["Tool Registry<br/>(useAgentTool)"]
             SR["Subagent Registry<br/>(useAgentSubAgent)"]
-            Tools["34 Tools"]
+            Tools["36 Tools"]
             SubAgents["8 Subagents"]
             TR --> Tools
             SR --> SubAgents
@@ -260,6 +260,16 @@ The user types directly in the chat drawer. The agent has access to all globally
 | **Tools** | `select_dataset_type`, `set_dataset_title`, `set_rest_options`, `skip_init_from_step`, `advance_to_confirmation` |
 | **Source** | `ui/src/composables/dataset/agent-creation-tools.ts`, `ui/src/pages/new-dataset.vue` |
 
+### 4.15 Summarize Service Releases
+
+| | |
+|---|---|
+| **Trigger** | Action button on the `/admin/info` page |
+| **Action ID** | `summarize-releases` |
+| **Pattern** | **Tool-chaining**: agent calls `list_services_versions` for installed versions, then `explore_github` (`/repos/{name}/releases`, falling back to `/tags`) per service, compares semver, and summarizes available-but-not-deployed versions. |
+| **Tools** | `list_services_versions`, `explore_github` |
+| **Source** | `ui/src/composables/agent/releases-tools.ts`, `ui/src/pages/admin/info.vue` |
+
 ## 5. Tool Reference
 
 | Tool | Category | R/W | Source |
@@ -305,6 +315,8 @@ The user types directly in the chat drawer. The agent has access to all globally
 | `list_catalogs` | Connectors | R | `agent/connector-tools.ts` |
 | `describe_catalog` | Connectors | R | `agent/connector-tools.ts` |
 | `page_guidance` | Page guidance | R | `dataset/agent-page-guidance-tools.ts` (dataset detail page) |
+| `list_services_versions` | Service info | R | `agent/releases-tools.ts` |
+| `explore_github` | Service info | R | `agent/releases-tools.ts` |
 
 All source paths are relative to `ui/src/composables/` unless otherwise noted. **W*** = client-side state only (no server write). Connector tools are conditional on integration flags. **`page_guidance`** is a page-scoped fallback tool: each page that registers it (currently only the dataset detail page) carries its own essential anti-misroute facts in the tool description and a full page structure / interaction guide in the returned content. The agent is instructed to call it only when unsure how to help the user on the current page.
 
@@ -333,6 +345,9 @@ All source paths are relative to `ui/src/composables/` unless otherwise noted. *
 | `ui/src/composables/agent/navigation-tools.ts` | Navigation tools (3) |
 | `ui/src/composables/agent/geo-tools.ts` | Geolocation tools (2) |
 | `ui/src/composables/agent/connector-tools.ts` | Processings & catalogs tools (0-4) |
+| `ui/src/composables/agent/releases-tools.ts` | Service-version + GitHub exploration tools (2) |
+| `ui/src/composables/agent/releases-tools-logic.ts` | Pure helpers for the releases tools (unit-tested) |
+| `ui/src/pages/admin/info.vue` | `summarize-releases` action button + page-scoped tool registration |
 | `ui/src/composables/agent/utils.ts` | Shared helpers: `createAgentTranslator`, `agentToolError`, `csvEscape`, `toCsv`, `cleanRow`, `fetchSampleRows`, `buildPaginatedQuery` |
 | `ui/src/composables/dataset/agent-tools.ts` | Dataset metadata tools (2) + `serializeDatasetInfo` |
 | `ui/src/composables/dataset/agent-data-tools.ts` | Dataset data query tools (5) + `dataset_data` subagent |

--- a/tests/features/agent-tools/releases-tools.unit.spec.ts
+++ b/tests/features/agent-tools/releases-tools.unit.spec.ts
@@ -1,0 +1,65 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import {
+  validateGithubPath,
+  truncateBody,
+  serializeServicesInfo
+} from '../../../ui/src/composables/agent/releases-tools-logic.ts'
+
+test.describe('validateGithubPath', () => {
+  test('accepts a /repos/ path', () => {
+    assert.deepEqual(validateGithubPath('/repos/data-fair/data-fair/releases'), { ok: true })
+  })
+
+  test('rejects a non-/repos/ path', () => {
+    const r = validateGithubPath('/search/repositories')
+    assert.equal(r.ok, false)
+    assert.match((r as { message: string }).message, /\/repos\//)
+  })
+
+  test('rejects absolute / protocol-relative URLs and traversal', () => {
+    assert.equal(validateGithubPath('https://evil.com/repos/x').ok, false)
+    assert.equal(validateGithubPath('//evil.com/repos/x').ok, false)
+    assert.equal(validateGithubPath('/repos/../../etc').ok, false)
+  })
+
+  test('rejects non-string input', () => {
+    assert.equal(validateGithubPath(undefined as unknown as string).ok, false)
+  })
+})
+
+test.describe('truncateBody', () => {
+  test('passes short text through untouched', () => {
+    assert.deepEqual(truncateBody('hello', 10), { text: 'hello', truncated: false })
+  })
+
+  test('truncates text longer than the limit', () => {
+    const r = truncateBody('abcdefghij', 4)
+    assert.deepEqual(r, { text: 'abcd', truncated: true })
+  })
+})
+
+test.describe('serializeServicesInfo', () => {
+  test('reports installed version, commit and date for loaded services', () => {
+    const out = serializeServicesInfo([
+      { name: 'data-fair/data-fair', loaded: true, version: '6.6.0', commit: 'abc123', date: '2026-05-01' }
+    ])
+    assert.match(out, /data-fair\/data-fair/)
+    assert.match(out, /6\.6\.0/)
+    assert.match(out, /abc123/)
+    assert.match(out, /GitHub repo: data-fair\/data-fair/)
+  })
+
+  test('reports errors and pending loads', () => {
+    const out = serializeServicesInfo([
+      { name: 'data-fair/events', error: 'boom' },
+      { name: 'data-fair/portals' }
+    ])
+    assert.match(out, /events.*boom/)
+    assert.match(out, /portals.*loading/i)
+  })
+
+  test('handles an empty list', () => {
+    assert.match(serializeServicesInfo([]), /No services/i)
+  })
+})

--- a/ui/src/composables/agent/releases-tools-logic.ts
+++ b/ui/src/composables/agent/releases-tools-logic.ts
@@ -1,0 +1,47 @@
+export interface ServiceInfo {
+  name: string
+  loaded?: boolean
+  error?: string
+  commit?: string
+  date?: string
+  version?: string
+}
+
+/**
+ * Validate a GitHub REST API path for the explore_github tool.
+ * Only unauthenticated GET access to "/repos/..." is allowed.
+ */
+export function validateGithubPath (path: string): { ok: true } | { ok: false, message: string } {
+  if (typeof path !== 'string' || !path.startsWith('/repos/')) {
+    return { ok: false, message: 'path must start with "/repos/" — only the GitHub /repos/... API is allowed' }
+  }
+  if (path.startsWith('//') || path.includes('://') || path.includes('..')) {
+    return { ok: false, message: 'invalid path' }
+  }
+  return { ok: true }
+}
+
+/**
+ * Truncate a (possibly large) response body to a character budget.
+ */
+export function truncateBody (text: string, max = 10_000): { text: string, truncated: boolean } {
+  if (text.length <= max) return { text, truncated: false }
+  return { text: text.slice(0, max), truncated: true }
+}
+
+/**
+ * Serialize the /admin/info services list into a markdown summary for the agent.
+ * Each service `name` doubles as its GitHub repo slug ("owner/repo").
+ */
+export function serializeServicesInfo (services: ServiceInfo[]): string {
+  if (!services.length) return 'No services configured.'
+  const lines = services.map((s) => {
+    if (s.error) return `- **${s.name}**: error loading info (${s.error})`
+    if (!s.loaded) return `- **${s.name}**: loading…`
+    const parts = [`installed version: ${s.version ?? 'unknown'}`]
+    if (s.commit) parts.push(`commit: ${s.commit}`)
+    if (s.date) parts.push(`date: ${s.date}`)
+    return `- **${s.name}** (GitHub repo: ${s.name}) — ${parts.join(', ')}`
+  })
+  return ['Data Fair services and their currently installed versions:', '', ...lines].join('\n')
+}

--- a/ui/src/composables/agent/releases-tools.ts
+++ b/ui/src/composables/agent/releases-tools.ts
@@ -1,0 +1,85 @@
+import type { Ref } from 'vue'
+import { useAgentTool } from '@data-fair/lib-vue-agents'
+import { createAgentTranslator, agentToolError } from './utils'
+import { validateGithubPath, truncateBody, serializeServicesInfo, type ServiceInfo } from './releases-tools-logic'
+
+const messages: Record<string, Record<string, string>> = {
+  fr: {
+    listServicesVersions: 'Lister les versions des services',
+    exploreGithub: "Explorer l'API GitHub"
+  },
+  en: {
+    listServicesVersions: 'List services versions',
+    exploreGithub: 'Explore GitHub API'
+  }
+}
+
+export function useAgentServicesInfoTool (locale: Ref<string>, services: Ref<ServiceInfo[]>) {
+  const t = createAgentTranslator(messages, locale)
+
+  useAgentTool({
+    name: 'list_services_versions',
+    description: 'List the Data Fair platform services running on this instance with their currently installed version, git commit and build date. Each service `name` is also its GitHub repository slug ("owner/repo", e.g. "data-fair/data-fair") and can be passed directly to explore_github. Use this first to know which version is deployed before comparing with available releases.',
+    annotations: { title: t('listServicesVersions'), readOnlyHint: true },
+    inputSchema: { type: 'object' as const, properties: {} },
+    execute: async () => serializeServicesInfo(services.value)
+  })
+}
+
+export function useAgentGithubTool (locale: Ref<string>) {
+  const t = createAgentTranslator(messages, locale)
+
+  useAgentTool({
+    name: 'explore_github',
+    description: [
+      'Perform an unauthenticated GET request against the public GitHub REST API. Restricted to "/repos/..." paths.',
+      'Useful endpoints for service releases:',
+      '- /repos/{owner}/{repo}/releases?per_page=10 — recent releases with notes (newest first)',
+      '- /repos/{owner}/{repo}/releases/latest — latest non-prerelease release',
+      '- /repos/{owner}/{repo}/tags?per_page=10 — git tags; use as a FALLBACK when a repo has no GitHub releases (the "available version" shown on this page is read from tags)',
+      '- /repos/{owner}/{repo}/compare/{base}...{head} — diff between two tags/commits',
+      'Pass owner/repo from list_services_versions. Keep per_page small. Large responses are truncated. Unauthenticated rate limit is 60 requests/hour.'
+    ].join('\n'),
+    annotations: { title: t('exploreGithub'), readOnlyHint: true },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        path: { type: 'string' as const, description: 'GitHub API path starting with "/repos/", e.g. "/repos/data-fair/data-fair/releases"' },
+        query: { type: 'string' as const, description: 'Optional query string without leading "?", e.g. "per_page=10"' }
+      },
+      required: ['path'] as const
+    },
+    execute: async (params) => {
+      const path = params.path as string
+      const valid = validateGithubPath(path)
+      if (!valid.ok) {
+        return { content: [{ type: 'text' as const, text: valid.message }], isError: true }
+      }
+      try {
+        const url = `https://api.github.com${path}${params.query ? '?' + (params.query as string) : ''}`
+        const res = await fetch(url, {
+          credentials: 'omit',
+          headers: {
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28'
+          }
+        })
+        if (!res.ok) {
+          if (res.status === 403 && res.headers.get('x-ratelimit-remaining') === '0') {
+            return { content: [{ type: 'text' as const, text: 'GitHub rate limit reached (unauthenticated, 60 requests/hour). Try again later.' }], isError: true }
+          }
+          if (res.status === 404) {
+            return { content: [{ type: 'text' as const, text: `Not found: ${path}` }], isError: true }
+          }
+          const body = await res.text()
+          return { content: [{ type: 'text' as const, text: `HTTP ${res.status}: ${truncateBody(body, 500).text}` }], isError: true }
+        }
+        const body = await res.text()
+        const { text, truncated } = truncateBody(body)
+        return text + (truncated ? '\n\n…(response truncated)' : '')
+      } catch (err) {
+        return agentToolError('GitHub API request failed', err)
+      }
+    }
+  })
+}

--- a/ui/src/pages/admin/info.vue
+++ b/ui/src/pages/admin/info.vue
@@ -1,5 +1,13 @@
 <template>
   <v-container v-if="services && statusFetch.data.value">
+    <df-agent-chat-action
+      v-if="showAgentChat"
+      action-id="summarize-releases"
+      :visible-prompt="t('summarizeReleasesPrompt')"
+      :hidden-context="releasesContext"
+      :btn-props="{ text: t('summarizeReleasesBtn'), class: 'mb-4' }"
+      :title="t('summarizeReleasesPrompt')"
+    />
     <v-expansion-panels>
       <v-expansion-panel
         expand
@@ -59,6 +67,8 @@
     info: Informations sur les services
     installed: installé
     available: disponible
+    summarizeReleasesBtn: Résumer les mises à jour
+    summarizeReleasesPrompt: Fais un résumé des dernières mises à jour des services avec un focus sur les versions disponibles et non encore déployées.
     services:
       data-fair/data-fair: Data Fair - Back Office
       data-fair/simple-directory: Gestion des comptes
@@ -73,6 +83,8 @@
     info: Services information
     installed: installed
     available: available
+    summarizeReleasesBtn: Summarize updates
+    summarizeReleasesPrompt: Summarize the latest service updates with a focus on versions that are available but not yet deployed.
     services:
       data-fair/data-fair: Data Fair - Back Office
       data-fair/simple-directory: Accounts management
@@ -86,9 +98,12 @@
   </i18n>
 
 <script setup lang="ts">
+import { DfAgentChatAction } from '@data-fair/lib-vuetify-agents'
 import { useBreadcrumbs } from '~/composables/layout/use-breadcrumbs'
+import { useShowAgentChat } from '~/composables/agent/use-show-chat'
+import { useAgentServicesInfoTool, useAgentGithubTool } from '~/composables/agent/releases-tools'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const breadcrumbs = useBreadcrumbs()
 breadcrumbs.receive({ breadcrumbs: [{ text: t('info') }] })
 
@@ -121,6 +136,17 @@ if ($uiConfig.metricsIntegration) {
 if ($uiConfig.openapiViewerIntegration) {
   services.value.push({ name: 'data-fair/openapi-viewer', infoUrl: '/openapi-viewer/api/admin/info' })
 }
+
+const showAgentChat = useShowAgentChat()
+
+const releasesContext = `To answer questions about service releases:
+1. Call list_services_versions to get each service and its currently installed version. The service name is the GitHub repo slug (owner/repo).
+2. For each relevant service, call explore_github with "/repos/{name}/releases?per_page=10" to get recent releases. If a repo has no releases, fall back to "/repos/{name}/tags?per_page=10".
+3. Compare the latest available version/tag with the installed version to identify versions that are available but not yet deployed.
+4. Summarize the recent updates, focusing on those available-but-not-deployed versions. Respond in the user's language.`
+
+useAgentServicesInfoTool(locale, services)
+useAgentGithubTool(locale)
 
 onMounted(async () => {
   for (const service of services.value) {


### PR DESCRIPTION
Add an AI-assistant button on `/admin/info` that summarizes recent service updates with a focus on versions that are available but not yet deployed, plus the two agent tools it needs.

**What changed**
- New page-scoped agent tools (`ui/src/composables/agent/releases-tools.ts`):
  - `list_services_versions` — lists each platform service with its installed version/commit/date (the service name doubles as its GitHub `owner/repo`).
  - `explore_github` — unauthenticated GET against the GitHub REST API, restricted to `/repos/...` paths, with size truncation and clear rate-limit / 404 handling. Its description carries curated endpoint examples and the tags-vs-releases fallback.
- `summarize-releases` action button on `/admin/info` that chains the two tools (bilingual prompt; hidden context drives the comparison).
- Pure helpers split into `releases-tools-logic.ts` and covered by unit tests (`tests/features/agent-tools/releases-tools.unit.spec.ts`).
- Updated `docs/architecture/agent-integration.md` (workflow §4.15, tool table,
  key files, tool count).

**Why:** give superadmins a one-click summary of which service releases are available but not yet deployed, answerable by the in-app assistant.

**Regression risks:**
- The two tools register unconditionally in the page setup (only the button is gated by `showAgentChat`), matching the existing `new-dataset.vue` pattern — they now register on every `/admin/info` visit.
- `explore_github` makes a browser-side call to `api.github.com` (CORS-enabled, unauthenticated, 60 req/hour per IP); no credentials sent, no new server surface.
- Verified locally: 9/9 unit tests pass, lint clean, no new type errors in the touched files, UI builds. End-to-end agent invocation not exercised (needs the  running agents service).
