### PR TITLE
feat(ui): paginate the dataset journal with a show more button

### DIFF
--- a/ui/src/components/journal-view.vue
+++ b/ui/src/components/journal-view.vue
@@ -64,15 +64,28 @@
       </template>
     </v-list-item>
   </v-list>
+  <div
+    v-if="visibleCount < filteredEvents.length"
+    class="text-center my-2"
+  >
+    <v-btn
+      variant="text"
+      @click="visibleCount += 100"
+    >
+      {{ t('showMore') }}
+    </v-btn>
+  </div>
 </template>
 
 <i18n lang="yaml">
 fr:
   draft: Brouillon
   downloadDiagnostic: Télécharger le diagnostic
+  showMore: Voir plus
 en:
   draft: Draft
   downloadDiagnostic: Download diagnostic
+  showMore: Show more
 </i18n>
 
 <script setup lang="ts">
@@ -106,13 +119,15 @@ const diagnosticDownloadHref = (event: Event) => {
 const eventTypes = eventsList[type]
 const draftEventTypes = eventsList[`${type}-draft`]
 
+const filteredEvents = computed(() => journal.filter(event => !!eventTypes[event.type] && (!after || event.date >= after)))
+
+const visibleCount = ref(10)
+
 const groupedEvents = computed(() => {
   const groups = []
   let currentGroup: { draft: boolean, events: Event[] } = { draft: false, events: [] }
-  const events = journal.filter(event => !!eventTypes[event.type])
 
-  for (const event of events) {
-    if (after && event.date < after) continue
+  for (const event of filteredEvents.value.slice(0, visibleCount.value)) {
     if (!!event.draft !== currentGroup.draft) {
       groups.push(currentGroup)
       currentGroup = { draft: !!event.draft, events: [] }


### PR DESCRIPTION
Render the dataset journal incrementally instead of dumping every event at once: 10 by default, then a "show more" button reveals 100 more per click. The journal endpoint already returns up to 1000 events in one response, so this is purely client-side — no extra requests.

**Why:** very long journals (datasets re-imported hundreds of times hit the endpoint's 1000-event cap) rendered every event upfront, which is heavy and hard to scan.

**Regression risks:**
- The `after`-date filter was refactored into a single predicate. Equivalent for events that have a `date`, but events *without* one are now filtered out when `after` is set (previously kept). Journal events normally always carry a date, so this should be inert.
