### PR TITLE
fix(ui): keep error detail line in notifications from embedded d-frames

### DIFF
--- a/ui/src/components/dataset/schema/dataset-schema-edit.vue
+++ b/ui/src/components/dataset/schema/dataset-schema-edit.vue
@@ -6,7 +6,7 @@
     :owner="owner ?? null"
     :active="!!conformsToActive"
     :disabled="!can('writeDescription')"
-    @update:model-value="v => emit('update:conformsTo', v)"
+    @update:model-value="(v: ConformsTo | null) => emit('update:conformsTo', v)"
   />
 
   <div class="d-flex align-center flex-wrap ga-2 mb-2">

--- a/ui/src/pages/admin-extra/[id].vue
+++ b/ui/src/pages/admin-extra/[id].vue
@@ -12,7 +12,7 @@
       :adapter.prop="stateChangeAdapter"
       @message="onMessage"
       @iframe-message="onMessage"
-      @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+      @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
     />
   </template>
   <v-container v-else>

--- a/ui/src/pages/admin/agents.vue
+++ b/ui/src/pages/admin/agents.vue
@@ -34,7 +34,7 @@
       emit-iframe-messages
       @message="onMessage"
       @iframe-message="onMessage"
-      @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+      @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
     />
   </div>
 </template>

--- a/ui/src/pages/admin/catalogs-plugins.vue
+++ b/ui/src/pages/admin/catalogs-plugins.vue
@@ -8,7 +8,7 @@
     :adapter.prop="stateChangeAdapter"
     @message="onMessage"
     @iframe-message="onMessage"
-    @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+    @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
   />
 </template>
 

--- a/ui/src/pages/admin/processings-plugins.vue
+++ b/ui/src/pages/admin/processings-plugins.vue
@@ -8,7 +8,7 @@
     :adapter.prop="stateChangeAdapter"
     @message="onMessage"
     @iframe-message="onMessage"
-    @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+    @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
   />
 </template>
 

--- a/ui/src/pages/api-doc.vue
+++ b/ui/src/pages/api-doc.vue
@@ -9,7 +9,7 @@
     :adapter.prop="stateChangeAdapter"
     @message="onMessage"
     @iframe-message="onMessage"
-    @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+    @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
   />
 </template>
 

--- a/ui/src/pages/application/[id]/api-doc.vue
+++ b/ui/src/pages/application/[id]/api-doc.vue
@@ -7,7 +7,7 @@
     sync-params
     emit-iframe-messages
     :adapter.prop="stateChangeAdapter"
-    @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+    @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
   />
 </template>
 

--- a/ui/src/pages/catalogs.vue
+++ b/ui/src/pages/catalogs.vue
@@ -10,7 +10,7 @@
     emit-iframe-messages
     @message="onMessage"
     @iframe-message="onMessage"
-    @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+    @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
   />
 </template>
 

--- a/ui/src/pages/dataset/[id]/api-doc.vue
+++ b/ui/src/pages/dataset/[id]/api-doc.vue
@@ -7,7 +7,7 @@
     sync-params
     emit-iframe-messages
     :adapter.prop="stateChangeAdapter"
-    @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+    @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
   />
 </template>
 

--- a/ui/src/pages/department.vue
+++ b/ui/src/pages/department.vue
@@ -10,7 +10,7 @@
     :adapter.prop="stateChangeAdapter"
     @message="onMessage"
     @iframe-message="onMessage"
-    @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+    @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
   />
   <v-container v-else>
     <v-alert type="error">

--- a/ui/src/pages/events.vue
+++ b/ui/src/pages/events.vue
@@ -10,7 +10,7 @@
     emit-iframe-messages
     @message="onMessage"
     @iframe-message="onMessage"
-    @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+    @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
   />
 </template>
 

--- a/ui/src/pages/extra/[id].vue
+++ b/ui/src/pages/extra/[id].vue
@@ -12,7 +12,7 @@
       :adapter.prop="stateChangeAdapter"
       @message="onMessage"
       @iframe-message="onMessage"
-      @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+      @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
     />
   </template>
   <v-container v-else>

--- a/ui/src/pages/me.vue
+++ b/ui/src/pages/me.vue
@@ -9,7 +9,7 @@
     :adapter.prop="stateChangeAdapter"
     @message="onMessage"
     @iframe-message="onMessage"
-    @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+    @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
   />
 </template>
 

--- a/ui/src/pages/metrics.vue
+++ b/ui/src/pages/metrics.vue
@@ -10,7 +10,7 @@
     emit-iframe-messages
     @message="onMessage"
     @iframe-message="onMessage"
-    @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+    @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
   />
 </template>
 

--- a/ui/src/pages/notifications.vue
+++ b/ui/src/pages/notifications.vue
@@ -6,7 +6,7 @@
     <d-frame
       :src="`${$sitePath}/events/embed/devices`"
       resize
-      @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+      @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
     />
 
     <h2 class="mt-8 mb-2 text-title-large">
@@ -17,7 +17,7 @@
     <d-frame
       :src="datasetsSubscribeUrl"
       resize
-      @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+      @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
     />
 
     <h2 class="mt-8 mb-2 text-title-large">
@@ -28,7 +28,7 @@
     <d-frame
       :src="appsSubscribeUrl"
       resize
-      @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+      @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
     />
 
     <template v-if="$uiConfig.portalsIntegration">
@@ -50,25 +50,25 @@
         <d-frame
           :src="selectedSite.subscribeUrl"
           resize
-          @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+          @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
         />
         <d-frame
           v-if="requestedDatasetPublicationSiteUrl"
           :src="requestedDatasetPublicationSiteUrl"
           resize
-          @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+          @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
         />
         <d-frame
           v-if="requestedApplicationPublicationSiteUrl"
           :src="requestedApplicationPublicationSiteUrl"
           resize
-          @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+          @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
         />
         <d-frame
           v-if="userCreationPublicationSiteUrl"
           :src="userCreationPublicationSiteUrl"
           resize
-          @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+          @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
         />
       </template>
     </template>

--- a/ui/src/pages/organization.vue
+++ b/ui/src/pages/organization.vue
@@ -10,7 +10,7 @@
     :adapter.prop="stateChangeAdapter"
     @message="onMessage"
     @iframe-message="onMessage"
-    @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+    @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
   />
   <v-container v-else>
     <v-alert type="error">

--- a/ui/src/pages/pages.vue
+++ b/ui/src/pages/pages.vue
@@ -10,7 +10,7 @@
     emit-iframe-messages
     @message="onMessage"
     @iframe-message="onMessage"
-    @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+    @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
   />
 </template>
 

--- a/ui/src/pages/portals.vue
+++ b/ui/src/pages/portals.vue
@@ -10,7 +10,7 @@
     emit-iframe-messages
     @message="onMessage"
     @iframe-message="onMessage"
-    @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+    @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
   />
 </template>
 

--- a/ui/src/pages/processings.vue
+++ b/ui/src/pages/processings.vue
@@ -10,7 +10,7 @@
     emit-iframe-messages
     @message="onMessage"
     @iframe-message="onMessage"
-    @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+    @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
   />
 </template>
 

--- a/ui/src/pages/remote-service/[id]/api-doc.vue
+++ b/ui/src/pages/remote-service/[id]/api-doc.vue
@@ -7,7 +7,7 @@
     sync-params
     emit-iframe-messages
     :adapter.prop="stateChangeAdapter"
-    @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+    @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
   />
 </template>
 

--- a/ui/src/pages/reuses.vue
+++ b/ui/src/pages/reuses.vue
@@ -10,7 +10,7 @@
     emit-iframe-messages
     @message="onMessage"
     @iframe-message="onMessage"
-    @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+    @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
   />
 </template>
 

--- a/ui/src/pages/subscription.vue
+++ b/ui/src/pages/subscription.vue
@@ -11,7 +11,7 @@
     emit-iframe-messages
     @message="onMessage"
     @iframe-message="onMessage"
-    @notif="(e: any) => sendUiNotif({ msg: e.detail.title || e.detail.detail, type: e.detail.type })"
+    @notif="(e: any) => sendUiNotif(frameNotifArg(e.detail))"
   />
 </template>
 

--- a/ui/src/utils/frame-notif.ts
+++ b/ui/src/utils/frame-notif.ts
@@ -1,0 +1,34 @@
+import type { UiNotif } from '@data-fair/lib-vue/ui-notif.js'
+
+// Re-emit a notification forwarded by an embedded <d-frame> sub-app
+// (catalogs, processings, ...) to the host's sendUiNotif.
+//
+// @data-fair/frame's convertVIframeUiNotif flattens the iframe message into
+// { type, title, detail }, turning client/server errors into type
+// 'warning' | 'error'. The naive handler { msg: title || detail, type } drops
+// `detail` whenever a title is present, so error notifications lose their
+// second (message) line once embedded.
+//
+// Here we rebuild the exact shape @data-fair/lib-vue produces for errors — see
+// useAsyncAction (`sendUiNotif(getFullNotif({ msg, error }))`) whose getFullNotif
+// error branch yields a UiNotifError { type: 'error', msg, errorMsg, clientError }
+// (the `error` object is stripped at the iframe boundary by sendUiNotif). Returning
+// that shape lets the host's getFullNotif keep `errorMsg`/`clientError` untouched and
+// the ui-notif component render both the title and the detail line.
+
+type FrameNotif = { type: string, title?: string, detail?: string }
+
+export const frameNotifArg = (notif: FrameNotif): UiNotif => {
+  if (notif.type === 'error' || notif.type === 'warning') {
+    return {
+      type: 'error',
+      msg: notif.title ?? '',
+      errorMsg: notif.detail ?? notif.title ?? '',
+      clientError: notif.type === 'warning'
+    }
+  }
+  return {
+    type: notif.type as 'default' | 'info' | 'success' | 'warning',
+    msg: notif.title ?? notif.detail ?? ''
+  }
+}


### PR DESCRIPTION
Error notifications forwarded by embedded `<d-frame>` sub-apps (catalogs, processings, events, api-doc, etc.) were losing their detail line.

`@data-fair/frame`'s `convertVIframeUiNotif` flattens the iframe message into `{ type, title, detail }`, mapping a client (4xx) error to `type: 'warning'` and a server (5xx) error to `type: 'error'`. The inline handler duplicated across every page — `{ msg: e.detail.title || e.detail.detail, type: e.detail.type }` — dropped `detail` whenever a `title` was present, so embedded error notifications rendered only their first line.

**What changed:**
- Add `ui/src/utils/frame-notif.ts` with `frameNotifArg`, which reverses `convertVIframeUiNotif`: it rebuilds the `UiNotif` error shape `@data-fair/lib-vue` expects (`{ type: 'error', msg, errorMsg, clientError }`), restoring `clientError` from the flattened `type` (`warning` → client 4xx, `error` → server 5xx). The host's ui-notif renderer only shows the detail line when `type === 'error'`, and still colors client errors as `warning`, so the visual severity is preserved while the message line is restored.
- Replace the duplicated inline `@notif` handler with `frameNotifArg(e.detail)` across all 21 pages that embed a `<d-frame>`.

**Why:** error notifications coming from embedded d-frames must keep their message line, not just the title.

**Regression risks:**
- Edge case: a sub-app emitting a genuine severity `warning` (not derived from an HTTP error) arrives as `{ type: 'warning', detail: undefined }` and is promoted to `type: 'error'` with `errorMsg` falling back to the title, which would render the title twice. In practice `@data-fair/lib` only produces warnings via `clientError`, so this path is not expected to trigger.
