### PR TITLE
feat(worker): make per-account concurrency limit configurable

### DIFF
--- a/api/config/custom-environment-variables.cjs
+++ b/api/config/custom-environment-variables.cjs
@@ -218,6 +218,10 @@ module.exports = {
       __name: 'WORKER_BASE_CONCURRENCY',
       __format: 'json'
     },
+    concurrencyLimitPerAccount: {
+      __name: 'WORKER_CONCURRENCY_LIMIT_PER_ACCOUNT',
+      __format: 'json'
+    },
     errorRetryDelay: {
       __name: 'WORKER_ERROR_RETRY_DELAY',
       __format: 'json'

--- a/api/config/default.cjs
+++ b/api/config/default.cjs
@@ -172,6 +172,10 @@ module.exports = {
     // base interval for polling the database for new resources to work on
     interval: 4000,
     baseConcurrency: 2,
+    // fraction (0-1) of a worker's slots a single account/owner may use concurrently.
+    // 1 = full concurrency (a single owner can use every slot, fair-allocation rules disabled), suitable for
+    // mono-organization deployments. Lower it (e.g. 0.5) on shared multi-organization deployments.
+    concurrencyLimitPerAccount: 1,
     errorRetryDelay: 600000, // 10 minutes
     closeTimeout: 60000 // 10 minutes to finish running tasks before shutting down
   },

--- a/api/config/type/schema.json
+++ b/api/config/type/schema.json
@@ -250,10 +250,11 @@
     },
     "worker": {
       "type": "object",
-      "required": ["interval", "baseConcurrency", "errorRetryDelay", "closeTimeout"],
+      "required": ["interval", "baseConcurrency", "concurrencyLimitPerAccount", "errorRetryDelay", "closeTimeout"],
       "properties": {
         "interval": { "type": "number" },
         "baseConcurrency": { "type": "number" },
+        "concurrencyLimitPerAccount": { "type": "number" },
         "errorRetryDelay": { "type": "number" },
         "closeTimeout": { "type": "number" }
       }

--- a/api/src/workers/concurrency.ts
+++ b/api/src/workers/concurrency.ts
@@ -1,0 +1,44 @@
+import { type AccountKeys } from '@data-fair/lib-express'
+
+const matchOwner = (o1: AccountKeys, o2: AccountKeys) => o1.type === o2.type && o1.id === o2.id
+
+/**
+ * Decide which owners must be excluded from grabbing a new slot on a worker,
+ * to enforce fair allocation between accounts.
+ *
+ * `concurrencyLimitPerAccount` is the fraction (0-1) of a worker's slots a single
+ * owner may use concurrently. At 1 (the default) the rules below are disabled and a
+ * single owner can use every slot, which suits small mono-organization deployments.
+ * Lower it (e.g. 0.5) on shared multi-organization deployments to keep an owner from
+ * monopolizing the workers.
+ *
+ * Pure function (no side effects, no module state) so it can be unit tested directly.
+ */
+export const computeExcludedOwners = (
+  maxConcurrency: number,
+  pending: { owner: AccountKeys }[],
+  concurrencyLimitPerAccount: number
+): AccountKeys[] => {
+  const excludedOwners: AccountKeys[] = []
+  if (maxConcurrency >= 2 && concurrencyLimitPerAccount < 1) {
+    // 1rst rule: prevent a owner from using more than their share of the available slots
+    const maxOwnerConcurrency = Math.floor(maxConcurrency * concurrencyLimitPerAccount)
+    for (const task of pending) {
+      if (!excludedOwners.some(o => matchOwner(o, task.owner))) {
+        const nbOwnerTasks = pending.filter(t => matchOwner(t.owner, task.owner)).length
+        if (nbOwnerTasks >= maxOwnerConcurrency) {
+          excludedOwners.push(task.owner)
+        }
+      }
+    }
+    // 2nd rule: prevent a owner who already has a running task from using the last slot
+    if (pending.length >= maxConcurrency - 1) {
+      for (const task of pending) {
+        if (!excludedOwners.some(o => matchOwner(o, task.owner))) {
+          excludedOwners.push(task.owner)
+        }
+      }
+    }
+  }
+  return excludedOwners
+}

--- a/api/src/workers/index.ts
+++ b/api/src/workers/index.ts
@@ -13,7 +13,7 @@ import * as ping from './ping.ts'
 import taskProgress from '../datasets/utils/task-progress.ts'
 import { Histogram, Gauge } from 'prom-client'
 import { internalError } from '@data-fair/lib-node/observer.js'
-import { type AccountKeys } from '@data-fair/lib-express'
+import { computeExcludedOwners } from './concurrency.ts'
 
 const debug = debugLib('workers')
 
@@ -49,37 +49,17 @@ export const hook = async (key: string) => {
   return newResource
 }
 
-const matchOwner = (o1: AccountKeys, o2: AccountKeys) => o1.type === o2.type && o1.id === o2.id
-
 const getWorkersStatus = () => {
   return (Object.keys(workers) as WorkerId[])
     .map(key => {
       const pending = pendingTasks[key] ?? {}
       const maxConcurrency = workers[key].options.maxThreads * workers[key].options.concurrentTasksPerWorker
       const currentConcurrency = Object.keys(pending).length
-      const excludedOwners: AccountKeys[] = []
-      if (maxConcurrency >= 2) {
-        // 1rst rule: prevent a owner from using more than half the available slots
-        const maxOwnerConcurrency = Math.floor(maxConcurrency / 2)
-        for (const task of Object.values(pending)) {
-          if (!excludedOwners.some(o => matchOwner(o, task.owner))) {
-            const nbOwnerTasks = Object.values(pending).filter(t => matchOwner(t.owner, task.owner)).length
-            if (nbOwnerTasks >= maxOwnerConcurrency) {
-              debug('owner uses more than half concurrency slots for worker, exclude them', key, task.owner)
-              excludedOwners.push(task.owner)
-            }
-          }
-        }
-        // 2nd rule: prevent a owner who already has a running task from using the last slot
-        if (Object.keys(pending).length >= maxConcurrency - 1) {
-          for (const task of Object.values(pending)) {
-            if (!excludedOwners.some(o => matchOwner(o, task.owner))) {
-              debug('owner uses a concurrency slot for worker and there is only one left, exclude them', key, task.owner)
-              excludedOwners.push(task.owner)
-            }
-          }
-        }
-      }
+      // concurrencyLimitPerAccount is the fraction (0-1) of a worker's slots a single owner may use.
+      // At 1 (the default) a single owner can use all the slots, which suits small mono-organization
+      // deployments. Lower it (e.g. 0.5) on shared multi-organization deployments. See ./concurrency.ts.
+      const excludedOwners = computeExcludedOwners(maxConcurrency, Object.values(pending), config.worker.concurrencyLimitPerAccount)
+      if (excludedOwners.length) debug('exclude owners from fair allocation on worker', key, excludedOwners)
       return { key, maxConcurrency, currentConcurrency, excludedOwners }
     })
 }

--- a/docs/architecture/dataset-processing.md
+++ b/docs/architecture/dataset-processing.md
@@ -106,9 +106,14 @@ Each worker type defines a MongoDB filter (see `api/src/workers/tasks.ts`) that 
 
 ### Fair allocation
 
-To prevent a single owner from monopolizing workers:
-- No owner can use more than **50%** of available slots
-- The last available slot is reserved for a different owner
+Fair allocation is controlled by the `worker.concurrencyLimitPerAccount` config (env var `WORKER_CONCURRENCY_LIMIT_PER_ACCOUNT`), the fraction of a worker's slots a single account/owner may use concurrently:
+
+- **`1` (default)** — full concurrency: a single owner can use every slot. The fair-allocation rules below are disabled. Suitable for small mono-organization deployments where all slots must be usable.
+- **`< 1` (e.g. `0.5`)** — on shared multi-organization deployments, to prevent a single owner from monopolizing workers:
+  - No owner can use more than that fraction (e.g. **50%**) of a worker's available slots
+  - The last available slot is reserved for a different owner
+
+These rules only apply to workers with at least 2 slots.
 
 ### Draft priority
 

--- a/tests/features/infra/worker-concurrency.unit.spec.ts
+++ b/tests/features/infra/worker-concurrency.unit.spec.ts
@@ -1,0 +1,68 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { computeExcludedOwners } from '../../../api/src/workers/concurrency.ts'
+
+// computeExcludedOwners decides which owners are barred from grabbing a new slot on a
+// worker, to enforce fair allocation between accounts. `concurrencyLimitPerAccount` is the
+// fraction (0-1) of a worker's slots a single owner may use; at 1 the rules are disabled.
+
+const owner = (id: string) => ({ type: 'organization' as const, id })
+const pendingFor = (...ids: string[]) => ids.map(id => ({ owner: owner(id) }))
+
+test.describe('computeExcludedOwners', () => {
+  test('ratio 1 (default): a single owner holding every slot is never excluded', () => {
+    // full-concurrency default — fair-allocation rules off, all slots usable by one owner
+    const pending = pendingFor('a', 'a', 'a', 'a')
+    assert.deepEqual(computeExcludedOwners(4, pending, 1), [])
+  })
+
+  test('ratio 1: no exclusions even when the worker is completely full', () => {
+    const pending = pendingFor('a', 'a', 'b', 'b')
+    assert.deepEqual(computeExcludedOwners(4, pending, 1), [])
+  })
+
+  test('ratio 0.5: owner reaching half the slots is excluded (rule 1)', () => {
+    // max 8 slots, half = 4. Owner "a" holds 4 -> excluded. Owner "b" holds 1 -> not.
+    const pending = pendingFor('a', 'a', 'a', 'a', 'b')
+    assert.deepEqual(computeExcludedOwners(8, pending, 0.5), [owner('a')])
+  })
+
+  test('ratio 0.5: owner just below half is not excluded', () => {
+    // max 8 slots, half = 4. Owner "a" holds 3 -> not excluded yet.
+    const pending = pendingFor('a', 'a', 'a', 'b')
+    assert.deepEqual(computeExcludedOwners(8, pending, 0.5), [])
+  })
+
+  test('ratio 0.5: an owner is only listed once even with several tasks over the limit', () => {
+    const pending = pendingFor('a', 'a', 'a', 'a', 'a')
+    assert.deepEqual(computeExcludedOwners(8, pending, 0.5), [owner('a')])
+  })
+
+  test('rule 2: with only the last slot free, owners already running are excluded', () => {
+    // max 4 slots, 3 used by distinct owners under the half-limit (floor(4*0.5)=2, none reach it),
+    // but only one slot remains -> reserve it for a different owner, so all running owners are excluded.
+    const pending = pendingFor('a', 'b', 'c')
+    assert.deepEqual(computeExcludedOwners(4, pending, 0.5), [owner('a'), owner('b'), owner('c')])
+  })
+
+  test('a very small ratio excludes any owner already running a task', () => {
+    // floor(5 * 0.1) = 0, so any owner holding >= 1 task is over its share. Documents that a ratio
+    // below 1/maxConcurrency limits every owner to a single concurrent task on that worker.
+    const pending = pendingFor('a', 'b')
+    assert.deepEqual(computeExcludedOwners(5, pending, 0.1), [owner('a'), owner('b')])
+  })
+
+  test('rules are disabled when a worker has fewer than 2 slots', () => {
+    const pending = pendingFor('a')
+    assert.deepEqual(computeExcludedOwners(1, pending, 0.5), [])
+  })
+
+  test('users and organizations with the same id are distinct owners', () => {
+    const pending = [
+      { owner: { type: 'user' as const, id: 'x' } },
+      { owner: { type: 'organization' as const, id: 'x' } }
+    ]
+    // max 4, half = 2, each "owner" holds only 1 -> neither excluded by rule 1; only 2 used so rule 2 off
+    assert.deepEqual(computeExcludedOwners(4, pending, 0.5), [])
+  })
+})


### PR DESCRIPTION
Make the worker's per-account concurrency limit configurable via `worker.concurrencyLimitPerAccount` (env `WORKER_CONCURRENCY_LIMIT_PER_ACCOUNT`), the fraction (0-1) of a worker's slots a single account may use concurrently. The fair-allocation decision is extracted into a pure `computeExcludedOwners()` with a unit test.

**Why:** most deployments are small mono-organization environments where all slots must be usable; the previous hardcoded half-slot limit made that impossible.

**Regression risks:**
- The default changes to `1` (full concurrency), which **disables both fair-allocation rules** (max-share and reserved-last-slot). Multi-organization deployments that relied on the old default now need `WORKER_CONCURRENCY_LIMIT_PER_ACCOUNT=0.5` to keep today's behavior.
- The infra env-var changes that pin koumoul's production/staging2/sandbox to `0.5` live in the separate `koumoul-infrastructure` repo and **must be deployed together** with this PR — otherwise those environments lose fair allocation on merge.
- At `0.5` the logic is equivalent to the previous hardcoded behavior (`floor(max * 0.5) === floor(max / 2)`), so setting that value is a no-op change.
