### PR TITLE
fix: connect elasticsearch in validateFile and manageTTL workers

### DIFF
--- a/api/src/workers/batch-processor/index.ts
+++ b/api/src/workers/batch-processor/index.ts
@@ -20,7 +20,9 @@ export const indexLines = async function (dataset: Dataset) {
 }
 
 export const validateFile = async function (dataset: FileDataset) {
-  await mongo.connect(true)
+  // es.connect is required because validateFile now also runs extensions (process-file.ts phase B),
+  // and local master-data extensions read from elasticsearch via es.client
+  await Promise.all([mongo.connect(true), es.connect()])
   await wsEmitter.init(mongo.db)
   await eventsQueue.start({ eventsUrl: config.privateEventsUrl, eventsSecret: config.secretKeys.events, inactive: !config.privateEventsUrl })
   const processFile = await import('./process-file.ts')

--- a/api/src/workers/short-processor/index.ts
+++ b/api/src/workers/short-processor/index.ts
@@ -20,7 +20,9 @@ export const renewApiKey = async function (dataset: DatasetInternal) {
 }
 
 export const manageTTL = async function (dataset: RestDataset) {
-  await mongo.connect(true)
+  // es.connect is required because applyTTL iterates elasticsearch hits (iterHits -> es.client)
+  // to find the expired lines to delete
+  await Promise.all([mongo.connect(true), es.connect()])
   const restUtils = await import('../../datasets/utils/rest.ts')
   return restUtils.applyTTL(dataset)
 }


### PR DESCRIPTION
Connect elasticsearch (not just mongo) in the `validateFile` and `manageTTL` worker entry points, which both reach `es.client` through their downstream code.

**Why:** production hit `db was not connected` (thrown by the `es.client` getter) in the `validateFile` worker. `validateFile` runs phase-B extensions (`process-file.ts`), and local master-data extensions query elasticsearch via `es.client`. An audit of all worker entries found the same latent bug in `manageTTL`, whose `applyTTL` iterates ES hits (`iterHits` → `es.client.search`). Both were introduced when extension/TTL work moved into these entries but `es.connect()` was not added; they were masked in practice (and in CI) because the single worker thread is usually kept warm by sibling tasks (`extend`/`indexLines`/`finalize`) that do connect es, so the failure only surfaces on a cold/recycled thread.

**Regression risks:**
- Both workers now open an ES connection (connect + ping) per task invocation. This mirrors the existing `extend`/`indexLines`/`finalize` workers exactly, so it's consistent with current behavior — only flag is the marginal per-task connect cost where there previously was none.
- No public API, signature, or default changes; no callers affected.
