### PR TITLE
fix(rate-limiting): throttle api-key requests at the user tier

### DIFF
--- a/api/src/api-compat/ods/index.ts
+++ b/api/src/api-compat/ods/index.ts
@@ -9,6 +9,7 @@ import { Counter } from 'prom-client'
 import { getFlatten } from '../../datasets/utils/flatten.ts'
 import config from '#config'
 import datasetsRouter, { apiKeyMiddlewareRead } from '../../datasets/router.js'
+import * as rateLimiting from '../../misc/utils/rate-limiting.ts'
 import { parse as parseWhere } from './where.peg.js'
 import { parse as parseSelect } from './select.peg.js'
 import { parse as parseOrderBy } from './order-by.peg.js'
@@ -643,6 +644,7 @@ router.get(
   '/v2.1/catalog/datasets/:datasetId/records',
   readDataset({ fillDescendants: true }),
   apiKeyMiddlewareRead,
+  rateLimiting.middleware,
   permissions.middleware('readCompatODSRecords', 'read', 'readDataAPI'),
   cacheNowMiddleware,
   cacheHeaders.resourceBased('finalizedAt'),
@@ -652,6 +654,7 @@ router.get(
   '/v2.0/catalog/datasets/:datasetId/records',
   readDataset({ fillDescendants: true }),
   apiKeyMiddlewareRead,
+  rateLimiting.middleware,
   permissions.middleware('readCompatODSRecords', 'read', 'readDataAPI'),
   cacheNowMiddleware,
   cacheHeaders.resourceBased('finalizedAt'),
@@ -661,6 +664,7 @@ router.get(
   '/v2.1/catalog/datasets/:datasetId/exports/:format',
   readDataset({ fillDescendants: true }),
   apiKeyMiddlewareRead,
+  rateLimiting.middleware,
   permissions.middleware('readCompatODSExports', 'read', 'readDataAPI'),
   cacheHeaders.noCache,
   exports('2.1')
@@ -669,6 +673,7 @@ router.get(
   '/v2.0/catalog/datasets/:datasetId/exports/:format',
   readDataset({ fillDescendants: true }),
   apiKeyMiddlewareRead,
+  rateLimiting.middleware,
   permissions.middleware('readCompatODSExports', 'read', 'readDataAPI'),
   cacheHeaders.noCache,
   exports('2.0')
@@ -679,6 +684,7 @@ datasetsRouter.get(
   '/:datasetId/compat-ods/records',
   readDataset({ fillDescendants: true }),
   apiKeyMiddlewareRead,
+  rateLimiting.middleware,
   permissions.middleware('readCompatODSRecords', 'read', 'readDataAPI'),
   cacheNowMiddleware,
   cacheHeaders.resourceBased('finalizedAt'),
@@ -688,6 +694,7 @@ datasetsRouter.get(
   '/:datasetId/compat-ods/exports/:format',
   readDataset({ fillDescendants: true }),
   apiKeyMiddlewareRead,
+  rateLimiting.middleware,
   permissions.middleware('readCompatODSExports', 'read', 'readDataAPI'),
   cacheNowMiddleware,
   cacheHeaders.resourceBased('finalizedAt'),

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -41,7 +41,6 @@ export const run = async () => {
 
   if (config.mode.includes('server')) {
     const limits = await import('./limits/router.ts')
-    const rateLimiting = await import('./misc/utils/rate-limiting.ts')
     const { session } = await import('@data-fair/lib-express/index.js')
     const { reqIsInternal, reqHost, createSiteMiddleware } = await import('@data-fair/lib-express/index.js')
     session.init(config.privateDirectoryUrl || config.directoryUrl)
@@ -144,7 +143,9 @@ export const run = async () => {
     app.use('/api/v1/catalog', apiKey(['datasets', 'datasets-read']), (await import('./catalog/router.js')).default)
     app.use('/api/v1/base-applications', (await import('./base-applications/router.ts')).router)
     app.use('/api/v1/applications', apiKey('applications'), (await import('./applications/router.js')).default)
-    app.use('/api/v1/datasets', rateLimiting.middleware(), (await import('./datasets/router.js')).default)
+    // rate limiting is applied per-route inside the datasets router, after the api-key middleware, so that
+    // requests authenticated with an api key are throttled at the `user` tier rather than as anonymous
+    app.use('/api/v1/datasets', (await import('./datasets/router.js')).default)
     app.use('/api/v1/stats', apiKey('stats'), (await import('./stats/router.ts')).default)
     app.use('/api/v1/settings', (await import('./settings/router.ts')).default)
     app.use('/api/v1/admin', (await import('./admin/router.js')).default)
@@ -152,7 +153,7 @@ export const run = async () => {
     app.use('/api/v1/activity', (await import('./activity/router.js')).default)
     app.use('/api/v1/limits', limits.router)
     if (config.compatODS) {
-      app.use('/api/v1/compat-ods', rateLimiting.middleware(), (await import('./api-compat/ods/index.ts')).default)
+      app.use('/api/v1/compat-ods', (await import('./api-compat/ods/index.ts')).default)
     }
     if (process.env.NODE_ENV === 'development') {
       app.use('/api/v1/test-env', (await import('./misc/routers/test-env.ts')).default)

--- a/api/src/datasets/router.js
+++ b/api/src/datasets/router.js
@@ -44,6 +44,7 @@ import * as observe from '../misc/utils/observe.ts'
 import * as publicationSites from '../misc/utils/publication-sites.ts'
 import * as clamav from '../misc/utils/clamav.ts'
 import * as apiKeyUtils from '../misc/utils/api-key.ts'
+import * as rateLimiting from '../misc/utils/rate-limiting.ts'
 import { syncDataset as syncRemoteService } from '../remote-services/service.ts'
 import { findDatasets, applyPatch, deleteDataset, createDataset, memoizedGetDataset, cancelDraft } from './service.js'
 import { tableSchema, jsonSchema, getSchemaBreakingChanges, filterSchema } from './utils/data-schema.ts'
@@ -85,7 +86,7 @@ router.use((req, res, next) => {
 })
 
 // Get the list of datasets
-router.get('', apiKeyMiddlewareRead, cacheHeaders.listBased, async (req, res) => {
+router.get('', apiKeyMiddlewareRead, rateLimiting.middleware, cacheHeaders.listBased, async (req, res) => {
   // @ts-ignore
   const publicationSite = req.publicationSite
   // @ts-ignore
@@ -99,13 +100,13 @@ router.get('', apiKeyMiddlewareRead, cacheHeaders.listBased, async (req, res) =>
   res.json(response)
 })
 
-router.use('/:datasetId/permissions', readDataset({ noCache: true }), apiKeyMiddlewareAdmin, permissions.router('datasets', 'dataset', async (req, patchedDataset) => {
+router.use('/:datasetId/permissions', readDataset({ noCache: true }), apiKeyMiddlewareAdmin, rateLimiting.middleware, permissions.router('datasets', 'dataset', async (req, patchedDataset) => {
   // this callback function is called when the resource becomes public
   await publicationSites.onPublic(patchedDataset, 'datasets', reqSessionAuthenticated(req))
 }))
 
 // retrieve a dataset by its id
-router.get('/:datasetId', readDataset({ acceptInitialDraft: true, noCache: true }), apiKeyMiddlewareRead, applicationKey, permissions.middleware('readDescription', 'read'), cacheHeaders.noCache, (req, res, next) => {
+router.get('/:datasetId', readDataset({ acceptInitialDraft: true, noCache: true }), apiKeyMiddlewareRead, rateLimiting.middleware, applicationKey, permissions.middleware('readDescription', 'read'), cacheHeaders.noCache, (req, res, next) => {
   // @ts-ignore
   const dataset = clone(req.dataset)
   res.status(200).send(clean(req, dataset))
@@ -127,11 +128,11 @@ const sendSchema = (req, res, schema) => {
   }
   res.status(200).send(schema)
 }
-router.get('/:datasetId/schema', readDataset(), apiKeyMiddlewareRead, applicationKey, permissions.middleware('readSchema', 'read'), cacheHeaders.noCache, (req, res, next) => {
+router.get('/:datasetId/schema', readDataset(), apiKeyMiddlewareRead, rateLimiting.middleware, applicationKey, permissions.middleware('readSchema', 'read'), cacheHeaders.noCache, (req, res, next) => {
   sendSchema(req, res, clone(req.dataset.schema))
 })
 // alternate read schema route that does not return clues about the data (cardinality and enums)
-router.get('/:datasetId/safe-schema', readDataset(), apiKeyMiddlewareRead, applicationKey, permissions.middleware('readSafeSchema', 'read'), cacheHeaders.noCache, (req, res, next) => {
+router.get('/:datasetId/safe-schema', readDataset(), apiKeyMiddlewareRead, rateLimiting.middleware, applicationKey, permissions.middleware('readSafeSchema', 'read'), cacheHeaders.noCache, (req, res, next) => {
   const schema = clone(req.dataset.schema)
   for (const p of schema) {
     delete p['x-cardinality']
@@ -174,7 +175,7 @@ router.patch('/:datasetId',
       }
     }
   }),
-  apiKeyMiddlewareWrite,
+  apiKeyMiddlewareWrite, rateLimiting.middleware,
   lockDataset((/** @type {any} */ patch) => {
     return !!(patch.schema || patch.virtual || patch.extensions || patch.publications || patch.projection)
   }),
@@ -236,7 +237,7 @@ router.patch('/:datasetId',
   })
 
 // Change ownership of a dataset
-router.put('/:datasetId/owner', readDataset({ noCache: true }), apiKeyMiddlewareAdmin, permissions.middleware('changeOwner', 'admin'), async (req, res) => {
+router.put('/:datasetId/owner', readDataset({ noCache: true }), apiKeyMiddlewareAdmin, rateLimiting.middleware, permissions.middleware('changeOwner', 'admin'), async (req, res) => {
   // @ts-ignore
   const dataset = req.dataset
 
@@ -337,7 +338,7 @@ router.put('/:datasetId/owner', readDataset({ noCache: true }), apiKeyMiddleware
 })
 
 // Delete a dataset
-router.delete('/:datasetId', readDataset({ acceptedStatuses: ['*'], alwaysDraft: true }), apiKeyMiddlewareAdmin, permissions.middleware('delete', 'admin'), async (req, res) => {
+router.delete('/:datasetId', readDataset({ acceptedStatuses: ['*'], alwaysDraft: true }), apiKeyMiddlewareAdmin, rateLimiting.middleware, permissions.middleware('delete', 'admin'), async (req, res) => {
   // @ts-ignore
   const dataset = req.dataset
   // @ts-ignore
@@ -454,7 +455,7 @@ const createDatasetRoute = async (req, res) => {
     throw err
   }
 }
-router.post('', apiKeyMiddlewareWrite, checkStorage(true, true), createDatasetRoute)
+router.post('', apiKeyMiddlewareWrite, rateLimiting.middleware, checkStorage(true, true), createDatasetRoute)
 
 const updateDatasetRoute = async (req, res, next) => {
   // deep clone to allow mutation by applyPatch (req.dataset may be an immutable proxy from cache)
@@ -547,12 +548,12 @@ const updateDatasetRoute = async (req, res, next) => {
   res.status(200).json(clean(req, dataset))
 }
 
-router.post('/:datasetId', lockDataset(), readDataset({ acceptedStatuses: ['finalized', 'error'], acceptMissing: true }), apiKeyMiddlewareWrite, permissions.middleware('writeData', 'write', null, true), checkStorage(true, true), updateDatasetRoute)
-router.put('/:datasetId', lockDataset(), readDataset({ acceptedStatuses: ['finalized', 'error'], acceptMissing: true }), apiKeyMiddlewareWrite, permissions.middleware('writeData', 'write', null, true), checkStorage(true, true), updateDatasetRoute)
+router.post('/:datasetId', lockDataset(), readDataset({ acceptedStatuses: ['finalized', 'error'], acceptMissing: true }), apiKeyMiddlewareWrite, rateLimiting.middleware, permissions.middleware('writeData', 'write', null, true), checkStorage(true, true), updateDatasetRoute)
+router.put('/:datasetId', lockDataset(), readDataset({ acceptedStatuses: ['finalized', 'error'], acceptMissing: true }), apiKeyMiddlewareWrite, rateLimiting.middleware, permissions.middleware('writeData', 'write', null, true), checkStorage(true, true), updateDatasetRoute)
 
 // validate the draft
 // TODO: apply different permission if draft has breaking changes or not
-router.post('/:datasetId/draft', readDataset({ acceptedStatuses: ['finalized'], alwaysDraft: true }), apiKeyMiddlewareWrite, permissions.middleware('validateDraft', 'write'), lockDataset(), async (req, res, next) => {
+router.post('/:datasetId/draft', readDataset({ acceptedStatuses: ['finalized'], alwaysDraft: true }), apiKeyMiddlewareWrite, rateLimiting.middleware, permissions.middleware('validateDraft', 'write'), lockDataset(), async (req, res, next) => {
   const dataset = clone(req.dataset)
   const sessionState = reqSession(req)
 
@@ -570,7 +571,7 @@ router.post('/:datasetId/draft', readDataset({ acceptedStatuses: ['finalized'], 
 })
 
 // cancel the draft
-router.delete('/:datasetId/draft', readDataset({ acceptedStatuses: ['draft', 'finalized', 'error'], alwaysDraft: true }), apiKeyMiddlewareWrite, permissions.middleware('cancelDraft', 'write'), lockDataset(), async (req, res, next) => {
+router.delete('/:datasetId/draft', readDataset({ acceptedStatuses: ['draft', 'finalized', 'error'], alwaysDraft: true }), apiKeyMiddlewareWrite, rateLimiting.middleware, permissions.middleware('cancelDraft', 'write'), lockDataset(), async (req, res, next) => {
   const dataset = clone(req.dataset)
   const sessionState = reqSession(req)
   const datasetFull = clone(req.datasetFull)
@@ -604,19 +605,19 @@ function isRest (req, res, next) {
 }
 
 const readWritableDataset = readDataset({ acceptedStatuses: ['finalized', 'indexed', 'error'] })
-router.get('/:datasetId/lines/:lineId', readDataset(), isRest, apiKeyMiddlewareRead, permissions.middleware('readLine', 'read', 'readDataAPI'), cacheHeaders.noCache, restDatasetsUtils.readLine)
-router.post('/:datasetId/lines', readWritableDataset, isRest, applicationKey, apiKeyMiddlewareWrite, permissions.middleware('createLine', 'write'), checkStorage(false), restDatasetsUtils.uploadAttachment, restDatasetsUtils.fixFormBody, uploadUtils.fsyncFiles, clamav.middleware, restDatasetsUtils.createOrUpdateLine)
-router.put('/:datasetId/lines/:lineId', readWritableDataset, isRest, apiKeyMiddlewareWrite, permissions.middleware('updateLine', 'write'), checkStorage(false), restDatasetsUtils.uploadAttachment, restDatasetsUtils.fixFormBody, uploadUtils.fsyncFiles, clamav.middleware, restDatasetsUtils.createOrUpdateLine)
-router.patch('/:datasetId/lines/:lineId', readWritableDataset, isRest, apiKeyMiddlewareWrite, permissions.middleware('patchLine', 'write'), checkStorage(false), restDatasetsUtils.uploadAttachment, restDatasetsUtils.fixFormBody, uploadUtils.fsyncFiles, clamav.middleware, restDatasetsUtils.patchLine)
-router.post('/:datasetId/_bulk_lines', readWritableDataset, isRest, apiKeyMiddlewareWrite, permissions.middleware('bulkLines', 'write'), lockDataset((body, query) => query.lock === 'true'), checkStorage(false), restDatasetsUtils.uploadBulk, restDatasetsUtils.bulkLines)
-router.delete('/:datasetId/lines/:lineId', readWritableDataset, isRest, apiKeyMiddlewareWrite, permissions.middleware('deleteLine', 'write'), restDatasetsUtils.deleteLine)
-router.get('/:datasetId/lines/:lineId/revisions', readWritableDataset, isRest, apiKeyMiddlewareRead, permissions.middleware('readLineRevisions', 'read', 'readDataAPI'), cacheHeaders.noCache, restDatasetsUtils.readRevisions)
-router.get('/:datasetId/revisions', readWritableDataset, isRest, apiKeyMiddlewareRead, permissions.middleware('readRevisions', 'read', 'readDataAPI'), cacheHeaders.noCache, restDatasetsUtils.readRevisions)
-router.delete('/:datasetId/lines', readWritableDataset, isRest, apiKeyMiddlewareWrite, permissions.middleware('deleteAllLines', 'write'), restDatasetsUtils.deleteAllLines)
-router.post('/:datasetId/_sync_attachments_lines', readWritableDataset, isRest, apiKeyMiddlewareWrite, permissions.middleware('bulkLines', 'write'), lockDataset((body, query) => query.lock === 'true'), restDatasetsUtils.syncAttachmentsLines)
+router.get('/:datasetId/lines/:lineId', readDataset(), isRest, apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('readLine', 'read', 'readDataAPI'), cacheHeaders.noCache, restDatasetsUtils.readLine)
+router.post('/:datasetId/lines', readWritableDataset, isRest, applicationKey, apiKeyMiddlewareWrite, rateLimiting.middleware, permissions.middleware('createLine', 'write'), checkStorage(false), restDatasetsUtils.uploadAttachment, restDatasetsUtils.fixFormBody, uploadUtils.fsyncFiles, clamav.middleware, restDatasetsUtils.createOrUpdateLine)
+router.put('/:datasetId/lines/:lineId', readWritableDataset, isRest, apiKeyMiddlewareWrite, rateLimiting.middleware, permissions.middleware('updateLine', 'write'), checkStorage(false), restDatasetsUtils.uploadAttachment, restDatasetsUtils.fixFormBody, uploadUtils.fsyncFiles, clamav.middleware, restDatasetsUtils.createOrUpdateLine)
+router.patch('/:datasetId/lines/:lineId', readWritableDataset, isRest, apiKeyMiddlewareWrite, rateLimiting.middleware, permissions.middleware('patchLine', 'write'), checkStorage(false), restDatasetsUtils.uploadAttachment, restDatasetsUtils.fixFormBody, uploadUtils.fsyncFiles, clamav.middleware, restDatasetsUtils.patchLine)
+router.post('/:datasetId/_bulk_lines', readWritableDataset, isRest, apiKeyMiddlewareWrite, rateLimiting.middleware, permissions.middleware('bulkLines', 'write'), lockDataset((body, query) => query.lock === 'true'), checkStorage(false), restDatasetsUtils.uploadBulk, restDatasetsUtils.bulkLines)
+router.delete('/:datasetId/lines/:lineId', readWritableDataset, isRest, apiKeyMiddlewareWrite, rateLimiting.middleware, permissions.middleware('deleteLine', 'write'), restDatasetsUtils.deleteLine)
+router.get('/:datasetId/lines/:lineId/revisions', readWritableDataset, isRest, apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('readLineRevisions', 'read', 'readDataAPI'), cacheHeaders.noCache, restDatasetsUtils.readRevisions)
+router.get('/:datasetId/revisions', readWritableDataset, isRest, apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('readRevisions', 'read', 'readDataAPI'), cacheHeaders.noCache, restDatasetsUtils.readRevisions)
+router.delete('/:datasetId/lines', readWritableDataset, isRest, apiKeyMiddlewareWrite, rateLimiting.middleware, permissions.middleware('deleteAllLines', 'write'), restDatasetsUtils.deleteAllLines)
+router.post('/:datasetId/_sync_attachments_lines', readWritableDataset, isRest, apiKeyMiddlewareWrite, rateLimiting.middleware, permissions.middleware('bulkLines', 'write'), lockDataset((body, query) => query.lock === 'true'), restDatasetsUtils.syncAttachmentsLines)
 
 // specific routes with rest datasets with lineOwnership activated
-router.use('/:datasetId/own/:owner', readWritableDataset, isRest, apiKeyUtils.middleware(['datasets']), (req, res, next) => {
+router.use('/:datasetId/own/:owner', readWritableDataset, isRest, apiKeyUtils.middleware(['datasets']), rateLimiting.middleware, (req, res, next) => {
   const sessionState = reqSessionAuthenticated(req)
   if (!req.dataset.rest?.lineOwnership) {
     return res.status(501)
@@ -646,7 +647,7 @@ router.get('/:datasetId/own/:owner/lines/:lineId/revisions', readWritableDataset
 router.get('/:datasetId/own/:owner/revisions', readWritableDataset, isRest, applicationKey, permissions.middleware('readOwnRevisions', 'manageOwnLines', 'readDataAPI'), cacheHeaders.noCache, restDatasetsUtils.readRevisions)
 
 // Specific routes for datasets with masterData functionalities enabled
-router.get('/:datasetId/master-data/single-searchs/:singleSearchId', readDataset({ fillDescendants: true }), apiKeyMiddlewareRead, permissions.middleware('readLines', 'read', 'readDataAPI'), async (req, res) => {
+router.get('/:datasetId/master-data/single-searchs/:singleSearchId', readDataset({ fillDescendants: true }), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('readLines', 'read', 'readDataAPI'), async (req, res) => {
   const singleSearch = req.dataset.masterData && req.dataset.masterData.singleSearchs && req.dataset.masterData.singleSearchs.find(ss => ss.id === req.params.singleSearchId)
   if (!singleSearch) return res.status(404).send(`Recherche unitaire "${req.params.singleSearchId}" inconnue`)
 
@@ -684,7 +685,7 @@ router.get('/:datasetId/master-data/single-searchs/:singleSearchId', readDataset
   }
   res.send(result)
 })
-router.post('/:datasetId/master-data/bulk-searchs/:bulkSearchId', readDataset({ fillDescendants: true }), apiKeyMiddlewareRead, permissions.middleware('bulkSearch', 'read'), async (req, res) => {
+router.post('/:datasetId/master-data/bulk-searchs/:bulkSearchId', readDataset({ fillDescendants: true }), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('bulkSearch', 'read'), async (req, res) => {
   // no buffering of this response in the reverse proxy
   res.setHeader('X-Accel-Buffering', 'no')
   const flatten = getFlatten(req.dataset)
@@ -1001,11 +1002,11 @@ const readLines = async (req, res) => {
   result = attachQueryHint(req, esSearchDurationMs, result)
   res.status(200).send(result)
 }
-router.get('/:datasetId/lines', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, permissions.middleware('readLines', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), readLines)
-router.get('/:datasetId/own/:owner/lines', readDataset({ fillDescendants: true }), isRest, applicationKey, apiKeyMiddlewareRead, permissions.middleware('readOwnLines', 'manageOwnLines', 'readDataAPI'), cacheHeaders.noCache, readLines)
+router.get('/:datasetId/lines', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('readLines', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), readLines)
+router.get('/:datasetId/own/:owner/lines', readDataset({ fillDescendants: true }), isRest, applicationKey, apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('readOwnLines', 'manageOwnLines', 'readDataAPI'), cacheHeaders.noCache, readLines)
 
 // Special geo aggregation
-router.get('/:datasetId/geo_agg', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, permissions.middleware('getGeoAgg', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
+router.get('/:datasetId/geo_agg', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('getGeoAgg', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
   res.throttleEnd()
 
   const vectorTileRequested = ['mvt', 'vt', 'pbf'].includes(req.query.format)
@@ -1056,7 +1057,7 @@ router.get('/:datasetId/geo_agg', readDataset({ fillDescendants: true }), applic
 })
 
 // Standard aggregation to group items by value and perform an optional metric calculation on each group
-router.get('/:datasetId/values_agg', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, permissions.middleware('getValuesAgg', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
+router.get('/:datasetId/values_agg', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('getValuesAgg', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
   res.throttleEnd()
   const sessionState = reqSession(req)
 
@@ -1129,7 +1130,7 @@ router.get('/:datasetId/values_agg', readDataset({ fillDescendants: true }), app
 
 // Simpler values list and filter (q is applied only to the selected field, not all fields)
 // mostly useful for selects/autocompletes on values
-router.get('/:datasetId/values/:fieldKey', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, permissions.middleware('getValues', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
+router.get('/:datasetId/values/:fieldKey', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('getValues', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
   res.throttleEnd()
   const esAbortContext = esUtils.createEsRequestOptions(req, res)
   let result
@@ -1142,7 +1143,7 @@ router.get('/:datasetId/values/:fieldKey', readDataset({ fillDescendants: true }
 })
 
 // Same as previous, but also uses x-labels for a better experience
-router.get('/:datasetId/values-labels/:fieldKey', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, permissions.middleware('getValues', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
+router.get('/:datasetId/values-labels/:fieldKey', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('getValues', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
   res.throttleEnd()
   let result
   const field = req.dataset.schema.find(p => p.key === req.params.fieldKey)
@@ -1163,7 +1164,7 @@ router.get('/:datasetId/values-labels/:fieldKey', readDataset({ fillDescendants:
 })
 
 // Simple metric aggregation to calculate 1 value (sum, avg, etc.) about 1 column
-router.get('/:datasetId/metric_agg', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, permissions.middleware('getMetricAgg', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
+router.get('/:datasetId/metric_agg', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('getMetricAgg', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
   res.throttleEnd()
   const esAbortContext = esUtils.createEsRequestOptions(req, res)
   let result
@@ -1179,7 +1180,7 @@ router.get('/:datasetId/metric_agg', readDataset({ fillDescendants: true }), app
 })
 
 // Simple metric aggregation to calculate some basic values about a list of columns
-router.get('/:datasetId/simple_metrics_agg', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, permissions.middleware('getSimpleMetricsAgg', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
+router.get('/:datasetId/simple_metrics_agg', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('getSimpleMetricsAgg', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
   res.throttleEnd()
   const esAbortContext = esUtils.createEsRequestOptions(req, res)
   let result
@@ -1192,7 +1193,7 @@ router.get('/:datasetId/simple_metrics_agg', readDataset({ fillDescendants: true
 })
 
 // Simple words aggregation for significant terms extraction
-router.get('/:datasetId/words_agg', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, permissions.middleware('getWordsAgg', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
+router.get('/:datasetId/words_agg', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('getWordsAgg', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
   res.throttleEnd()
   const esAbortContext = esUtils.createEsRequestOptions(req, res)
   let result
@@ -1206,7 +1207,7 @@ router.get('/:datasetId/words_agg', readDataset({ fillDescendants: true }), appl
 
 // DEPRECATED, replaced by metric_agg
 // Get max value of a field
-router.get('/:datasetId/max/:fieldKey', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, permissions.middleware('getMaxAgg', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
+router.get('/:datasetId/max/:fieldKey', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('getMaxAgg', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
   const esAbortContext = esUtils.createEsRequestOptions(req, res)
   let result
   try {
@@ -1219,7 +1220,7 @@ router.get('/:datasetId/max/:fieldKey', readDataset({ fillDescendants: true }), 
 
 // DEPRECATED, replaced by metric_agg
 // Get min value of a field
-router.get('/:datasetId/min/:fieldKey', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, permissions.middleware('getMinAgg', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
+router.get('/:datasetId/min/:fieldKey', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('getMinAgg', 'read', 'readDataAPI'), cacheHeaders.resourceBased('finalizedAt'), async (req, res) => {
   const esAbortContext = esUtils.createEsRequestOptions(req, res)
   let result
   try {
@@ -1231,7 +1232,7 @@ router.get('/:datasetId/min/:fieldKey', readDataset({ fillDescendants: true }), 
 })
 
 // For datasets with attached files
-router.get('/:datasetId/attachments/*attachmentPath', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, permissions.middleware('downloadAttachment', 'read', 'readDataFiles'), cacheHeaders.noCache, async (req, res, next) => {
+router.get('/:datasetId/attachments/*attachmentPath', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('downloadAttachment', 'read', 'readDataFiles'), cacheHeaders.noCache, async (req, res, next) => {
   if (req.dataset.isVirtual) {
     const childDatasetId = req.params.attachmentPath[0]
     if (!req.dataset.descendants?.find(c => c === childDatasetId)) return res.status(404).send('Child dataset not found')
@@ -1254,23 +1255,23 @@ router.get('/:datasetId/attachments/*attachmentPath', readDataset({ fillDescenda
 })
 
 // Direct access to data files
-router.get('/:datasetId/data-files', readDataset({ noCache: true }), apiKeyMiddlewareRead, permissions.middleware('listDataFiles', 'read'), cacheHeaders.noCache, async (req, res, next) => {
+router.get('/:datasetId/data-files', readDataset({ noCache: true }), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('listDataFiles', 'read'), cacheHeaders.noCache, async (req, res, next) => {
   res.send(await datasetUtils.dataFiles(req.dataset, req.publicBaseUrl))
 })
-router.get('/:datasetId/data-files/*filePath', readDataset(), apiKeyMiddlewareRead, permissions.middleware('downloadDataFile', 'read', 'readDataFiles'), cacheHeaders.noCache, async (req, res, next) => {
+router.get('/:datasetId/data-files/*filePath', readDataset(), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('downloadDataFile', 'read', 'readDataFiles'), cacheHeaders.noCache, async (req, res, next) => {
   const relFilePath = path.join(...req.params.filePath)
   await downloadFileFromStorage(
     resolvePath(dataFilesDir(req.dataset), relFilePath), req, res)
 })
 
 // Special attachments referenced in dataset metadatas
-router.post('/:datasetId/metadata-attachments', readDataset({ noCache: true }), apiKeyMiddlewareWrite, permissions.middleware('postMetadataAttachment', 'write'), checkStorage(false), attachments.metadataUpload(), clamav.middleware, async (req, res, next) => {
+router.post('/:datasetId/metadata-attachments', readDataset({ noCache: true }), apiKeyMiddlewareWrite, rateLimiting.middleware, permissions.middleware('postMetadataAttachment', 'write'), checkStorage(false), attachments.metadataUpload(), clamav.middleware, async (req, res, next) => {
   req.body.size = req.file.size
   req.body.updatedAt = moment().toISOString()
   await updateStorage(req.dataset)
   res.status(200).send(req.body)
 })
-router.get('/:datasetId/metadata-attachments/*attachmentPath', readDataset({ noCache: true }), apiKeyMiddlewareRead, permissions.middleware('downloadMetadataAttachment', 'read', 'readDataFiles'), cacheHeaders.noCache, async (req, res, next) => {
+router.get('/:datasetId/metadata-attachments/*attachmentPath', readDataset({ noCache: true }), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('downloadMetadataAttachment', 'read', 'readDataFiles'), cacheHeaders.noCache, async (req, res, next) => {
   // the transform stream option was patched into "send" module using patch-package
   // res.set('content-disposition', `inline; filename="${req.params.attachmentPath}"`)
   const relFilePath = path.join(...req.params.attachmentPath)
@@ -1329,14 +1330,14 @@ router.get('/:datasetId/metadata-attachments/*attachmentPath', readDataset({ noC
     req, res, { dispositionType: 'inline' })
 })
 
-router.delete('/:datasetId/metadata-attachments/*attachmentPath', readDataset(), apiKeyMiddlewareWrite, permissions.middleware('deleteMetadataAttachment', 'write'), async (req, res, next) => {
+router.delete('/:datasetId/metadata-attachments/*attachmentPath', readDataset(), apiKeyMiddlewareWrite, rateLimiting.middleware, permissions.middleware('deleteMetadataAttachment', 'write'), async (req, res, next) => {
   await filesStorage.removeFile(datasetUtils.metadataAttachmentPath(req.dataset, path.join(...req.params.attachmentPath)))
   await updateStorage(req.dataset)
   res.status(204).send()
 })
 
 // Download the full dataset in its original form
-router.get('/:datasetId/raw', readDataset({ noCache: true }), apiKeyMiddlewareRead, permissions.middleware('downloadOriginalData', 'read', 'readDataFiles'), cacheHeaders.noCache, async (req, res, next) => {
+router.get('/:datasetId/raw', readDataset({ noCache: true }), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('downloadOriginalData', 'read', 'readDataFiles'), cacheHeaders.noCache, async (req, res, next) => {
   const sessionState = reqSession(req)
   // a special case for superadmins.. handy but quite dangerous for the db load
   if (req.dataset.isRest && sessionState.user?.adminMode) {
@@ -1356,14 +1357,14 @@ router.get('/:datasetId/raw', readDataset({ noCache: true }), apiKeyMiddlewareRe
 })
 
 // Download the dataset in various formats
-router.get('/:datasetId/convert', readDataset({ noCache: true }), apiKeyMiddlewareRead, permissions.middleware('downloadOriginalData', 'read', 'readDataFiles'), cacheHeaders.noCache, async (req, res, next) => {
+router.get('/:datasetId/convert', readDataset({ noCache: true }), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('downloadOriginalData', 'read', 'readDataFiles'), cacheHeaders.noCache, async (req, res, next) => {
   if (!req.dataset.file) return res.status(404).send('Ce jeu de données ne contient pas de fichier de données')
   await downloadFileFromStorage(datasetUtils.filePath(req.dataset), req, res)
 })
 
 // Download the full dataset with extensions
 // TODO use ES scroll functionality instead of file read + extensions
-router.get('/:datasetId/full', readDataset({ noCache: true }), apiKeyMiddlewareRead, permissions.middleware('downloadFullData', 'read', 'readDataFiles'), cacheHeaders.noCache, async (req, res, next) => {
+router.get('/:datasetId/full', readDataset({ noCache: true }), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('downloadFullData', 'read', 'readDataFiles'), cacheHeaders.noCache, async (req, res, next) => {
   if (!req.dataset.file) return res.status(404).send('Ce jeu de données ne contient pas de fichier de données')
   if (await filesStorage.pathExists(datasetUtils.fullFilePath(req.dataset))) {
     await downloadFileFromStorage(datasetUtils.fullFilePath(req.dataset), req, res)
@@ -1374,7 +1375,7 @@ router.get('/:datasetId/full', readDataset({ noCache: true }), apiKeyMiddlewareR
 
 // Download the validation diagnostic CSV. Same permission as the journal that
 // references it.
-router.get('/:datasetId/validation-diagnostic.csv', readDataset({ acceptInitialDraft: true, noCache: true }), apiKeyMiddlewareRead, permissions.middleware('readJournal', 'readAdvanced'), cacheHeaders.noCache, async (req, res, next) => {
+router.get('/:datasetId/validation-diagnostic.csv', readDataset({ acceptInitialDraft: true, noCache: true }), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('readJournal', 'readAdvanced'), cacheHeaders.noCache, async (req, res, next) => {
   const filePath = validationDiagnosticFilePath(req.dataset)
   if (!await filesStorage.pathExists(filePath)) {
     return res.status(404).type('text/plain').send('Aucun fichier de diagnostic disponible')
@@ -1384,7 +1385,7 @@ router.get('/:datasetId/validation-diagnostic.csv', readDataset({ acceptInitialD
   await downloadFileFromStorage(filePath, req, res)
 })
 
-router.get('/:datasetId/metadata-settings', readDataset(), apiKeyMiddlewareRead, permissions.middleware('readDescription', 'read'), async (req, res, next) => {
+router.get('/:datasetId/metadata-settings', readDataset(), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('readDescription', 'read'), async (req, res, next) => {
   // @ts-ignore
   const dataset = req.dataset
   const settings = await mongo.db.collection('settings')
@@ -1392,19 +1393,19 @@ router.get('/:datasetId/metadata-settings', readDataset(), apiKeyMiddlewareRead,
   return res.send(settings?.datasetsMetadata ?? {})
 })
 
-router.get('/:datasetId/api-docs.json', readDataset({ noCache: true }), apiKeyMiddlewareRead, permissions.middleware('readApiDoc', 'read'), cacheHeaders.resourceBased(), async (req, res) => {
+router.get('/:datasetId/api-docs.json', readDataset({ noCache: true }), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('readApiDoc', 'read'), cacheHeaders.resourceBased(), async (req, res) => {
   const settings = await mongo.db.collection('settings')
     .findOne({ type: req.dataset.owner.type, id: req.dataset.owner.id }, { projection: { info: 1, compatODS: 1 } })
   res.send(datasetAPIDocs(req.dataset, req.publicBaseUrl, settings, req.publicationSite).api)
 })
 
-router.get('/:datasetId/private-api-docs.json', readDataset({ noCache: true }), apiKeyMiddlewareRead, permissions.middleware('readPrivateApiDoc', 'readAdvanced'), cacheHeaders.noCache, async (req, res) => {
+router.get('/:datasetId/private-api-docs.json', readDataset({ noCache: true }), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('readPrivateApiDoc', 'readAdvanced'), cacheHeaders.noCache, async (req, res) => {
   const settings = await mongo.db.collection('settings')
     .findOne({ type: req.dataset.owner.type, id: req.dataset.owner.id }, { projection: { info: 1, compatODS: 1 } })
   res.send(privateDatasetAPIDocs(req.dataset, req.publicBaseUrl, reqSessionAuthenticated(req), settings))
 })
 
-router.get('/:datasetId/journal', readDataset({ acceptInitialDraft: true }), apiKeyMiddlewareRead, permissions.middleware('readJournal', 'readAdvanced'), cacheHeaders.noCache, async (req, res) => {
+router.get('/:datasetId/journal', readDataset({ acceptInitialDraft: true }), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('readJournal', 'readAdvanced'), cacheHeaders.noCache, async (req, res) => {
   const journal = await mongo.db.collection('journals').findOne({
     type: 'dataset',
     id: req.dataset.id,
@@ -1425,7 +1426,7 @@ router.get('/:datasetId/journal', readDataset({ acceptInitialDraft: true }), api
   res.json(journal.events)
 })
 
-router.get('/:datasetId/task-progress', readDataset(), apiKeyMiddlewareRead, permissions.middleware('readJournal', 'readAdvanced'), cacheHeaders.noCache, async (req, res) => {
+router.get('/:datasetId/task-progress', readDataset(), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('readJournal', 'readAdvanced'), cacheHeaders.noCache, async (req, res) => {
   const journal = await mongo.db.collection('journals').findOne({
     type: 'dataset',
     id: req.dataset.id,
@@ -1443,7 +1444,7 @@ router.post(
   '/:datasetId/user-notification',
   readDataset(),
   applicationKey,
-  apiKeyMiddlewareWrite,
+  apiKeyMiddlewareWrite, rateLimiting.middleware,
   (req, res, next) => req.body.visibility === 'public' ? sendUserNotificationPublicPermissions(req, res, next) : sendUserNotificationPermissions(req, res, next),
   async (req, res, next) => {
     const userNotification = req.body
@@ -1471,11 +1472,11 @@ router.post(
   }
 )
 
-router.get('/:datasetId/thumbnail', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, permissions.middleware('readDescription', 'read'), async (req, res, next) => {
+router.get('/:datasetId/thumbnail', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('readDescription', 'read'), async (req, res, next) => {
   if (!req.dataset.image) return res.status(404).send("dataset doesn't have an image")
   await getThumbnail(req, res, req.dataset.image)
 })
-router.get('/:datasetId/thumbnail/:thumbnailId', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, permissions.middleware('readLines', 'read'), async (req, res, next) => {
+router.get('/:datasetId/thumbnail/:thumbnailId', readDataset({ fillDescendants: true }), applicationKey, apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('readLines', 'read'), async (req, res, next) => {
   const url = Buffer.from(req.params.thumbnailId, 'hex').toString()
   if (req.dataset.attachmentsAsImage && url.startsWith('/attachments/')) {
     if (req.dataset.isVirtual) {
@@ -1504,7 +1505,7 @@ router.get('/:datasetId/read-api-key', readDataset(), permissions.middleware('ge
   res.send(req.dataset._readApiKey)
 })
 
-router.post('/:datasetId/_simulate-extension', readDataset({ noCache: true }), apiKeyMiddlewareWrite, permissions.middleware('simulateExtension', 'write'), async (req, res, next) => {
+router.post('/:datasetId/_simulate-extension', readDataset({ noCache: true }), apiKeyMiddlewareWrite, rateLimiting.middleware, permissions.middleware('simulateExtension', 'write'), async (req, res, next) => {
   const line = req.body
   const dataset = clone(req.dataset.__proxyTarget ?? req.dataset)
   if (!dataset.extensions?.length) throw httpError(400, 'no extension to simulate')

--- a/api/src/misc/utils/rate-limiting.ts
+++ b/api/src/misc/utils/rate-limiting.ts
@@ -5,11 +5,21 @@ import requestIp from 'request-ip'
 import debug from 'debug'
 import promClient from 'prom-client'
 import { type Request, type Response } from 'express'
-import { reqUser } from '@data-fair/lib-express'
+import { reqUser, reqSession, type SessionState } from '@data-fair/lib-express'
 import { ComputeBucket } from './compute-budget.ts'
 import { queryAdvice } from './query-advice.ts'
 
 const debugLimits = debug('limits')
+
+// The user the rate limiter accounts a request to. Application keys are a loose, anonymous-style access
+// tier (the application-key middleware sets a pseudo-user for embed / public `?key=` access); we
+// deliberately rate-limit them as anonymous (keyed by IP), since they are exactly the kind of public
+// traffic the anonymous tier is meant to bound. Real users (JWT/cookie) and api keys keep the user tier.
+const rateLimitUser = (req: Request) => {
+  const user = reqUser(req)
+  if (!user) return undefined
+  return (reqSession(req) as SessionState & { isApplicationKey?: boolean }).isApplicationKey ? undefined : user
+}
 
 // IMPORTANT NOTE: all rate limiting is based on memory only, to be strictly applied when scaling the service
 // load balancing has to be based on a hash of the rate limiting key i.e the origin IP
@@ -53,7 +63,7 @@ export const clear = () => {
 }
 
 export const getRateLimiter = (req: Request, limitType: string, throttlingKey = '') => {
-  const user = reqUser(req)
+  const user = rateLimitUser(req)
   const throttlingId = throttlingKey + '_' + (user ? user.id : requestIp.getClientIp(req)) + '_' + limitType
   // init lastUsed at creation so the 20-min sweep can detect this entry as idle later — without it,
   // a limiter that's never followed by a consume() (or whose consume() path errors out) stays with
@@ -82,7 +92,7 @@ const getComputeBucket = (req: Request, limitType: string): ComputeBucket | unde
   if (!limit || !('computeMs' in limit) || !limit.computeMs || limit.computeMs <= 0) return undefined
   const budgetMs = limit.computeMs
   const windowMs = limit.duration * 1000
-  const user = reqUser(req)
+  const user = rateLimitUser(req)
   const key = (user ? user.id : requestIp.getClientIp(req)) + '_' + limitType
   let bucket = computeBuckets[key]
   // recreate the bucket if the configured budget/window changed (e.g. tests tweaking config at runtime)
@@ -105,7 +115,7 @@ export const debitComputeBudget = (req: Request, limitType: string, ms: number):
 
 const burstFactor = 4
 export const getTokenBucket = (req, limitType, bandwidthType) => {
-  const user = reqUser(req)
+  const user = rateLimitUser(req)
   const throttlingId = user ? user.id : requestIp.getClientIp(req)
   const bucketSize = config.defaultLimits.apiRate[limitType].bandwidth[bandwidthType] * burstFactor
   // init lastUsed at creation so the 20-min sweep can detect this entry as idle later — every call
@@ -180,8 +190,11 @@ const throttledEnd = async (res: Response, buffer: Buffer, tokenBucket: TokenBuc
   res._originalEnd()
 }
 
-export const middleware = (_limitType) => async (req, res, next) => {
-  const user = reqUser(req)
+// builds a rate-limiting middleware; `_limitType` forces a tier, otherwise it is auto-detected
+// (`user` when there is a user, else `anonymous`). The returned middleware is stateless (all state lives
+// in the module-level buckets keyed per client), so a single instance can be reused across every route.
+const buildMiddleware = (_limitType) => async (req, res, next) => {
+  const user = rateLimitUser(req)
   const limitType = _limitType || (user ? 'user' : 'anonymous')
 
   const ignoreRateLimiting = config.secretKeys.ignoreRateLimiting && req.get('x-ignore-rate-limiting') === config.secretKeys.ignoreRateLimiting
@@ -232,3 +245,9 @@ export const middleware = (_limitType) => async (req, res, next) => {
   }
   next()
 }
+
+// the default, shared instance — auto-detects user vs anonymous; reused on every dataset/ODS route
+export const middleware = buildMiddleware()
+
+// remote-service proxy traffic is forced onto its own tier
+export const remoteServiceMiddleware = buildMiddleware('remoteService')

--- a/api/src/remote-services/router.js
+++ b/api/src/remote-services/router.js
@@ -216,7 +216,7 @@ async function getAppOwner (req) {
 
 // Use the proxy as a user of an application
 // always apply restrictive rate limiting to remote services, privileged access does not go through here
-router.use('/:remoteServiceId/proxy/*proxyPath', rateLimiting.middleware('remoteService'), async (req, res, next) => {
+router.use('/:remoteServiceId/proxy/*proxyPath', rateLimiting.remoteServiceMiddleware, async (req, res, next) => {
   const appOwner = await getAppOwner(req)
   debug('Referer application owner', appOwner)
 

--- a/docs/architecture/load-management.md
+++ b/docs/architecture/load-management.md
@@ -49,7 +49,12 @@ defence; the in-app limiter (§4) backs it up and adds cost-awareness.
 - `express.json({ limit: '1000kb' })` body parser, bypassed for routes ending in `_bulk` or
   containing `bulk-searchs` (those stream).
 - Graceful shutdown via `http-terminator`.
-- Rate-limiting middleware is mounted on `/api/v1/datasets` and `/api/v1/compat-ods`.
+- Rate-limiting middleware is applied **per-route** inside the datasets and ODS routers — a single shared
+  `rateLimiting.middleware` instance placed right after each `apiKeyMiddlewareRead/Write/Admin`. It
+  deliberately runs *after* api-key resolution so a request authenticated with an api key is throttled at
+  the `user` tier rather than as anonymous; the trade-off is that each route opts in (routes with no
+  api-key middleware — e.g. `_diagnose`, `_reindex`, `read-api-key` — are not throttled, which is fine for
+  those admin paths). Remote-service proxy traffic uses its own `rateLimiting.remoteServiceMiddleware`.
 
 ## 4. In-app rate limiting (`api/src/misc/utils/rate-limiting.ts`)
 
@@ -73,6 +78,14 @@ expensive the query is. Bandwidth is throttled separately: handlers call `res.th
 4 burst factor). The middleware picks `user` vs `anonymous` based on `reqUser(req)`; specific limit
 types are passed explicitly elsewhere (application keys, captures, remote services). The header
 `x-ignore-rate-limiting: <SECRET_IGNORE_RATE_LIMITING>` bypasses everything (internal callers).
+
+> **Who counts as a "user":** the limiter keys the tier and the bucket off `rateLimitUser(req)`, not
+> `reqUser(req)` directly. It returns the request's user **except** for application-key sessions
+> (the pseudo-user the application-key middleware sets for embed / public `?key=` access, flagged
+> `isApplicationKey`), which are deliberately rate-limited as anonymous (by IP) — they are public-style
+> traffic the anonymous tier is meant to bound. Real users (JWT/cookie) and api keys get the `user`
+> tier. Because the limiter runs per-route after the api-key middleware (§3), `reqUser` is already
+> populated when it reads it.
 
 > **Weakness:** uniform cost-per-request, plus per-pod / per-IP scope. A burst of expensive queries
 > from one IP is allowed up to 600/min (anon) or 1200/min (user); a *distributed* flood (many IPs,

--- a/tests/features/infra/api-key-rate-limiting.api.spec.ts
+++ b/tests/features/infra/api-key-rate-limiting.api.spec.ts
@@ -1,0 +1,56 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { axios, axiosAuth, clean, checkPendingTasks } from '../../support/axios.ts'
+import { sendDataset, setConfig, clearRateLimiting } from '../../support/workers.ts'
+
+const testUser1 = await axiosAuth('test_user1@test.com')
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+// Regression test for middleware ordering: rate-limiting (`rateLimiting.middleware()`) is mounted on
+// /api/v1/datasets *before* the datasets router, while API keys used to be resolved only per-route
+// *inside* that router. As a result `reqUser(req)` was empty when the limiter ran, and every request
+// authenticated with an API key was throttled at the `anonymous` tier instead of `user`.
+//
+// We make the `anonymous` compute budget so tiny a single ES query exhausts it, and disable the `user`
+// budget. An API-key request that is correctly classified as `user` therefore never gets a 429; one
+// wrongly classified as `anonymous` gets a 429 on its second /lines call.
+test.describe('API key rate limiting tier', () => {
+  test.beforeAll(async () => {
+    await setConfig('defaultLimits.apiRate.anonymous.computeMs', 0.001) // exhausted by one ES query
+    await setConfig('defaultLimits.apiRate.user.computeMs', 0) // disabled
+  })
+  test.afterAll(async () => {
+    await setConfig('defaultLimits.apiRate.anonymous.computeMs', 0) // back to the dev/test default
+    await clearRateLimiting()
+  })
+  test.beforeEach(async () => {
+    await clean()
+  })
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === 'passed') await checkPendingTasks()
+  })
+
+  test('a request authenticated with an API key is rate-limited as a user, not anonymous', async () => {
+    const dataset = await sendDataset('datasets/dataset1.csv', testUser1)
+
+    // a datasets-scoped API key for the owner of the dataset
+    const res = await testUser1.put('/api/v1/settings/user/test_user1', {
+      apiKeys: [{ title: 'rl-key', scopes: ['datasets'] }]
+    })
+    const key = res.data.apiKeys[0].clearKey
+    const axKey = axios({ headers: { 'x-apiKey': key } })
+
+    await clearRateLimiting() // start every tier with a fresh, full budget
+
+    // first /lines call via the API key: served; its ES query debits >0.001 ms on response close
+    let r = await axKey.get(`/api/v1/datasets/${dataset.id}/lines`)
+    assert.equal(r.status, 200)
+    await sleep(300) // let the server-side 'close' handler run the debit before the next call
+
+    // second call: if the API key were (wrongly) classified as anonymous, the tiny anonymous budget
+    // would now be exhausted -> 429. Classified as a user (budget disabled) it must still be 200.
+    r = await axKey.get(`/api/v1/datasets/${dataset.id}/lines`, { validateStatus: () => true })
+    assert.equal(r.status, 200)
+  })
+})


### PR DESCRIPTION
Rate limiting was mounted on `/api/v1/datasets` and `/api/v1/compat-ods` *before* the per-route api-key middleware resolved the session, so `reqUser(req)` was empty and api-key traffic was throttled at the `anonymous` tier instead of `user`.

This moves rate limiting to run **per-route**, right after the api-key middleware (a single shared `rateLimiting.middleware` instance placed next to each `apiKeyMiddlewareRead/Write/Admin`, plus the ODS routes). By then the api key — and the per-resource read key — is resolved, so requests get the correct tier. A new `rateLimitUser()` helper keeps application-key pseudo-users on the `anonymous` tier, preserving today's behavior for public embed traffic. The `middleware` factory now also exposes a single reused default instance (and a dedicated `remoteServiceMiddleware`) instead of being re-invoked on every route.

**Why:** users reported that rate limiting was not adjusted when authenticating with an api key, because of the middleware ordering.

**Regression risks:**
- A few admin/maintenance routes with no api-key middleware (`read-api-key`, `_diagnose`, `_reindex`, `_refinalize`, `_lock`) are no longer rate-limited — intentional, they don't need it.
- Per-resource *read* api-key requests now resolve before the limiter, so they move from the `anonymous` to the `user` tier (all keyed under the shared `readApiKey` id). New behavior, but the correct one.
- `rate-limiting.ts` `middleware` export changed from a factory `(limitType) => mw` to a ready middleware instance; the only parametrized caller (remote-services) now uses the new `remoteServiceMiddleware`. Any other caller invoking `middleware(...)` would break — none exist in-repo.
- Application-key traffic must stay on the anonymous tier via `rateLimitUser` (verified: the `postApplicationKey` test still 429s).
