### PR TITLE
fix(ui): refetch embed table when a URL filter is removed

### DIFF
--- a/tests/features/embed/dataset-table.e2e.spec.ts
+++ b/tests/features/embed/dataset-table.e2e.spec.ts
@@ -22,4 +22,31 @@ test.describe('embed dataset table page', () => {
     await goToWithAuth(`/data-fair/embed/dataset/${dataset.id}/journal`, 'test_user1')
     await expect(page.getByText('le jeu de données a été entièrement traité')).toBeVisible({ timeout: 10000 })
   })
+
+  // Regression for #1755: when an embedding parent drops a filter from the URL via <d-frame>
+  // (an in-app router.replace, not a reload), the table must refetch without that filter.
+  // `id_in=koumoul` is a single-value "in" filter, normalized to "eq" internally by addFilter,
+  // which also guards against a naive removal loop matching operators by strict equality.
+  test('refetches when a URL filter is removed externally', async ({ page, goToWithAuth }) => {
+    const ax = await axiosAuth('test_user1@test.com')
+    const dataset = await sendDataset('datasets/dataset1.csv', ax)
+
+    await goToWithAuth(`/data-fair/embed/dataset/${dataset.id}/table?id_in=koumoul`, 'test_user1')
+
+    // the filter is applied: only the matching row is shown
+    await expect(page.getByRole('cell', { name: 'koumoul' })).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('cell', { name: 'bidule' })).toHaveCount(0)
+
+    // simulate the parent <d-frame> removing the filter: an updateSrc message without the query
+    // triggers router.replace in-app (window.parent === window for a standalone embed page)
+    await page.evaluate(() => {
+      const url = new URL(window.location.href)
+      url.search = ''
+      window.postMessage(['df-parent', 'updateSrc', url.href], '*')
+    })
+
+    // the table must refetch without the filter: the previously filtered-out row appears
+    await expect(page.getByRole('cell', { name: 'bidule' })).toBeVisible({ timeout: 10000 })
+    await expect(page.getByRole('cell', { name: 'koumoul' })).toBeVisible()
+  })
 })

--- a/ui/src/composables/dataset/filters.ts
+++ b/ui/src/composables/dataset/filters.ts
@@ -14,6 +14,14 @@ export type DatasetFilter = {
 
 export const operators: Operator[] = ['in', 'nin', 'eq', 'neq', 'gt', 'lt', 'gte', 'lte', 'search', 'contains', 'starts', 'exists', 'nexists']
 
+// addFilter normalizes single-value "in"/"nin" filters to "eq"/"neq", so an internal filter
+// may not carry the operator of the URL param it originated from. Treat those as equivalent
+// when reconciling internal filters against the query params.
+const matchesQueryOperator = (queryOperator: Operator, filterOperator: Operator) =>
+  queryOperator === filterOperator ||
+  (filterOperator === 'eq' && queryOperator === 'in') ||
+  (filterOperator === 'neq' && queryOperator === 'nin')
+
 export const findEqFilter = (filters: DatasetFilter[], property: SchemaProperty, result: ExtendedResult) => {
   return filters.find(f => f.property.key === property.key && f.operator === 'eq' && (Array.isArray(result.values[property.key])
     ? (result.values[property.key] as ExtendedResultValue[]).some(v => v.raw === f.value)
@@ -101,9 +109,17 @@ export const useFilters = (datasetRef: MaybeRefOrGetter<ExtendedDataset | null>,
   })
 
   watch(queryParamsFilters, () => {
+    // add filters newly present in the URL
     for (const filter of queryParamsFilters.value) {
       if (filters.value.some(f => f.property.key === filter.property.key && f.operator === filter.operator)) continue
       addFilter(filter)
+    }
+    // remove filters whose query param disappeared from the URL (e.g. an embedding parent
+    // dropping a key via <d-frame>). excludeKeys are managed outside this sync, leave them be.
+    for (const filter of [...filters.value]) {
+      if (excludeKeys.includes(`${filter.property.key}_${filter.operator}`) || excludeKeys.includes(filter.property.key)) continue
+      if (queryParamsFilters.value.some(f => f.property.key === filter.property.key && matchesQueryOperator(f.operator, filter.operator))) continue
+      removeFilter(filter)
     }
   }, { immediate: true })
 


### PR DESCRIPTION
Fixes the embedded dataset table not refetching when a filter is removed from its URL by an embedding parent via `<d-frame>` (an in-app `router.replace`, not a reload). Adding a filter already worked; removing it left the stale filter applied and showed no fresh data.

**Why:** in `useFilters`, the watcher on `queryParamsFilters` only *added* filters present in the URL — it never *removed* internal filters whose query param had disappeared, so `queryParams` → `extraParams` → `baseFetchUrl` stayed unchanged and `watch(baseFetchUrl, reset)` never re-ran. The watcher now reconciles both directions. Removal accounts for the `in`→`eq` / `nin`→`neq` normalization `addFilter` applies to single-value filters, so a transformed filter (e.g. `?id_in=x` stored internally as `eq`) is not spuriously dropped — a naive strict-operator match would have removed it on load. `excludeKeys` (e.g. `_id_eq` used for row selection) are left untouched.

**Regression risks:**
- `useFilters` is shared by the back-office table, the map and the embed table/download. The watcher now *removes* filters, not just adds them — verify no consumer relied on an internal filter persisting after its URL key vanished.
- Out of scope: a filter whose *value* changes in the URL without its key disappearing is still not propagated (pre-existing; the add loop matches on key+operator only).

**Test:** e2e regression in `embed/dataset-table` loads the table with a single-value `in` filter, drops it through the real `<d-frame>` `updateSrc` message, and asserts the table refetches without the filter.
