### PR TITLE
feat(datasets): preserve downloadable diagnostic on auto-cancelled contribution drafts

### DIFF
--- a/api/src/datasets/router.js
+++ b/api/src/datasets/router.js
@@ -48,7 +48,7 @@ import * as rateLimiting from '../misc/utils/rate-limiting.ts'
 import { syncDataset as syncRemoteService } from '../remote-services/service.ts'
 import { findDatasets, applyPatch, deleteDataset, createDataset, memoizedGetDataset, cancelDraft } from './service.js'
 import { tableSchema, jsonSchema, getSchemaBreakingChanges, filterSchema } from './utils/data-schema.ts'
-import { dir, dataFilesDir, attachmentsDir, validationDiagnosticFilePath } from './utils/files.ts'
+import { dir, dataFilesDir, attachmentsDir, validationDiagnosticFilePath, cancelledDraftDiagnosticFilePath } from './utils/files.ts'
 import { preparePatch } from './utils/patch.js'
 import { checkStorage, lockDataset, readDataset } from './middlewares.js'
 import config from '#config'
@@ -1381,6 +1381,19 @@ router.get('/:datasetId/validation-diagnostic.csv', readDataset({ acceptInitialD
     return res.status(404).type('text/plain').send('Aucun fichier de diagnostic disponible')
   }
   res.setHeader('content-disposition', contentDisposition(`${req.dataset.slug}-validation-diagnostic.csv`))
+  res.setHeader('Content-Type', 'text/csv; charset=utf-8')
+  await downloadFileFromStorage(filePath, req, res)
+})
+
+// Download the diagnostic of a contribution whose draft was auto-cancelled
+// (compatibleOrCancel). Stored in its own slot on the main dataset so it is not
+// confused with the live dataset's own validation diagnostic. Same permission gate.
+router.get('/:datasetId/cancelled-draft-diagnostic.csv', readDataset({ acceptInitialDraft: true, noCache: true }), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('readJournal', 'readAdvanced'), cacheHeaders.noCache, async (req, res, next) => {
+  const filePath = cancelledDraftDiagnosticFilePath(req.dataset)
+  if (!await filesStorage.pathExists(filePath)) {
+    return res.status(404).type('text/plain').send('Aucun fichier de diagnostic disponible')
+  }
+  res.setHeader('content-disposition', contentDisposition(`${req.dataset.slug}-cancelled-draft-diagnostic.csv`))
   res.setHeader('Content-Type', 'text/csv; charset=utf-8')
   await downloadFileFromStorage(filePath, req, res)
 })

--- a/api/src/datasets/service.js
+++ b/api/src/datasets/service.js
@@ -13,7 +13,7 @@ import * as webhooks from '../misc/utils/webhooks.ts'
 import { sendResourceEvent } from '../misc/utils/notifications.ts'
 import catalogsPublicationQueue from '../misc/utils/catalogs-publication-queue.ts'
 import { updateStorage } from './utils/storage.ts'
-import { dir, filePath, fullFilePath, originalFilePath, attachmentsDir, metadataAttachmentsDir } from './utils/files.ts'
+import { dir, filePath, fullFilePath, originalFilePath, attachmentsDir, metadataAttachmentsDir, cancelledDraftDiagnosticFilePath } from './utils/files.ts'
 import { fixConcepts, getSchemaBreakingChanges } from './utils/data-schema.ts'
 import { getExtensionKey, prepareExtensions, prepareExtensionsSchema, checkExtensions } from './utils/extensions.ts'
 import assertImmutable from '../misc/utils/assert-immutable.js'
@@ -644,6 +644,13 @@ export const validateDraft = async (dataset, datasetFull, patch) => {
   await filesStorage.moveFile(draftFilePath, newFilePath)
   if (oldFilePath && newFilePath !== oldFilePath) {
     await filesStorage.removeFile(oldFilePath)
+  }
+
+  // a previous contribution to this dataset may have left a cancelled-draft
+  // diagnostic; now that a contribution succeeded it is stale, remove it
+  const staleCancelledDiagnostic = cancelledDraftDiagnosticFilePath(patchedDataset)
+  if (await filesStorage.pathExists(staleCancelledDiagnostic)) {
+    await filesStorage.removeFile(staleCancelledDiagnostic)
   }
 
   await validateDraftAlias(dataset)

--- a/api/src/datasets/service.js
+++ b/api/src/datasets/service.js
@@ -651,6 +651,13 @@ export const validateDraft = async (dataset, datasetFull, patch) => {
   const staleCancelledDiagnostic = cancelledDraftDiagnosticFilePath(patchedDataset)
   if (await filesStorage.pathExists(staleCancelledDiagnostic)) {
     await filesStorage.removeFile(staleCancelledDiagnostic)
+    // the now-removed file was referenced by a past draft-cancelled event; clear
+    // its hasDiagnosticFile flag so the UI stops offering a download that 404s
+    await mongo.db.collection('journals').updateOne(
+      { type: 'dataset', id: patchedDataset.id, 'owner.type': patchedDataset.owner.type, 'owner.id': patchedDataset.owner.id },
+      { $unset: { 'events.$[stale].hasDiagnosticFile': '' } },
+      { arrayFilters: [{ 'stale.type': 'draft-cancelled', 'stale.hasDiagnosticFile': true }] }
+    )
   }
 
   await validateDraftAlias(dataset)

--- a/api/src/datasets/utils/files.ts
+++ b/api/src/datasets/utils/files.ts
@@ -60,6 +60,11 @@ export const validationDiagnosticFilePath = (dataset: any) => {
   return resolvePath(dataFilesDir(dataset), 'validation-diagnostic.csv')
 }
 
+export const cancelledDraftDiagnosticFilePath = (dataset: any) => {
+  // always the main (non-draft) dir: this file outlives the cancelled draft
+  return resolvePath(dataFilesDir({ ...dataset, draftReason: null }), 'cancelled-draft-diagnostic.csv')
+}
+
 export const loadedAttachmentsFilePath = (dataset: any) => {
   return resolvePath(loadingDir(dataset), 'attachments.zip')
 }

--- a/api/src/workers/batch-processor/process-file.ts
+++ b/api/src/workers/batch-processor/process-file.ts
@@ -12,6 +12,8 @@ import * as schemaUtils from '../../datasets/utils/data-schema.ts'
 import taskProgress from '../../datasets/utils/task-progress.ts'
 import { readStreams as getReadStreams } from '../../datasets/utils/data-streams.js'
 import { DiagnosticWriter } from '../../datasets/utils/diagnostic-file.ts'
+import filesStorage from '#files-storage'
+import { validationDiagnosticFilePath, cancelledDraftDiagnosticFilePath } from '../../datasets/utils/files.ts'
 import * as extensionsUtils from '../../datasets/utils/extensions.ts'
 import { updateStorage } from '../../datasets/utils/storage.ts'
 import truncateMiddle from 'truncate-middle'
@@ -208,11 +210,18 @@ export default async function (dataset: DatasetInternal) {
     // and emit a draft-cancelled event with breakdown counts instead of a
     // validation-error event that would reference a nonexistent file.
     if (dataset.draftReason?.validationMode === 'compatibleOrCancel') {
-      await writer.discard()
+      // Finalize the diagnostic to its normal (draft) path, then move it out of the
+      // draft directory into a stable slot on the main dataset before cancelDraft
+      // wipes the draft dir — so the contributor keeps a downloadable report.
+      const fileResult = await writer.finalize()
+      await filesStorage.moveFile(validationDiagnosticFilePath(dataset), cancelledDraftDiagnosticFilePath(dataset))
       delete patch.validateDraft
       await journals.log('datasets', dataset, {
         type: 'draft-cancelled',
         data: `annulation automatique : ${summary}`,
+        hasDiagnosticFile: true,
+        diagnosticErrorCount: fileResult.count,
+        diagnosticCapped: fileResult.capped,
         validationErrorCount: nbValidationErrors,
         extensionErrorCount: blockingExtensionErrors
       } as any)

--- a/api/src/workers/batch-processor/process-file.ts
+++ b/api/src/workers/batch-processor/process-file.ts
@@ -214,7 +214,10 @@ export default async function (dataset: DatasetInternal) {
       // draft directory into a stable slot on the main dataset before cancelDraft
       // wipes the draft dir — so the contributor keeps a downloadable report.
       const fileResult = await writer.finalize()
-      await filesStorage.moveFile(validationDiagnosticFilePath(dataset), cancelledDraftDiagnosticFilePath(dataset))
+      const srcDiagnostic = validationDiagnosticFilePath(dataset)
+      if (await filesStorage.pathExists(srcDiagnostic)) {
+        await filesStorage.moveFile(srcDiagnostic, cancelledDraftDiagnosticFilePath(dataset))
+      }
       delete patch.validateDraft
       await journals.log('datasets', dataset, {
         type: 'draft-cancelled',

--- a/docs/architecture/dataset-validation.md
+++ b/docs/architecture/dataset-validation.md
@@ -45,7 +45,7 @@ process-file worker
   │    non-mandatory remoteService errors stay in the row's error field, not in the diagnostic
   └─ Aggregate decision
        if writer.errorCount > 0:
-         (compatibleOrCancel draft → discard writer, emit draft-cancelled, cancelDraft)
+         (compatibleOrCancel draft → finalize writer, move diagnostic to cancelled-draft slot, emit draft-cancelled, cancelDraft)
          else → finalize file, emit validation-error, throw [validation-error]
        else:
          discard writer, advance status to 'extended' or 'validated'
@@ -143,7 +143,16 @@ A failed run emits exactly one `validation-error` journal event with these field
 
 A user notification is sent via `sendResourceEvent('datasets', dataset, 'data-fair-worker', 'validation-error', { params: { nbErrors, diagnosticUrl } })`. The `notifications.datasets.validation-error` and `.draft-validation-error` keys are localized in `api/i18n/messages/{fr,en}.json`.
 
-For drafts opened with `validationMode: 'compatibleOrCancel'`, an attempt that produces row errors emits a **`draft-cancelled`** event (with the same breakdown counts) instead of `validation-error`. The diagnostic file is discarded because the draft directory is wiped — there would be nowhere stable to point a download link.
+For drafts opened with `validationMode: 'compatibleOrCancel'`, an attempt that produces
+row errors emits a **`draft-cancelled`** event (with the same breakdown counts) instead
+of `validation-error`. The diagnostic file is **finalized as usual and then moved** out
+of the draft directory (which `cancelDraft` wipes) into a distinct slot on the main
+dataset, `datasets/<id>/data-files/cancelled-draft-diagnostic.csv`, served by
+`GET /api/v1/datasets/:datasetId/cancelled-draft-diagnostic.csv` (same `readJournal` /
+`readAdvanced` gate as the canonical diagnostic). The `draft-cancelled` event carries
+`hasDiagnosticFile: true` so the UI shows a download link. The dataset's own
+`validation-diagnostic.csv` slot is left untouched. The file is overwritten by a later
+cancelled contribution and removed by `validateDraft` once a contribution succeeds.
 
 ## UI surface
 

--- a/tests/features/datasets/extensions/validation-diagnostic.api.spec.ts
+++ b/tests/features/datasets/extensions/validation-diagnostic.api.spec.ts
@@ -403,4 +403,51 @@ test.describe('validation diagnostic file', () => {
     assert.equal(rows[0], 'line,error_type,field,message,raw_value')
     assert.ok(rows.slice(1).some((r: string) => r.includes(',extension,')), `expected an extension error row: ${diag.data}`)
   })
+
+  test('a successful re-contribution clears the cancelled-draft diagnostic', async () => {
+    const initialCsv = 'id,n\na,5\nb,10\n'
+    const form = new FormData()
+    form.append('file', Buffer.from(initialCsv), 'simple.csv')
+    let dataset = (await testUser1.post('/api/v1/datasets', form, {
+      headers: { 'Content-Length': form.getLengthSync(), ...form.getHeaders() }
+    })).data
+    dataset = await waitForFinalize(testUser1, dataset.id)
+
+    await testUser1.patch(`/api/v1/datasets/${dataset.id}`, {
+      schema: dataset.schema,
+      extensions: [{
+        active: true,
+        mandatory: true,
+        type: 'exprEval',
+        expr: 'n == 0 ? "zero" : n',
+        property: { key: 'inverse', type: 'number' }
+      }]
+    })
+    await waitForFinalize(testUser1, dataset.id)
+
+    // failing contribution -> draft cancelled, diagnostic relocated
+    const badForm = new FormData()
+    badForm.append('file', Buffer.from('id,n\nc,7\nd,0\n'), 'simple.csv')
+    await testUser1.post(`/api/v1/datasets/${dataset.id}`, badForm, {
+      headers: { 'Content-Length': badForm.getLengthSync(), ...badForm.getHeaders() },
+      params: { draft: 'compatibleOrCancel' }
+    })
+    for (let i = 0; i < 60; i++) {
+      const journal = (await testUser1.get(`/api/v1/datasets/${dataset.id}/journal`)).data
+      if (journal.find((e: any) => e.type === 'draft-cancelled')) break
+      await new Promise(resolve => setTimeout(resolve, 500))
+    }
+    assert.equal((await fetchCancelledDiagnostic(dataset.id)).status, 200)
+
+    // good contribution -> draft validated/promoted, relocated diagnostic removed
+    const goodForm = new FormData()
+    goodForm.append('file', Buffer.from('id,n\nc,7\nd,8\n'), 'simple.csv')
+    await testUser1.post(`/api/v1/datasets/${dataset.id}`, goodForm, {
+      headers: { 'Content-Length': goodForm.getLengthSync(), ...goodForm.getHeaders() },
+      params: { draft: 'compatibleOrCancel' }
+    })
+    await waitForFinalize(testUser1, dataset.id)
+
+    assert.equal((await fetchCancelledDiagnostic(dataset.id)).status, 404)
+  })
 })

--- a/tests/features/datasets/extensions/validation-diagnostic.api.spec.ts
+++ b/tests/features/datasets/extensions/validation-diagnostic.api.spec.ts
@@ -451,5 +451,12 @@ test.describe('validation diagnostic file', () => {
     await waitForFinalize(testUser1, dataset.id)
 
     assert.equal((await fetchCancelledDiagnostic(dataset.id)).status, 404)
+
+    // the stale draft-cancelled event must no longer advertise a diagnostic, so the
+    // UI stops rendering a download button that would 404
+    const journal = (await testUser1.get(`/api/v1/datasets/${dataset.id}/journal`)).data
+    const staleCancel = journal.find((e: any) => e.type === 'draft-cancelled')
+    assert.ok(staleCancel, 'expected the draft-cancelled event to still be in the journal')
+    assert.ok(!staleCancel.hasDiagnosticFile, 'expected hasDiagnosticFile to be cleared after re-contribution')
   })
 })

--- a/tests/features/datasets/extensions/validation-diagnostic.api.spec.ts
+++ b/tests/features/datasets/extensions/validation-diagnostic.api.spec.ts
@@ -432,11 +432,13 @@ test.describe('validation diagnostic file', () => {
       headers: { 'Content-Length': badForm.getLengthSync(), ...badForm.getHeaders() },
       params: { draft: 'compatibleOrCancel' }
     })
+    let cancelled = false
     for (let i = 0; i < 60; i++) {
       const journal = (await testUser1.get(`/api/v1/datasets/${dataset.id}/journal`)).data
-      if (journal.find((e: any) => e.type === 'draft-cancelled')) break
+      if (journal.find((e: any) => e.type === 'draft-cancelled')) { cancelled = true; break }
       await new Promise(resolve => setTimeout(resolve, 500))
     }
+    assert.ok(cancelled, 'expected draft-cancelled event before re-contribution')
     assert.equal((await fetchCancelledDiagnostic(dataset.id)).status, 200)
 
     // good contribution -> draft validated/promoted, relocated diagnostic removed

--- a/tests/features/datasets/extensions/validation-diagnostic.api.spec.ts
+++ b/tests/features/datasets/extensions/validation-diagnostic.api.spec.ts
@@ -13,6 +13,13 @@ const fetchDiagnostic = async (datasetId: string) => {
   })
 }
 
+const fetchCancelledDiagnostic = async (datasetId: string) => {
+  return testUser1.get(`/api/v1/datasets/${datasetId}/cancelled-draft-diagnostic.csv`, {
+    responseType: 'text',
+    validateStatus: () => true
+  })
+}
+
 const findEvent = async (datasetId: string, type: string) => {
   const journal = (await testUser1.get(`/api/v1/datasets/${datasetId}/journal`)).data
   return journal.find((e: any) => e.type === type)
@@ -341,5 +348,59 @@ test.describe('validation diagnostic file', () => {
     // diagnostic endpoint should 404 (the draft directory was wiped)
     const diag = await fetchDiagnostic(dataset.id)
     assert.equal(diag.status, 404)
+  })
+
+  test('compatibleOrCancel preserves a downloadable cancelled-draft diagnostic', async () => {
+    const initialCsv = 'id,n\na,5\nb,10\n'
+    const form = new FormData()
+    form.append('file', Buffer.from(initialCsv), 'simple.csv')
+    let dataset = (await testUser1.post('/api/v1/datasets', form, {
+      headers: { 'Content-Length': form.getLengthSync(), ...form.getHeaders() }
+    })).data
+    dataset = await waitForFinalize(testUser1, dataset.id)
+
+    const patchRes = await testUser1.patch(`/api/v1/datasets/${dataset.id}`, {
+      schema: dataset.schema,
+      extensions: [{
+        active: true,
+        mandatory: true,
+        type: 'exprEval',
+        expr: 'n == 0 ? "zero" : n',
+        property: { key: 'inverse', type: 'number' }
+      }]
+    })
+    assert.equal(patchRes.status, 200)
+    await waitForFinalize(testUser1, dataset.id)
+
+    // draft with one failing row (n=0) — schema-compatible, extension fails
+    const draftCsv = 'id,n\nc,7\nd,0\n'
+    const form2 = new FormData()
+    form2.append('file', Buffer.from(draftCsv), 'simple.csv')
+    await testUser1.post(`/api/v1/datasets/${dataset.id}`, form2, {
+      headers: { 'Content-Length': form2.getLengthSync(), ...form2.getHeaders() },
+      params: { draft: 'compatibleOrCancel' }
+    })
+
+    // poll for the draft-cancelled event
+    let cancelEvent: any
+    for (let i = 0; i < 60; i++) {
+      const journal = (await testUser1.get(`/api/v1/datasets/${dataset.id}/journal`)).data
+      cancelEvent = journal.find((e: any) => e.type === 'draft-cancelled')
+      if (cancelEvent) break
+      await new Promise(resolve => setTimeout(resolve, 500))
+    }
+    assert.ok(cancelEvent, 'expected draft-cancelled event')
+    assert.equal(cancelEvent.hasDiagnosticFile, true)
+    assert.ok((cancelEvent.diagnosticErrorCount ?? 0) > 0)
+
+    // canonical slot untouched (still 404)
+    assert.equal((await fetchDiagnostic(dataset.id)).status, 404)
+
+    // relocated diagnostic is downloadable and lists the failing row
+    const diag = await fetchCancelledDiagnostic(dataset.id)
+    assert.equal(diag.status, 200)
+    const rows = diag.data.replace(/^\uFEFF/, '').trim().split('\n')
+    assert.equal(rows[0], 'line,error_type,field,message,raw_value')
+    assert.ok(rows.slice(1).some((r: string) => r.includes(',extension,')), `expected an extension error row: ${diag.data}`)
   })
 })

--- a/ui/src/components/journal-view.vue
+++ b/ui/src/components/journal-view.vue
@@ -51,7 +51,7 @@
             {{ event.date ? dayjs(event.date).format('lll') : dayjs().format('lll') }}
           </span>
           <v-btn
-            v-if="event.type === 'validation-error' && (event as any).hasDiagnosticFile && diagnosticDownloadHref(event)"
+            v-if="(event as any).hasDiagnosticFile && diagnosticDownloadHref(event)"
             variant="text"
             size="small"
             color="error"
@@ -112,6 +112,11 @@ const { journal, type, after } = defineProps<{
 const datasetStore = inject<DatasetStore | undefined>(datasetStoreKey, undefined)
 const diagnosticDownloadHref = (event: Event) => {
   if (type !== 'dataset' || !datasetStore) return undefined
+  // an auto-cancelled contribution stores its diagnostic in a distinct slot on the
+  // main dataset (the draft is gone), served by a dedicated route, no ?draft
+  if (event.type === 'draft-cancelled') {
+    return `${datasetStore.resourceUrl.value}/cancelled-draft-diagnostic.csv`
+  }
   const qs = event.draft ? '?draft=true' : ''
   return `${datasetStore.resourceUrl.value}/validation-diagnostic.csv${qs}`
 }


### PR DESCRIPTION
When a contribution draft is auto-cancelled in `compatibleOrCancel` mode, the validation diagnostic is now preserved instead of discarded, so the contributor can still download the error report.

**What changed:**
- `process-file` worker: on `compatibleOrCancel` cancellation, finalize the diagnostic and move it out of the (about-to-be-wiped) draft directory into a stable slot on the main dataset (`data-files/cancelled-draft-diagnostic.csv`). The `draft-cancelled` journal event now carries `hasDiagnosticFile`, `diagnosticErrorCount`, `diagnosticCapped`.
- New `cancelledDraftDiagnosticFilePath` helper (always resolves to the main, non-draft dir).
- New route `GET /api/v1/datasets/:datasetId/cancelled-draft-diagnostic.csv`, same `readJournal`/`readAdvanced` gate and shape as the canonical diagnostic route.
- `validateDraft`: on a successful re-contribution, removes a stale cancelled-draft diagnostic file **and** clears `hasDiagnosticFile` on the prior `draft-cancelled` journal event so the UI stops offering a download that 404s.
- UI `journal-view`: download button now keys off `hasDiagnosticFile` for any event (not just `validation-error`), and `draft-cancelled` events link to the new dedicated route.
- Docs + API tests (relocated-diagnostic download, and clear-on-successful-re-contribution incl. the journal flag).

**Why:** a cancelled `compatibleOrCancel` contribution previously discarded its diagnostic because the draft dir is wiped — leaving the contributor with no way to see which rows failed.

**Regression risks:**
- The canonical `validation-diagnostic.csv` slot is intentionally left untouched; verify no path confuses the two diagnostics.
- The UI `v-if` was broadened from `event.type === 'validation-error' && hasDiagnosticFile` to just `hasDiagnosticFile && href`. Only `validation-error` and `draft-cancelled` set the flag today, so behavior is unchanged in practice — but any future event that sets `hasDiagnosticFile` will now render a download link.
