### PR TITLE
fix(virtual): pinpoint the faulty child in virtual dataset 501 errors

### DIFF
--- a/api/src/datasets/utils/virtual.ts
+++ b/api/src/datasets/utils/virtual.ts
@@ -142,11 +142,32 @@ const recurseDescendants = async (descendants: any[], dataset: Pick<VirtualDatas
   }, mongoOptions).toArray()
 
   if (children.length !== dataset.virtual.children.length) {
-    throw httpError(501, '[noretry] Le jeu de données virtuel ne peut pas être requêté, il utilise un jeu de données pour lequel ce compte n\'a pas de permission de lecture ou qui n\'existe plus.')
+    const foundIds = new Set(children.map(c => c.id))
+    const missingIds = dataset.virtual.children.filter(id => !foundIds.has(id))
+    // re-query the missing children ignoring the permissions filter to tell apart
+    // "the dataset does not exist anymore" from "it exists but is not readable by the
+    // account owning the virtual dataset" — and report exactly which child is at fault
+    const existingMissing = await mongo.datasets
+      .find({ id: { $in: missingIds } }, { projection: { id: 1, title: 1, owner: 1 } })
+      .toArray()
+    const existingMissingById = new Map(existingMissing.map(c => [c.id, c]))
+    const details = missingIds.map(id => {
+      const child = existingMissingById.get(id)
+      if (!child) return `le jeu de données "${id}" n'existe plus`
+      const owner = child.owner
+      const ownerLabel = owner.department
+        ? `${owner.type === 'user' ? 'utilisateur' : 'organisation'} "${owner.name}" / département "${owner.departmentName ?? owner.department}"`
+        : `${owner.type === 'user' ? 'utilisateur' : 'organisation'} "${owner.name}"`
+      return `le jeu de données "${child.title ?? id}" (${id}, propriété de ${ownerLabel}) n'est pas accessible en lecture par le compte propriétaire du jeu de données virtuel`
+    })
+    throw httpError(501, `[noretry] Le jeu de données virtuel "${dataset.id}" ne peut pas être requêté : ${details.join(' ; ')}.`)
   }
   for (const child of children) {
     if (child.isVirtual && (child.virtual?.filters?.length || child.virtual?.filterActiveAccount)) {
-      throw httpError(501, '[noretry] Le jeu de données virtuel ne peut pas être requêté, il utilise un autre jeu de données virtuel avec des filtres ce qui n\'est pas supporté.')
+      const filterKind = child.virtual?.filters?.length
+        ? `des filtres (${child.virtual.filters.map((f: any) => f.key).filter(Boolean).join(', ')})`
+        : 'un filtre sur le compte actif'
+      throw httpError(501, `[noretry] Le jeu de données virtuel "${dataset.id}" ne peut pas être requêté : il utilise le jeu de données virtuel enfant "${child.id}" qui définit ${filterKind}, ce qui n'est pas supporté.`)
     }
     if (child.isVirtual) {
       await recurseDescendants(descendants, child as VirtualDataset, mongoOptions)

--- a/api/src/datasets/utils/virtual.ts
+++ b/api/src/datasets/utils/virtual.ts
@@ -136,14 +136,17 @@ export const prepareSchema = async (dataset: VirtualDataset) => {
 const recurseDescendants = async (descendants: any[], dataset: Pick<VirtualDataset, 'id' | 'owner' | 'virtual'>, mongoOptions: any) => {
   const pseudoSessionState = getPseudoSessionState(dataset.owner, 'virtual-dataset', '_virtual-dataset', 'admin')
   const permissionsFilter = filterCan(pseudoSessionState, 'datasets', 'read')
+  // dedupe in case the same child is referenced twice, otherwise the count
+  // comparison below would wrongly report a missing/unreadable child
+  const childrenIds = [...new Set(dataset.virtual.children)]
   const children = await mongo.datasets.find({
-    id: { $in: dataset.virtual.children },
+    id: { $in: childrenIds },
     $or: permissionsFilter
   }, mongoOptions).toArray()
 
-  if (children.length !== dataset.virtual.children.length) {
+  if (children.length !== childrenIds.length) {
     const foundIds = new Set(children.map(c => c.id))
-    const missingIds = dataset.virtual.children.filter(id => !foundIds.has(id))
+    const missingIds = childrenIds.filter(id => !foundIds.has(id))
     // re-query the missing children ignoring the permissions filter to tell apart
     // "the dataset does not exist anymore" from "it exists but is not readable by the
     // account owning the virtual dataset" — and report exactly which child is at fault

--- a/tests/features/datasets/virtual/virtual-datasets-core.api.spec.ts
+++ b/tests/features/datasets/virtual/virtual-datasets-core.api.spec.ts
@@ -478,7 +478,9 @@ test.describe('virtual datasets core', () => {
 
     await assert.rejects(testUser3.get(`/api/v1/datasets/${res.data.id}/lines`), (err: any) => {
       assert.equal(err.status, 501)
-      assert.ok(err.data.includes('il utilise un jeu de données pour lequel ce compte n\'a pas de permission de lecture'))
+      // the error now pinpoints the exact child dataset that is not readable
+      assert.ok(err.data.includes(dataset.id))
+      assert.ok(err.data.includes('n\'est pas accessible en lecture par le compte propriétaire du jeu de données virtuel'))
       return true
     })
   })


### PR DESCRIPTION
Make the virtual-dataset "cannot be queried" 501 errors point to the exact child at fault instead of a generic message.

**Why:** complex virtual dataset configs were breaking with an opaque 501 ("uses a dataset this account can't read or that no longer exists"), with no way to tell which child or why.

**What changed:**
- Missing/unreadable child: re-query the missing ids without the permission filter to tell "doesn't exist anymore" apart from "exists but not readable by the owner account", and report each child's id/title/owner.
- Nested virtual dataset with filters: name the parent and child and which filter kind triggered it (static filters + field keys, or active-account filter).
- Both messages prefix the specific virtual dataset id at the failing recursion level, so nested chains are traceable.
- Dedupe child ids before the count check, so a child referenced twice no longer trips a false missing/unreadable error.

**Regression risks:**
- The user-facing 501 message text changed; one test assertion was updated to match. A repo-wide grep found no other code matching the old wording.
