### PR TITLE
fix(agent): harden navigate filterQuery handling and lean out dataset_data

### DIFF
--- a/agent-tools/_utils.ts
+++ b/agent-tools/_utils.ts
@@ -96,6 +96,20 @@ export function buildFilterQueryString (params: { q?: string, filters?: Record<s
 }
 
 /**
+ * Consumer-side counterpart to buildFilterQueryString, for browser apps that feed a
+ * filterQuery into their `navigate` tool. The dataset_data subagent returns filterQuery as
+ * a complete query string and the caller is told to pass it verbatim, but LLMs sometimes
+ * wrap it as "filterQuery=<the whole query string>". Detect that single-param mistake and
+ * return the inner query string; otherwise return the input unchanged.
+ */
+export function unwrapFilterQuery (query: string | undefined): string | undefined {
+  if (!query) return query
+  const match = /^filterQuery=(.+)$/s.exec(query.trim())
+  if (!match) return query
+  try { return decodeURIComponent(match[1]) } catch { return match[1] }
+}
+
+/**
  * Format schema columns into markdown table rows.
  * Filters out internal columns (_i, _id, _rand).
  */

--- a/agent-tools/dataset-data-subagent.ts
+++ b/agent-tools/dataset-data-subagent.ts
@@ -3,18 +3,18 @@ import { filtersGuide } from './_utils.js'
 export const annotations = {
   fr: {
     title: 'Interroger les données d\'un jeu de données',
-    description: 'Interroger les lignes d\'un jeu de données, calculer des agrégations et explorer les valeurs des colonnes. Fournissez l\'identifiant du jeu de données et décrivez les données dont vous avez besoin.'
+    description: 'Interroger les lignes d\'un jeu de données, calculer des agrégations et explorer les valeurs des colonnes. Fournissez l\'identifiant du jeu de données et décrivez les données dont vous avez besoin ; si vous connaissez déjà les colonnes (clés et types), transmettez-les pour qu\'il interroge directement sans refaire un appel au schéma.'
   },
   en: {
     title: 'Query dataset data',
-    description: 'Query dataset rows, compute aggregations, and explore field values. Provide the dataset ID and describe what data you need.'
+    description: 'Query dataset rows, compute aggregations, and explore field values. Provide the dataset ID and describe what data you need; if you already know the columns (keys and types), pass them too so it can query directly without re-fetching the schema.'
   }
 } as const
 
 export const prompt = `You are a data analyst assistant for a data platform. You help users explore and understand datasets by querying their content.
 
 Workflow:
-1. Always call get_dataset_schema first to understand column names, types, and sample data before using other tools.
+1. Know the columns before querying — but don't fetch what you already have. If your task already lists the relevant column keys and types (the parent assistant usually provides them, since it has already inspected the dataset), trust that and issue your first query directly. Only call get_dataset_schema when you have no column information, are unsure of an exact key spelling, or need sample values. The query tools return a 400 error listing a column's valid operations whenever a filter/sort/metric is rejected, so starting optimistically and self-correcting is cheaper than always fetching the schema first.
 2. Choose the right tool for the task:
    - get_field_values: to discover distinct values of a column before filtering
    - search_data: to retrieve specific rows matching filters or text search. Do NOT use for statistics.

--- a/agent-tools/get-dataset-schema.ts
+++ b/agent-tools/get-dataset-schema.ts
@@ -7,7 +7,7 @@ export const annotations = {
 
 export const schema = {
   name: 'get_dataset_schema',
-  description: 'Get column schema and 3 sample rows for a dataset. Always call this first before querying data to understand the structure.',
+  description: 'Get column schema and 3 sample rows for a dataset. Call this when you do not already know the column keys and types — if they were provided to you (e.g. by the parent assistant), skip it and query directly. A rejected filter/sort/metric returns a 400 listing the column\'s valid operations, so you can self-correct without fetching the schema upfront.',
   inputSchema: {
     type: 'object' as const,
     properties: {

--- a/agent-tools/package.json
+++ b/agent-tools/package.json
@@ -2,7 +2,7 @@
   "name": "@data-fair/agent-tools-data-fair",
   "type": "module",
   "license": "AGPL-3.0-only",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "prepublishOnly": "npm run build"

--- a/docs/architecture/agent-integration.md
+++ b/docs/architecture/agent-integration.md
@@ -131,7 +131,7 @@ The user types directly in the chat drawer. The agent has access to all globally
 |---|---|
 | **Trigger** | Free chat or via filter/quality actions |
 | **Subagent** | `dataset_data` — data analyst that queries dataset content |
-| **Pattern** | Schema-first exploration: always reads schema before querying. Returns "Navigation params" for table filtering handoff, including the dataset `slug` (read from `get_dataset_schema`). |
+| **Pattern** | Optimistic exploration: queries directly when the parent already supplied column keys/types (it usually has them from `describe_dataset` or the current page), and only calls `get_dataset_schema` when it lacks column info or needs sample values — relying on the 400 "valid operations" errors to self-correct. Returns a "Context" block for table filtering handoff, including the dataset `slug`. |
 | **Tools** | `get_dataset_schema`, `search_data`, `aggregate_data`, `calculate_metric`, `get_field_values` |
 | **Source** | `ui/src/composables/dataset/agent-data-tools.ts` |
 
@@ -155,7 +155,7 @@ The capability → operation mapping is a single source of truth: `FILTER_CAPABI
 |---|---|
 | **Trigger** | Action button on dataset table toolbar |
 | **Action ID** | `help-filter-table` |
-| **Pattern** | **Subagent-to-navigation handoff**: asks user intent, delegates to `dataset_data` subagent, then uses `navigate` with query params to apply filters to the table page. Query params are reactively bound to the table's filter composable. |
+| **Pattern** | **Subagent-to-navigation handoff**: asks user intent, delegates to `dataset_data` subagent (passing the already-known table columns so it skips `get_dataset_schema`), then uses `navigate` with query params to apply filters to the table page. The subagent's `filterQuery` is passed as the `navigate` `query` string; `navigate` defensively unwraps the occasional `filterQuery=<whole query string>` mistake rather than relying on extra prompt warnings. Query params are reactively bound to the table's filter composable. |
 | **Source** | `ui/src/components/dataset/table/dataset-table.vue` |
 
 ### 4.4 Check Data Quality

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
     },
     "agent-tools": {
       "name": "@data-fair/agent-tools-data-fair",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "AGPL-3.0-only"
     },
     "api": {

--- a/ui/src/components/dataset/table/dataset-table.vue
+++ b/ui/src/components/dataset/table/dataset-table.vue
@@ -552,7 +552,8 @@ const filterHelpContext = computed(() => {
   const d = dataset.value
   if (!d) return ''
   const activeFilters = filters.value.map(f => `${f.property.title || f.property.key} ${f.operator} ${f.formattedValue || f.value}`).join(', ')
-  return `The user is viewing the table page of dataset "${d.title}" (id: ${d.id}).${activeFilters ? ` Active filters: ${activeFilters}.` : ' No filters are currently applied.'} Ask the user what data they want to see or filter before using the data exploration subagent. After exploring, use the navigate tool to apply filters to this table page: the dataset_data subagent includes in its Context a filterQuery (URL query string) and columns (relevant column keys). Use the filterQuery as the query parameter of the navigate tool, adding select=col1,col2,col3 from the columns keys.`
+  const columns = d.schema?.filter((f: any) => !['_i', '_id', '_rand'].includes(f.key)).map((f: any) => `${f.key} (${f.title || f.key}, ${f.type})`).join(', ')
+  return `The user is viewing the table page of dataset "${d.title}" (id: ${d.id}).${activeFilters ? ` Active filters: ${activeFilters}.` : ' No filters are currently applied.'} Ask the user what data they want to see or filter before using the data exploration subagent.${columns ? ` When you delegate to the dataset_data subagent, pass it these known columns so it can query directly without re-fetching the schema: ${columns}.` : ''} After exploring, use the navigate tool to apply filters to this table page: the dataset_data subagent includes in its Context a filterQuery (URL query string) and columns (relevant column keys). Use the filterQuery as the query parameter of the navigate tool, adding select=col1,col2,col3 from the columns keys.`
 })
 
 const dataQualityContext = computed(() => {

--- a/ui/src/composables/agent/navigation-tools.ts
+++ b/ui/src/composables/agent/navigation-tools.ts
@@ -1,6 +1,7 @@
 import type { ComputedRef, Ref } from 'vue'
 import type { RouteLocationNormalizedLoaded, Router } from 'vue-router'
 import { useAgentTool } from '@data-fair/lib-vue-agents'
+import { unwrapFilterQuery } from '@data-fair/agent-tools-data-fair/_utils'
 import { createAgentTranslator } from './utils'
 import type { NavGroup } from '~/composables/layout/use-navigation-items'
 import type { BreadcrumbItem } from '~/composables/layout/use-breadcrumbs'
@@ -130,7 +131,8 @@ export function useAgentNavigationTools ({ route, router, navigationGroups, brea
     },
     execute: async (params) => {
       try {
-        const query = params.query ? Object.fromEntries(new URLSearchParams(params.query as string)) : undefined
+        const queryString = unwrapFilterQuery(params.query as string | undefined)
+        const query = queryString ? Object.fromEntries(new URLSearchParams(queryString)) : undefined
         await router.push(query ? { path: params.path, query } : params.path)
         await new Promise(resolve => setTimeout(resolve, 500))
         const currentRoute = router.currentRoute.value


### PR DESCRIPTION
Improve the back-office AI agent integration based on two pieces of usage feedback, plus a small consolidation in the shared `agent-tools-data-fair` module.

**What changed:**
- `navigate` tolerates the model wrapping the `dataset_data` subagent's `filterQuery` value as `filterQuery=<whole query string>` — it unwraps that single-param mistake instead of navigating to a junk filter. Extracted as `unwrapFilterQuery` in `agent-tools/_utils.ts`, next to its producer `buildFilterQueryString`.
- `dataset_data` no longer always calls `get_dataset_schema` first: it trusts column keys/types the parent already provides and queries optimistically, self-correcting on the existing 400 "valid operations" errors. The "pass known columns" guidance lives in the subagent description (where the caller is instructed), and the `help-filter-table` action now feeds the real table columns into the delegation context.
- Released `@data-fair/agent-tools-data-fair` 0.6.0 so the new export can be consumed (a companion portals PR adopts `unwrapFilterQuery` from it).

**Why:** users observed the agent wrapping `filterQuery` as a literal parameter, and the `dataset_data` subagent burning a tool call + context re-fetching a schema the main assistant already had.

**Regression risks:**
- `unwrapFilterQuery` only rewrites a query string that is *entirely* a single `filterQuery=...` param; no data-fair table route uses a real `filterQuery` param, so it should fire only on the malformed shape it targets — worth a glance to confirm.
- `dataset_data` may now issue queries against parent-supplied column names without first reading the schema; if those names are wrong/stale the query 400s and the agent self-corrects, but the always-fetch guarantee is gone. The `data_quality_checker` subagent still reads the schema (unchanged).
