### PR TITLE
fix(spa): resolve site-info hashes in dual-machine deployments

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -222,7 +222,15 @@ export const run = async () => {
           return directives
         }
       },
-      privateDirectoryUrl: config.privateDirectoryUrl
+      // serveSpa's getSiteHashes fetches `${privateDirectoryUrl}/simple-directory/api/sites/_hashes`
+      // to fill the {PUBLIC_SITE_INFO_HASH}/{THEME_CSS_HASH} placeholders in index.html.
+      // In a dual-machine deployment (data-fair split from simple-directory) privateDirectoryUrl
+      // is unset, so this fetch hit `null/...` and the SPA shipped the unresolved placeholders
+      // (the session util then throws "vuetifySessionOptions requires fetching site info").
+      // Fall back to the origin of the public directoryUrl — which the reverse proxy routes to
+      // simple-directory — mirroring the directoryUrl fallback already used by session.init and
+      // the jwks status check.
+      privateDirectoryUrl: config.privateDirectoryUrl || new URL(config.directoryUrl).origin
     }))
 
     server = (await import('http')).createServer(app)


### PR DESCRIPTION
## Problem

On a **dual-machine deployment** (data-fair running on a separate host from simple-directory, reached via the public reverse proxy), the back-office SPA ships a **blank page**. The browser console shows:

```
Error: vuetifySessionOptions requires fetching site info in session util
```

and `index.html` is served with the literal placeholders unresolved:

```html
<link href="{SITE_PATH}/simple-directory/api/sites/{THEME_CSS_HASH}_theme.css" rel="stylesheet">
<script src="{SITE_PATH}/simple-directory/api/sites/{PUBLIC_SITE_INFO_HASH}_public.js"></script>
```

(`{SITE_PATH}` resolves, but the two hashes don't.) The browser then requests `…/sites/{PUBLIC_SITE_INFO_HASH}_public.js`, which 404s, and the session util throws.

## Root cause

`@data-fair/lib-express` `serve-spa`'s `getSiteHashes` fills those hashes by fetching:

```
${privateDirectoryUrl}/simple-directory/api/sites/_hashes
```

`api/src/app.js` passes `privateDirectoryUrl: config.privateDirectoryUrl` to `serveSpa`. In a dual-machine setup there is no internal simple-directory origin, so `privateDirectoryUrl` is **unset (null)** — the fetch hits `null/simple-directory/api/sites/_hashes` and fails, leaving the placeholders unresolved.

Note that the other two consumers of the directory URL already handle this correctly by falling back to `directoryUrl`:
- `session.init(config.privateDirectoryUrl || config.directoryUrl)` (app.js)
- `jwksStatus`: `(config.privateDirectoryUrl || config.directoryUrl) + '/.well-known/jwks.json'` (admin/service.ts)

Only the `serveSpa` option was missing the fallback.

## Fix

Give `serveSpa` the same fallback — the **origin** of the public `directoryUrl` (origin, because `getSiteHashes` re-adds `/simple-directory`), which the reverse proxy routes to simple-directory:

```js
privateDirectoryUrl: config.privateDirectoryUrl || new URL(config.directoryUrl).origin
```

- **Monomachine / dev:** `privateDirectoryUrl` is set, so behaviour is unchanged.
- **Dual-machine:** falls back to e.g. `https://host` → `getSiteHashes` fetches `https://host/simple-directory/api/sites/_hashes` (200) and the hashes resolve.

## Validation

Reproduced on a real dual-machine deployment (data-fair 6.6.0 split from simple-directory 8.18.0): without the fix the SPA blank-pages with the unresolved `{PUBLIC_SITE_INFO_HASH}`; the resolved URL `https://host/simple-directory/api/sites/_hashes` returns `{ "publicInfo": "…", "themeCss": "…" }` as expected, confirming the fallback origin reaches simple-directory. Monomachine unaffected.