### PR TITLE
fix(es): drop removed `local` param from getAlias calls for ES 9 compat

### DIFF
--- a/api/src/datasets/es/manage-indices.js
+++ b/api/src/datasets/es/manage-indices.js
@@ -76,13 +76,13 @@ export const updateDatasetMapping = async (dataset, oldDataset) => {
 const getAliases = async (dataset) => {
   let prodAlias
   try {
-    prodAlias = await es.client.indices.getAlias({ name: aliasName({ ...dataset, draftReason: null }), local: false })
+    prodAlias = await es.client.indices.getAlias({ name: aliasName({ ...dataset, draftReason: null }) })
   } catch (err) {
     if (err.statusCode !== 404) throw err
   }
   let draftAlias
   try {
-    draftAlias = await es.client.indices.getAlias({ name: aliasName({ ...dataset, draftReason: true }), local: false })
+    draftAlias = await es.client.indices.getAlias({ name: aliasName({ ...dataset, draftReason: true }) })
   } catch (err) {
     if (err.statusCode !== 404) throw err
   }


### PR DESCRIPTION
Drop the `local: false` argument from the two `getAlias` calls in `manage-indices.js`.

**Why:** Elasticsearch 9.0 removed the `local` query parameter from the Get-Alias API (deprecated and ignored since 8.12), so a 9.x cluster rejects our requests with `unrecognized parameter: [local]`. Production is on ES 9.x; the dev image (8.19.9) still accepts the param, which is why this wasn't caught locally.

**What changed:** Removed `local: false` from both `getAlias` calls. Since `local: false` is already the API default, this is a behavioral no-op on 8.x and restores compatibility on 9.x.

**Regression risks:**
- Behavior is unchanged on existing 8.x clusters (omitting `local` == `local: false`). No caller relied on `local: true`.
- A full scan of all `es.client.*` calls confirmed `local` was the only ES-9-breaking usage; nothing else in the API needs changes for this.

**Out of scope (follow-ups noted, not done here):** bumping the dev ES image to 9.x (no `data-fair/elasticsearch:9.x` image exists yet) and upgrading the `@elastic/elasticsearch` client from v8 to v9.
