### PR TITLE
feat(validation): surface rejected value in REST validation errors

### DIFF
--- a/api/src/datasets/utils/rest.ts
+++ b/api/src/datasets/utils/rest.ts
@@ -5,8 +5,7 @@ import crypto from 'node:crypto'
 import fs from 'fs-extra'
 import path from 'path'
 import { httpError } from '@data-fair/lib-utils/http-errors.js'
-import { ajv } from '@data-fair/data-fair-shared/ajv.js'
-import { errorsText } from '@data-fair/lib-validation'
+import { ajv, errorsText, localize } from '@data-fair/data-fair-shared/ajv.js'
 import { nanoid } from 'nanoid'
 import pump from '../../misc/utils/pipe.ts'
 import multer from 'multer'
@@ -508,10 +507,15 @@ export const applyTransactions = async (dataset: RestDataset, sessionState: Sess
       continue
     } if (validate) {
       if (!validate(operation.body)) {
+        // localize in place via the shared Proxy localizer (preserves user-provided
+        // errorMessage text), then build a value-aware message so the rejected value
+        // is visible even to a caller that only logs the returned validation errors.
+        localize.fr(validate.errors)
+        const message = errorsText(validate.errors, '', operation.body)
         if (dataset.nonBlockingValidation) {
-          operation._warning = errorsText(validate.errors, '')
+          operation._warning = message
         } else {
-          operation._error = errorsText(validate.errors, '')
+          operation._error = message
           operation._status = 400
           continue
         }

--- a/api/src/workers/batch-processor/process-file.ts
+++ b/api/src/workers/batch-processor/process-file.ts
@@ -3,6 +3,7 @@ import config from '#config'
 import * as journals from '../../misc/utils/journals.ts'
 import { jsonSchema } from '../../datasets/utils/data-schema.ts'
 import * as ajv from '../../misc/utils/ajv.ts'
+import { valueAtPointer } from '@data-fair/data-fair-shared/ajv.js'
 import pump from '../../misc/utils/pipe.ts'
 import { sendResourceEvent } from '../../misc/utils/notifications.ts'
 import * as datasetUtils from '../../datasets/utils/index.js'
@@ -55,7 +56,10 @@ class ValidateStream extends Writable {
     const writerErrors = rawErrors.length
       ? rawErrors.map(err => {
         const field = (err?.instancePath ?? '').replace(/^\//, '') || err?.params?.missingProperty || ''
-        const rawValue = field ? String((chunk as any)?.[field] ?? '') : ''
+        // resolve the actual rejected value via the JSON-pointer so nested/array
+        // paths (e.g. /attr3/1) are handled, not just top-level fields.
+        const resolved = valueAtPointer(chunk, err?.instancePath ?? '')
+        const rawValue = resolved === undefined ? '' : String(resolved)
         return {
           field,
           message: err?.message ?? JSON.stringify(err),

--- a/docs/architecture/dataset-validation.md
+++ b/docs/architecture/dataset-validation.md
@@ -74,7 +74,7 @@ REST datasets cannot use the file-dataset worker because writes are interactive.
 
 In `api/src/datasets/utils/rest.ts → applyTransactions`:
 
-1. Standard AJV schema validation runs first; rows that fail are flagged with `_status=400, _error='...'`.
+1. Standard AJV schema validation runs first; rows that fail are flagged with `_status=400, _error='...'`. The message is built with the **value-aware `errorsText`** from `shared/ajv.js`: each error is suffixed with ` (valeur : …)` — the rejected value resolved at the error's `instancePath` (JSON-pointer, so nested/array paths like `/attr3/1` work), truncated to 200 chars. This is the same debugging context the diagnostic CSV's `raw_value` column carries, and it matters for callers (e.g. a processing posting `_bulk_lines`) that log the returned validation errors but never the raw input. Errors are localized in place via the shared `localize` Proxy first, so a user-provided `errorMessage` is preserved (the previously-used `@data-fair/lib-validation` `errorsText` re-localized with the raw `ajv-i18n` localizer and dropped custom messages). `nonBlockingValidation` rows get the same enriched text in `_warning`.
 2. If the dataset has at least one `mandatory && active` extension, the surviving operations are passed through `extensionsUtils.extendBatchSync(dataset, mandatoryExtensions, lines, { onLineError })`.
 3. Lines whose mandatory extension fails get `_status=400` and are excluded from the bulk write. Lines that pass have their enriched fields copied back into `operation.fullBody` for persistence.
 4. The MongoDB bulk write proceeds with the survivors.
@@ -103,7 +103,7 @@ The `extend` worker (`api/src/workers/batch-processor/extend-rest.ts`) handles o
 
 ### Format
 
-UTF-8 with BOM, header row `line,error_type,field,message,raw_value`. `error_type` is `validation` or `extension`. `raw_value` is the offending field's source value, truncated to 200 chars and ending with `…` if truncated.
+UTF-8 with BOM, header row `line,error_type,field,message,raw_value`. `error_type` is `validation` or `extension`. `raw_value` is the offending field's source value, truncated to 200 chars and ending with `…` if truncated. It is resolved from the row via the error's `instancePath` (using `valueAtPointer` from `shared/ajv.js`), so nested/array paths such as `/multipattern/1` produce the actual element value rather than an empty cell.
 
 ### Lifecycle
 
@@ -162,7 +162,7 @@ For drafts opened with `validationMode: 'compatibleOrCancel'`, an attempt that p
 | `api/src/workers/batch-processor/process-file.ts` | Combined file-dataset validation + extension worker |
 | `api/src/workers/batch-processor/extend-rest.ts` | REST-only extension worker |
 | `api/types/dataset/schema.js` | `mandatory` field on the `remoteService` extension oneOf branch |
-| `shared/ajv.js` | `ajv-errors` integration + Proxy-wrapped localizer (preserves user `errorMessage` text) |
+| `shared/ajv.js` | `ajv-errors` integration + Proxy-wrapped localizer (preserves user `errorMessage` text); `valueAtPointer` JSON-pointer resolver and value-aware `errorsText` (optional `data` arg appends ` (valeur : …)`) shared by the REST hot path and the diagnostic CSV |
 
 ## Out of scope (follow-ups)
 

--- a/shared/ajv.js
+++ b/shared/ajv.js
@@ -32,25 +32,55 @@ export const localize = new Proxy(ajvI18n, {
   }
 })
 
+// resolve a JSON-pointer (e.g. "/attr3/1") against `data`, decoding the
+// standard ~1 -> "/" and ~0 -> "~" escapes. Returns undefined when the path
+// does not exist or when the pointer is empty (root).
+export const valueAtPointer = (data, pointer) => {
+  if (!pointer) return undefined
+  let cur = data
+  for (const rawKey of pointer.split('/').slice(1)) {
+    if (cur === null || cur === undefined) return undefined
+    const key = rawKey.replace(/~1/g, '/').replace(/~0/g, '~')
+    cur = cur[key]
+  }
+  return cur
+}
+
+// keywords whose "offending value" is not a single field value worth showing:
+// the value is the absence of a field (required/dependencies) or it is the
+// parent object rather than the bad value (additionalProperties names the key
+// in its params tail instead).
+const noValueKeywords = new Set(['required', 'additionalProperties', 'dependencies', 'dependentRequired'])
+
+const truncateValue = (str, max = 200) => str.length > max ? str.slice(0, max) + '…' : str
+
 // temporary duplicate from @data-fair/lib/types/validation.js
-export const errorsText = (errors, varName = '') => {
+// When `data` is provided, the value rejected at each error's instancePath is
+// appended as " (valeur : …)" — same debugging context the validation
+// diagnostic CSV carries, useful when the raw input is not otherwise available.
+export const errorsText = (errors, varName = '', data = undefined) => {
   if (!errors || errors.length === 0) return 'No errors'
   return errors
     .map((e) => {
       let msg = `${varName}${e.instancePath} ${e.message}`.trim()
       // ajv-errors emits an "errorMessage" keyword whose params carry the underlying
       // ajv errors — surfacing them as "(errors=…)" leaks the regex/internals to the
-      // user, so suppress the params tail in that case.
-      if (e.keyword === 'errorMessage') return msg
-      const paramKeys = Object.keys(e.params || {}).filter(key => {
-        if (key === 'error') return false
-        if (e.keyword === 'type' && key === 'type') return false
-        return true
-      })
-      const params = paramKeys
-        .map(key => paramKeys.length > 1 ? `${key}=${e.params[key]}` : e.params[key])
-        .join(', ')
-      if (params) msg += ` (${params})`
+      // user, so suppress the params tail in that case (but still show the value below).
+      if (e.keyword !== 'errorMessage') {
+        const paramKeys = Object.keys(e.params || {}).filter(key => {
+          if (key === 'error') return false
+          if (e.keyword === 'type' && key === 'type') return false
+          return true
+        })
+        const params = paramKeys
+          .map(key => paramKeys.length > 1 ? `${key}=${e.params[key]}` : e.params[key])
+          .join(', ')
+        if (params) msg += ` (${params})`
+      }
+      if (data !== undefined && e.instancePath && !noValueKeywords.has(e.keyword)) {
+        const value = valueAtPointer(data, e.instancePath)
+        if (value !== undefined) msg += ` (valeur : ${truncateValue(JSON.stringify(value))})`
+      }
       return msg
     })
     .reduce((text, msg) => text + ', ' + msg)

--- a/tests/features/datasets/rest/rest-datasets-crud.api.spec.ts
+++ b/tests/features/datasets/rest/rest-datasets-crud.api.spec.ts
@@ -282,7 +282,7 @@ test.describe('REST datasets - CRUD', () => {
     })
 
     await assert.rejects(ax.post('/api/v1/datasets/rest4/lines', { attr1: 111 }), (err: any) => {
-      assert.equal(err.data, '/attr1 doit être de type string')
+      assert.equal(err.data, '/attr1 doit être de type string (valeur : 111)')
       assert.equal(err.status, 400)
       return true
     })
@@ -290,13 +290,13 @@ test.describe('REST datasets - CRUD', () => {
     await ax.put('/api/v1/datasets/rest4/lines/line1', { attr1: 'test', attr2: 'test1' })
 
     await assert.rejects(ax.put('/api/v1/datasets/rest4/lines/line1', { attr1: 111 }), (err: any) => {
-      assert.equal(err.data, '/attr1 doit être de type string')
+      assert.equal(err.data, '/attr1 doit être de type string (valeur : 111)')
       assert.equal(err.status, 400)
       return true
     })
 
     await assert.rejects(ax.patch('/api/v1/datasets/rest4/lines/line1', { attr1: 111 }), (err: any) => {
-      assert.equal(err.data, '/attr1 doit être de type string')
+      assert.equal(err.data, '/attr1 doit être de type string (valeur : 111)')
       assert.equal(err.status, 400)
       return true
     })
@@ -322,7 +322,7 @@ test.describe('REST datasets - CRUD', () => {
     assert.equal(res.data.nbErrors, 1)
     assert.equal(res.data.errors.length, 1)
     assert.equal(res.data.errors[0].line, 1)
-    assert.equal(res.data.errors[0].error, '/attr1 doit être de type string')
+    assert.equal(res.data.errors[0].error, '/attr1 doit être de type string (valeur : 111)')
 
     let line = await ax.post('/api/v1/datasets/rest4/lines', { attr1: 'test', attr3: 'test1, test2' }).then(r => r.data)
     assert.equal(line.attr3, 'test1, test2')
@@ -358,7 +358,7 @@ test1,,"",valko`, { headers: { 'content-type': 'text/csv' } })
     assert.equal(res.data.errors[0].line, 2)
     assert.ok(res.data.errors[0].error.startsWith('/attr3/1 doit correspondre au format'))
     assert.equal(res.data.errors[1].line, 5)
-    assert.ok(res.data.errors[1].error.endsWith('/attr4 doit correspondre à exactement un schéma de "oneOf"'))
+    assert.ok(res.data.errors[1].error.includes('/attr4 doit correspondre à exactement un schéma de "oneOf"'))
 
     res = await ax.post('/api/v1/datasets/rest4/_bulk_lines', [
       { attr1: 'test1', attr2: 'test1', attr3: 'test1' },
@@ -410,7 +410,7 @@ test1,,"",valko`, { headers: { 'content-type': 'text/csv' } })
     assert.equal(res.data.nbWarnings, 1)
     assert.equal(res.data.warnings.length, 1)
     assert.equal(res.data.warnings[0].line, 1)
-    assert.equal(res.data.warnings[0].warning, '/attr1 doit être de type string')
+    assert.equal(res.data.warnings[0].warning, '/attr1 doit être de type string (valeur : 111)')
 
     await waitForFinalize(ax, 'rest4')
   })

--- a/tests/features/datasets/upload/file-validation.api.spec.ts
+++ b/tests/features/datasets/upload/file-validation.api.spec.ts
@@ -165,5 +165,13 @@ bidule,123,test3`, 'dataset1.csv')
     const errorEvent = journal.find((e: any) => e.type === 'validation-error')
     assert.ok(errorEvent)
     assert.ok(errorEvent.data.includes('/multipattern/1 doit correspondre au format'))
+
+    // the diagnostic CSV must carry the actual rejected value, resolved through
+    // the nested JSON-pointer (/multipattern/1), not an empty cell
+    assert.ok(errorEvent.hasDiagnosticFile)
+    const diagnostic = (await ax.get(`/api/v1/datasets/${dataset2.id}/validation-diagnostic.csv`)).data
+    const multipatternRow = diagnostic.split('\n').find((l: string) => l.includes('multipattern/1'))
+    assert.ok(multipatternRow, 'expected a diagnostic row for multipattern/1')
+    assert.ok(multipatternRow.includes('testko'), `raw_value should hold the rejected value, got: ${multipatternRow}`)
   })
 })

--- a/tests/features/infra/validation-errors-text.unit.spec.ts
+++ b/tests/features/infra/validation-errors-text.unit.spec.ts
@@ -1,0 +1,76 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { ajv, errorsText, localize, valueAtPointer } from '@data-fair/data-fair-shared/ajv.js'
+
+// helper: validate `data` against `schema`, localize errors in fr, return the
+// shared errorsText output (value-aware when `data` is passed through).
+const validateText = (schema: any, data: any) => {
+  const validate = ajv.compile(schema)
+  validate(data)
+  localize.fr(validate.errors)
+  return errorsText(validate.errors, '', data)
+}
+
+test.describe('value-aware errorsText', () => {
+  test('appends the offending value for a type error', () => {
+    const text = validateText(
+      { type: 'object', properties: { age: { type: 'number' } } },
+      { age: 'N/A' }
+    )
+    assert.equal(text, '/age doit être de type number (valeur : "N/A")')
+  })
+
+  test('does not append a value for a missing required property', () => {
+    const text = validateText(
+      { type: 'object', required: ['attr1'], properties: { attr1: { type: 'string' } } },
+      {}
+    )
+    // no `(valeur : …)` tail — the value is the absence of the field
+    assert.ok(!text.includes('valeur :'), text)
+  })
+
+  test('preserves a user-provided errorMessage and still shows the value', () => {
+    const text = validateText(
+      {
+        type: 'object',
+        properties: { code: { type: 'string', pattern: '^[A-Z]+$' } },
+        errorMessage: { properties: { code: 'doit être en majuscules' } }
+      },
+      { code: 'abc' }
+    )
+    assert.ok(text.includes('doit être en majuscules'), text)
+    assert.ok(text.includes('(valeur : "abc")'), text)
+  })
+
+  test('truncates an over-long value', () => {
+    const long = 'x'.repeat(500)
+    const text = validateText(
+      { type: 'object', properties: { age: { type: 'number' } } },
+      { age: long }
+    )
+    assert.ok(text.includes('…)'), text)
+    assert.ok(text.length < 300, `expected truncated, got length ${text.length}`)
+  })
+})
+
+test.describe('valueAtPointer', () => {
+  test('resolves a top-level field', () => {
+    assert.equal(valueAtPointer({ a: 1 }, '/a'), 1)
+  })
+
+  test('resolves a nested array element', () => {
+    assert.equal(valueAtPointer({ attr3: ['x', 'y'] }, '/attr3/1'), 'y')
+  })
+
+  test('returns undefined for a missing path', () => {
+    assert.equal(valueAtPointer({ a: { b: 1 } }, '/a/c'), undefined)
+  })
+
+  test('decodes JSON-pointer escapes (~1 -> /, ~0 -> ~)', () => {
+    assert.equal(valueAtPointer({ 'a/b': 1 }, '/a~1b'), 1)
+  })
+
+  test('returns undefined for an empty pointer', () => {
+    assert.equal(valueAtPointer({ a: 1 }, ''), undefined)
+  })
+})


### PR DESCRIPTION
REST writes returned only the core AJV message (e.g. `/attr1 doit être de type string`), so a caller posting `_bulk_lines` that logs the returned validation errors but never the raw input had no way to tell which value was rejected. This appends the offending value to the message and centralizes the formatting.

**Why:** make broken input debuggable when the raw input isn't available — the case of a processing that sends `_bulk_lines` and logs the validation errors but not the rows.

**What changed:**
- `shared/ajv.js`: add `valueAtPointer` (JSON-pointer resolver) and make `errorsText` value-aware via an optional `data` arg, appending ` (valeur : …)` (truncated to 200 chars). Backward compatible — no-`data` callers are unchanged.
- `rest.ts`: drop `@data-fair/lib-validation`'s `errorsText` (which re-localized and dropped user `errorMessage`); localize via the shared Proxy then build the value-aware message for `_error`/`_warning`.
- `process-file.ts`: resolve the diagnostic CSV `raw_value` through the JSON-pointer so nested/array paths (e.g. `/attr3/1`) are no longer empty cells.

**Regression risks:**
- `errorsText` is shared (`rest.ts`, `misc/utils/ajv.ts`, `expr-eval.js`); the `errorMessage` early-return was restructured but no-`data` output is byte-identical (verified by existing tests).
- REST validation error strings now carry a ` (valeur : …)` suffix — any external consumer exact-matching the old text would need updating. Internal callers and tests are updated.
