### PR TITLE
fix(s3): verify object readable after moveFromFs + diagnose missing loaded file

### DIFF
--- a/api/src/files-storage/s3.ts
+++ b/api/src/files-storage/s3.ts
@@ -173,6 +173,12 @@ export class S3Backend implements FileBackend {
 
   async moveFromFs (tmpPath: string, path: string): Promise<void> {
     await this.writeStream(createReadStream(tmpPath), path)
+    // Confirm the object is actually readable before deleting the local source. Some S3
+    // providers can ack a write without durably storing the object, which then surfaces as
+    // a NoSuchKey when a worker reads the file in another process. Verifying here (like the
+    // multer upload path does with fileStats) turns that silent miss into a loud failure at
+    // upload time instead.
+    await this.metadataClient.send(new HeadObjectCommand({ Bucket: config.s3.bucket, Key: bucketPath(path) }))
     await unlink(tmpPath)
   }
 

--- a/api/src/files-storage/s3.ts
+++ b/api/src/files-storage/s3.ts
@@ -177,8 +177,10 @@ export class S3Backend implements FileBackend {
     // providers can ack a write without durably storing the object, which then surfaces as
     // a NoSuchKey when a worker reads the file in another process. Verifying here (like the
     // multer upload path does with fileStats) turns that silent miss into a loud failure at
-    // upload time instead.
-    await this.metadataClient.send(new HeadObjectCommand({ Bucket: config.s3.bucket, Key: bucketPath(path) }))
+    // upload time instead. retryOnMissing absorbs the transient cross-connection
+    // inconsistency (we write on dataClient and HEAD on metadataClient) so only a persistent
+    // miss — the durable loss we actually want to catch — fails the upload.
+    await retryOnMissing(() => this.metadataClient.send(new HeadObjectCommand({ Bucket: config.s3.bucket, Key: bucketPath(path) })))
     await unlink(tmpPath)
   }
 

--- a/api/src/workers/files-manager/store-file.ts
+++ b/api/src/workers/files-manager/store-file.ts
@@ -9,6 +9,7 @@ import { Transform } from 'node:stream'
 import split2 from 'split2'
 import pump from '../../misc/utils/pipe.ts'
 import debugLib from 'debug'
+import { internalError } from '@data-fair/lib-node/observer.js'
 import mongo from '#mongo'
 import type { DatasetInternal } from '#types'
 import filesStorage from '#files-storage'
@@ -27,6 +28,15 @@ export default async function (dataset: DatasetInternal) {
   const datasetFile = dataset.loaded?.dataset
   if (datasetFile) {
     const loadedFilePath = datasetUtils.loadedFilePath(dataset)
+
+    // TEMPORARY diagnostic: some uploads reach the storer with their loaded file missing from
+    // storage (a NoSuchKey on S3 when reading it below). Until the root cause is fixed, log what
+    // the loading dir actually contains so a wrong/absent key can be told apart from a read delay.
+    // Remove this block once the root cause is identified and fixed.
+    if (!await filesStorage.pathExists(loadedFilePath)) {
+      const existing = await filesStorage.lsrWithStats(loadingDir).catch(() => [])
+      internalError('storer-missing-file', `loaded file missing when storer started: expected ${loadedFilePath} — loading dir contents: ${JSON.stringify(existing)}`)
+    }
 
     // the file was just written by the upload (a separate process), but some S3 providers
     // do not guarantee read-after-write consistency across connections/processes: the reads


### PR DESCRIPTION
Harden the S3 upload path against silent `NoSuchKey` misses and add a temporary diagnostic for the file-storer.

**Why:** some uploads reach the file-storer with their loaded file missing from storage (surfaces as a `NoSuchKey` on read in another process). This catches the durable miss at upload time and captures evidence to pin down the root cause.

**What changed:**
- `moveFromFs` now HEADs the object after writing and before unlinking the local source, so a write that didn't durably land fails loudly at upload time instead of silently later. The HEAD is wrapped in `retryOnMissing`, so transient cross-connection read-after-write inconsistency is absorbed and only a persistent miss fails the upload.
- `store-file` logs the loading-dir contents via `internalError('storer-missing-file', …)` when the loaded file is missing at storer start. Marked TEMPORARY — to be removed once the root cause is fixed.

**Regression risks:**
- `moveFromFs` (extensions, normalize, store-file, diagnostic-file, REST attachments) now performs an extra HEAD per move and, on a genuine durable miss, blocks ~30s (`retryOnMissing`: 5 attempts, 2/4/8/16s backoff) before failing the upload — previously it returned immediately. The job is itself retried once by the worker error handler.
- The diagnostic `pathExists` at storer start is unretried, so expect some false `storer-missing-file` reports on inconsistent providers (logs only, never fails the job).
