### PR TITLE
fix(s3): retry transient NoSuchKey on eventually-consistent providers

### DIFF
--- a/api/src/files-storage/s3-retry.ts
+++ b/api/src/files-storage/s3-retry.ts
@@ -1,0 +1,47 @@
+// Some S3-compatible providers (Ceph RGW, older MinIO, Garage, ...) do not
+// guarantee read-after-write consistency across distinct connections/processes:
+// an object written by the API process can transiently return NoSuchKey (404)
+// when read moments later by a worker. The AWS SDK only retries 5xx/throttling,
+// not 404s, so we absorb these transient misses at the application layer.
+
+export const isMissingError = (err: any): boolean => {
+  if (!err) return false
+  return err.name === 'NoSuchKey' || err.name === 'NotFound' || err.$metadata?.httpStatusCode === 404
+}
+
+type RetryOptions = {
+  attempts?: number
+  baseDelay?: number
+  maxDelay?: number
+  sleep?: (ms: number) => Promise<void>
+}
+
+const defaultSleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
+
+/**
+ * Run an S3 read operation, retrying with exponential backoff when it fails
+ * with a "missing" error (NoSuchKey / 404). Defaults to 5 attempts with delays
+ * of 2s, 4s, 8s, 16s (~30s total) before giving up to the caller — which, for
+ * worker tasks, is itself retried once by the worker error handler.
+ * Non-missing errors are thrown immediately without retrying.
+ */
+export const retryOnMissing = async <T> (fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> => {
+  const attempts = options.attempts ?? 5
+  const baseDelay = options.baseDelay ?? 2000
+  const maxDelay = options.maxDelay ?? 16000
+  const sleep = options.sleep ?? defaultSleep
+
+  let lastErr: any
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      if (!isMissingError(err)) throw err
+      lastErr = err
+      if (attempt < attempts - 1) {
+        await sleep(Math.min(maxDelay, baseDelay * Math.pow(2, attempt)))
+      }
+    }
+  }
+  throw lastErr
+}

--- a/api/src/files-storage/s3.ts
+++ b/api/src/files-storage/s3.ts
@@ -12,6 +12,7 @@ import debugModule from 'debug'
 import { S3ReadStream } from 's3-readstream'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
 import { HttpAgent, HttpsAgent } from 'agentkeepalive'
+import { retryOnMissing } from './s3-retry.ts'
 
 const debug = debugModule('s3')
 
@@ -107,13 +108,18 @@ export class S3Backend implements FileBackend {
     }
   }
 
-  async readStream (path: string, ifModifiedSince?: string, range?: string, slow?: boolean) {
+  async readStream (path: string, ifModifiedSince?: string, range?: string, slow?: boolean, retryMissing?: boolean) {
     debug('readStream', path)
     const ifModifiedSinceDate = ifModifiedSince ? new Date(ifModifiedSince) : undefined
 
     const bucketParams = { Bucket: config.s3.bucket, Key: bucketPath(path), IfModifiedSince: ifModifiedSinceDate, }
     try {
-      const headObject = await this.dataClient.send(new HeadObjectCommand(bucketParams))
+      // retryMissing is set by callers that just wrote the file and so expect it to exist;
+      // it absorbs read-after-write inconsistency on some S3 providers. It must stay off for
+      // client-facing reads where a 404 is a normal, must-stay-fast response.
+      const headObject = retryMissing
+        ? await retryOnMissing(() => this.dataClient.send(new HeadObjectCommand(bucketParams)))
+        : await this.dataClient.send(new HeadObjectCommand(bucketParams))
 
       // this shouldn't happen except if the s3 provider does not support conditional header
       if (ifModifiedSinceDate && Math.floor(headObject.LastModified!.getTime() / 1000) <= Math.floor(ifModifiedSinceDate.getTime() / 1000)) {
@@ -309,7 +315,9 @@ export class S3Backend implements FileBackend {
       Key: bucketPath(path),
       Range: 'bytes=0-' + (1024 * 1024)
     })
-    const response = await this.dataClient.send(command)
+    // fileSample is only ever called right after the file was written (storer / csv analysis),
+    // so retry transient NoSuchKey caused by read-after-write inconsistency on some S3 providers.
+    const response = await retryOnMissing(() => this.dataClient.send(command))
     return Buffer.from(await response.Body!.transformToByteArray())
   }
 }

--- a/api/src/files-storage/types.ts
+++ b/api/src/files-storage/types.ts
@@ -13,7 +13,7 @@ export type FileBackend = {
   fileStats (path: string): Promise<{ size: number, lastModified: Date }>
   removeFile(path: string): Promise<void>
   removeDir(path: string): Promise<void>
-  readStream(path: string, ifModifiedSince?: string, range?: string, slow?: boolean): Promise<{ body: Readable, size: number, lastModified: Date, range?: string }>
+  readStream(path: string, ifModifiedSince?: string, range?: string, slow?: boolean, retryMissing?: boolean): Promise<{ body: Readable, size: number, lastModified: Date, range?: string }>
   moveFromFs(tmpPath: string, path: string): Promise<void>
   writeStream(readStream: Readable, path: string): Promise<void>
   writeString(path: string, content: string): Promise<void>

--- a/api/src/workers/files-manager/store-file.ts
+++ b/api/src/workers/files-manager/store-file.ts
@@ -9,7 +9,6 @@ import { Transform } from 'node:stream'
 import split2 from 'split2'
 import pump from '../../misc/utils/pipe.ts'
 import debugLib from 'debug'
-import { internalError } from '@data-fair/lib-node/observer.js'
 import mongo from '#mongo'
 import type { DatasetInternal } from '#types'
 import filesStorage from '#files-storage'
@@ -29,13 +28,10 @@ export default async function (dataset: DatasetInternal) {
   if (datasetFile) {
     const loadedFilePath = datasetUtils.loadedFilePath(dataset)
 
-    if (!await filesStorage.pathExists(loadedFilePath)) {
-      // we should not have to do this
-      // this is a weird thing, maybe an unsolved race condition ?
-      // let's wait a bit and try again to mask this problem temporarily
-      internalError('storer-missing-file', 'file missing when storer started working ' + loadedFilePath)
-      await new Promise(resolve => setTimeout(resolve, 10000))
-    }
+    // the file was just written by the upload (a separate process), but some S3 providers
+    // do not guarantee read-after-write consistency across connections/processes: the reads
+    // below (fileSample, readStream with retryMissing, moveFile after them) absorb the
+    // transient NoSuchKey via the backend's retry-on-missing logic instead of failing here.
 
     // manage some special cases of invalid files
     // some ESRI files have invalid geojson with stuff like this:
@@ -46,7 +42,7 @@ export default async function (dataset: DatasetInternal) {
       await fs.ensureFile(fixedFile.path)
       const globalIdRegexp = /"GLOBALID": \{(.*)\}/g
       await pump(
-        (await filesStorage.readStream(loadedFilePath)).body,
+        (await filesStorage.readStream(loadedFilePath, undefined, undefined, undefined, true)).body,
         split2(),
         new Transform({
           objectMode: true,

--- a/tests/features/infra/s3-retry.unit.spec.ts
+++ b/tests/features/infra/s3-retry.unit.spec.ts
@@ -1,0 +1,76 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { retryOnMissing, isMissingError } from '../../../api/src/files-storage/s3-retry.ts'
+
+// Some S3-compatible providers do not guarantee read-after-write consistency
+// across distinct connections/processes: an object written by the API process
+// can transiently 404 (NoSuchKey) when read moments later by a worker. The AWS
+// SDK does not retry 404s, so we absorb these at the application layer.
+
+const noSleep = async () => {}
+
+const missingError = () => {
+  const err: any = new Error('The specified key does not exist.')
+  err.name = 'NoSuchKey'
+  err.$metadata = { httpStatusCode: 404 }
+  return err
+}
+
+test('isMissingError detects NoSuchKey / NotFound / 404, ignores others', () => {
+  assert.ok(isMissingError(missingError()))
+  assert.ok(isMissingError({ name: 'NotFound' }))
+  assert.ok(isMissingError({ $metadata: { httpStatusCode: 404 } }))
+  assert.ok(!isMissingError(new Error('boom')))
+  assert.ok(!isMissingError({ $metadata: { httpStatusCode: 500 } }))
+  assert.ok(!isMissingError(undefined))
+})
+
+test('retryOnMissing returns immediately on success without sleeping', async () => {
+  let sleeps = 0
+  const res = await retryOnMissing(async () => 'ok', { sleep: async () => { sleeps++ } })
+  assert.equal(res, 'ok')
+  assert.equal(sleeps, 0)
+})
+
+test('retryOnMissing retries transient NoSuchKey then succeeds', async () => {
+  let calls = 0
+  const sleeps: number[] = []
+  const res = await retryOnMissing(async () => {
+    calls++
+    if (calls < 3) throw missingError()
+    return 'ok'
+  }, { sleep: async (ms) => { sleeps.push(ms) } })
+  assert.equal(res, 'ok')
+  assert.equal(calls, 3)
+  assert.deepEqual(sleeps, [2000, 4000])
+})
+
+test('retryOnMissing gives up after the default attempts (~30s of backoff) and throws the last missing error', async () => {
+  let calls = 0
+  const sleeps: number[] = []
+  await assert.rejects(
+    retryOnMissing(async () => { calls++; throw missingError() }, { sleep: async (ms) => { sleeps.push(ms) } }),
+    (err: any) => err.name === 'NoSuchKey'
+  )
+  assert.equal(calls, 5)
+  assert.deepEqual(sleeps, [2000, 4000, 8000, 16000])
+  assert.equal(sleeps.reduce((a, b) => a + b, 0), 30000)
+})
+
+test('retryOnMissing does not retry non-missing errors', async () => {
+  let calls = 0
+  await assert.rejects(
+    retryOnMissing(async () => { calls++; throw new Error('boom') }, { sleep: noSleep }),
+    /boom/
+  )
+  assert.equal(calls, 1)
+})
+
+test('retryOnMissing honours a custom attempts count', async () => {
+  let calls = 0
+  await assert.rejects(
+    retryOnMissing(async () => { calls++; throw missingError() }, { attempts: 2, sleep: noSleep }),
+    (err: any) => err.name === 'NoSuchKey'
+  )
+  assert.equal(calls, 2)
+})


### PR DESCRIPTION
The loaded dataset file is written by the API process and read back by a separate worker process (`fileSample` → `GetObject`). Some S3-compatible providers (Ceph RGW, older MinIO, Garage…) don't guarantee read-after-write consistency across connections/processes, so the read transiently returns `NoSuchKey`. The AWS SDK never retries 404s, so the storer task crashed frequently on such deployments.

**Why:** recurring `NoSuchKey` failures in an on-premise deployment with a non-AWS S3 provider, surfacing as `[worker-task] The specified key does not exist.` from `S3Backend.fileSample`.

**What changed:**
- New `retryOnMissing` helper (5 attempts, ~30s exponential backoff: 2s/4s/8s/16s) retrying only on `NoSuchKey`/`NotFound`/404.
- `fileSample` always retries (its callers always read a just-written file).
- `readStream` retries only when the new opt-in `retryMissing` flag is set, so client-facing download 404s stay fast.
- Removed the unreliable `pathExists`+10s-sleep band-aid in the storer, now subsumed by the retrying reads.

**Regression risks:**
- `fileSample` on a genuinely-missing key now takes ~30s before throwing instead of failing fast (only affects error paths; both callers read just-written files).
- The `storer-missing-file` `internalError` signal is removed — any alert keyed on it goes silent (intended; it was noisy on eventually-consistent providers).
- `readStream` signature gains an optional 5th param; backward-compatible, `FsBackend` unaffected.
