### PR TITLE
fix(datasets): index _attachment_url as wildcard so _exists_/eq work at any length

### DIFF
--- a/api/src/datasets/es/operations.ts
+++ b/api/src/datasets/es/operations.ts
@@ -203,6 +203,11 @@ export const esProperty = (prop: any, defaultAnalyzer: string): any => {
     }
   }
   if (prop.key === '_geocorners') esProp = { type: 'geo_point' }
+  // _attachment_url holds an absolute URL (publicUrl + datasetId + lineId + md5 + filename) that can
+  // easily exceed the keyword ignore_above:200 limit (e.g. sha256 line ids or long filenames). Over the
+  // limit the value is dropped from the index (kept only in _source), so _exists_ / term / agg / sort
+  // silently return nothing. The wildcard type is built for long machine strings and has no such limit.
+  if (prop.key === '_attachment_url') esProp = { type: 'wildcard' }
   if (prop.key === '_i') esProp = { type: 'long' }
   if (prop.key === '_rand') esProp = { type: 'integer' }
   if (prop.key === '_id') return null

--- a/api/src/datasets/utils/data-schema.ts
+++ b/api/src/datasets/utils/data-schema.ts
@@ -150,10 +150,15 @@ export const extendedSchema = async (db, dataset, fixConcept = true) => {
       schema.push({ 'x-calculated': true, key: '_file.content_type', type: 'string', title: 'Type mime du fichier', description: 'Résultat d\'une détection automatique.' })
       schema.push({ 'x-calculated': true, key: '_file.content_length', type: 'integer', title: 'La taille en octet du fichier', description: 'Résultat d\'une détection automatique.' })
     }
+    // _attachment_url is mapped as an ES "wildcard" field (see esProperty): it holds a long absolute URL
+    // and only needs existence/exact filtering, not analyzed full-text or case-insensitive sub-fields.
+    // Disabling those capabilities keeps the list of queryable fields consistent with the wildcard mapping
+    // (which has no .text / .text_standard / .keyword_insensitive inner fields).
+    const attachmentUrlCapabilities = { text: false, textStandard: false, insensitive: false }
     if (dataset.attachmentsAsImage) {
-      schema.push({ 'x-calculated': true, key: '_attachment_url', type: 'string', title: 'URL de téléchargement unitaire de l\'image jointe', 'x-refersTo': 'http://schema.org/image' })
+      schema.push({ 'x-calculated': true, key: '_attachment_url', type: 'string', title: 'URL de téléchargement unitaire de l\'image jointe', 'x-refersTo': 'http://schema.org/image', 'x-capabilities': attachmentUrlCapabilities })
     } else {
-      schema.push({ 'x-calculated': true, key: '_attachment_url', type: 'string', title: 'URL de téléchargement unitaire du fichier joint' })
+      schema.push({ 'x-calculated': true, key: '_attachment_url', type: 'string', title: 'URL de téléchargement unitaire du fichier joint', 'x-capabilities': attachmentUrlCapabilities })
     }
   }
   if (geoUtils.schemaHasGeopoint(dataset.schema) || geoUtils.schemaHasGeometry(dataset.schema)) {

--- a/tests/features/datasets/rest/rest-datasets-attachments.api.spec.ts
+++ b/tests/features/datasets/rest/rest-datasets-attachments.api.spec.ts
@@ -234,6 +234,58 @@ test.describe('REST datasets - Attachments', () => {
     await waitForFinalize(ax, 'restsync')
   })
 
+  test('_exists_ filter on _attachment_url works regardless of the attachment path/url length', async () => {
+    const ax = testUser1
+    // _attachment_url is an absolute URL (publicUrl + datasetId + lineId + md5 + filename) stored in the
+    // index. Mapped as a keyword with ignore_above:200, any value over 200 chars is silently dropped from
+    // the index (kept only in _source) so _exists_ / term / agg / sort return nothing while normal
+    // responses still show the value. A long filename pushes BOTH attachmentPath and _attachment_url well
+    // over 200, so the fix must be length-independent (a higher ignore_above or switching field would not
+    // be enough).
+    let res = await ax.post('/api/v1/datasets/rest-attachment-long-url', {
+      isRest: true,
+      title: 'rest attachment long url',
+      primaryKey: ['attr1'],
+      rest: { primaryKeyMode: 'sha256' },
+      schema: [
+        { key: 'attr1', type: 'string' },
+        { key: 'attachmentPath', type: 'string', 'x-refersTo': 'http://schema.org/DigitalDocument' }
+      ]
+    })
+    assert.equal(res.status, 201)
+
+    const longName = 'long-attachment-filename-' + 'x'.repeat(140) + '.pdf'
+    const form = new FormData()
+    const attachmentContent = fs.readFileSync('./tests/resources/datasets/files/dir1/test.pdf')
+    form.append('attachment', attachmentContent, longName)
+    form.append('attr1', 'key1')
+    // a primaryKey upsert returns 200 (not 201); just make sure the line was stored with its attachment path
+    res = await ax.post('/api/v1/datasets/rest-attachment-long-url/lines', form, { headers: { 'Content-Length': form.getLengthSync(), ...form.getHeaders() } })
+    assert.ok([200, 201].includes(res.status))
+    assert.ok(res.data.attachmentPath?.endsWith('/' + longName))
+    assert.ok(res.data.attachmentPath.length > 200, `expected attachmentPath > 200 chars, got ${res.data.attachmentPath.length}`)
+    await waitForFinalize(ax, 'rest-attachment-long-url')
+
+    // the _attachment_url is present in normal responses and is well over 200 chars
+    res = await ax.get('/api/v1/datasets/rest-attachment-long-url/lines', { params: { select: '_attachment_url' } })
+    assert.equal(res.data.total, 1)
+    const url = res.data.results[0]._attachment_url
+    assert.ok(url, 'expected _attachment_url to be present in the response')
+    assert.ok(url.length > 200, `expected _attachment_url longer than 200 chars to reproduce the bug, got ${url.length}`)
+
+    // filtering on the existence of _attachment_url must still find the line
+    res = await ax.get('/api/v1/datasets/rest-attachment-long-url/lines', { params: { qs: '_exists_:_attachment_url' } })
+    assert.equal(res.data.total, 1)
+
+    // exact-match (eq/in) filtering must also still work on the wildcard-mapped field, at any length
+    res = await ax.get('/api/v1/datasets/rest-attachment-long-url/lines', { params: { _attachment_url_eq: url } })
+    assert.equal(res.data.total, 1)
+    res = await ax.get('/api/v1/datasets/rest-attachment-long-url/lines', { params: { _attachment_url_eq: url + 'x' } })
+    assert.equal(res.data.total, 0)
+    res = await ax.get('/api/v1/datasets/rest-attachment-long-url/lines', { params: { _attachment_url_in: url } })
+    assert.equal(res.data.total, 1)
+  })
+
   test('Send attachment with special chars', async () => {
     const ax = testUser1
     let res = await ax.post('/api/v1/datasets', {


### PR DESCRIPTION
Map the calculated `_attachment_url` field to an ES `wildcard` type instead of a keyword with `ignore_above:200`, and disable its analyzed/insensitive sub-fields.

**Why:** some datavizs filter with `qs=_exists_:_attachment_url`. The field stores a full absolute URL; mapped as a keyword with `ignore_above:200`, any value over 200 chars (sha256 line ids, long filenames, deep paths) is silently dropped from the index but kept in `_source` — so `_exists_`/eq/agg/sort return nothing while responses still show the URL. The `wildcard` type has no length limit, so filtering works regardless of URL length.

**Regression risks:**
- Existing finalized datasets keep the old keyword mapping until manually reindexed (index-name hash is datasetId-only); no new breakage, but the fix only takes effect after reindex.
- `_attachment_url` loses the full-text `_search` filter and case-insensitive sort (now case-sensitive on the main field) — both capability-guarded, no crashes; `attachmentPath` retains them.
