### PR TITLE
feat(config): enable openapi-viewer integration via public URL (dual-machine)

### DIFF
--- a/api/config/custom-environment-variables.cjs
+++ b/api/config/custom-environment-variables.cjs
@@ -28,6 +28,7 @@ module.exports = {
   privateProcessingsUrl: 'PRIVATE_PROCESSINGS_URL',
   privateMetricsUrl: 'PRIVATE_METRICS_URL',
   privateAgentsUrl: 'PRIVATE_AGENTS_URL',
+  openapiViewerUrl: 'OPENAPI_VIEWER_URL',
   privateOpenapiViewerUrl: 'PRIVATE_OPENAPI_VIEWER_URL',
   privateRegistryUrl: 'PRIVATE_REGISTRY_URL',
   subscriptionUrl: 'SUBSCRIPTION_URL',

--- a/api/config/default.cjs
+++ b/api/config/default.cjs
@@ -31,6 +31,7 @@ module.exports = {
   privateProcessingsUrl: null,
   privateMetricsUrl: null,
   privateAgentsUrl: null,
+  openapiViewerUrl: null,
   privateOpenapiViewerUrl: null,
   privateRegistryUrl: null,
   subscriptionUrl: null,

--- a/api/config/type/schema.json
+++ b/api/config/type/schema.json
@@ -133,6 +133,9 @@
     "privateAgentsUrl": {
       "type": ["string", "null"]
     },
+    "openapiViewerUrl": {
+      "type": ["string", "null"]
+    },
     "privateOpenapiViewerUrl": {
       "type": ["string", "null"]
     },

--- a/api/src/ui-config.ts
+++ b/api/src/ui-config.ts
@@ -17,7 +17,11 @@ export const uiConfig = {
   subscriptionUrl: config.subscriptionUrl,
   agentsIntegration: !!config.privateAgentsUrl,
   metricsIntegration: !!config.privateMetricsUrl,
-  openapiViewerIntegration: !!config.privateOpenapiViewerUrl,
+  // In a dual-machine deployment openapi-viewer runs on the catalog VM and is not
+  // reachable through a private URL from data-fair, but it is still served to the
+  // browser via the public site path. So enable the integration when either the
+  // private or the public openapi-viewer URL is configured.
+  openapiViewerIntegration: !!(config.privateOpenapiViewerUrl || config.openapiViewerUrl),
   registryIntegration: !!config.privateRegistryUrl,
   extraNavigationItems: config.extraNavigationItems as { id: string, iframe?: string, [key: string]: any }[],
   extraAdminNavigationItems: config.extraAdminNavigationItems as { id: string, iframe?: string, [key: string]: any }[],


### PR DESCRIPTION
## Problem

The dataset / application **"Use the API"** action (and the related API-doc links in `dataset-actions.vue`, `application-actions.vue`, `remote-service-actions.vue`, the update-dataset workflow and the navigation items) are gated on `uiConfig.openapiViewerIntegration`:

```ts
openapiViewerIntegration: !!config.privateOpenapiViewerUrl,
```

This is only ever true when the **private** openapi-viewer URL (`PRIVATE_OPENAPI_VIEWER_URL`) is configured.

In a **dual-machine deployment**, openapi-viewer runs on a different host from data-fair and is **not reachable through a private/internal URL**. It is still served to the browser through the public site path — which is exactly what the api-doc iframes use:

```vue
<d-frame :src="`${$sitePath}/openapi-viewer/?...`" />
```

`privateOpenapiViewerUrl` is **never used as a URL server-side** (`grep` shows its only use is the boolean toggle above) — it is purely a feature flag. So a perfectly working dual-machine deployment silently loses the API documentation UI.

## Fix

Add a public `openapiViewerUrl` config (env `OPENAPI_VIEWER_URL`) and enable the integration when **either** the private or the public URL is set:

```ts
openapiViewerIntegration: !!(config.privateOpenapiViewerUrl || config.openapiViewerUrl),
```

This mirrors the existing `directoryUrl` / `privateDirectoryUrl` public+private pair, and is the same shape as the dual-machine fallback used for the SPA site hashes. No behaviour change for single-machine deployments (which set the private URL); dual-machine deployments can now enable the integration by pointing at the public openapi-viewer URL.

## Changes
- `api/config/default.cjs` — add `openapiViewerUrl: null`
- `api/config/custom-environment-variables.cjs` — map `openapiViewerUrl` → `OPENAPI_VIEWER_URL`
- `api/config/type/schema.json` — declare `openapiViewerUrl`
- `api/src/ui-config.ts` — `openapiViewerIntegration` falls back to the public URL