### PR TITLE
fix(ui): keep original file downloadable while dataset is stuck in conversion

### DIFF
--- a/ui/src/components/dataset/dataset-actions.vue
+++ b/ui/src/components/dataset/dataset-actions.vue
@@ -179,7 +179,7 @@ const isDraft = computed(() => !!dataset.value?.draftReason)
 
 const isFileDataset = computed(() => {
   const d = dataset.value
-  return d && !d.isRest && !d.isVirtual && !d.isMetaOnly && d.file
+  return d && !d.isRest && !d.isVirtual && !d.isMetaOnly && (d.file || d.originalFile)
 })
 
 const labelKeys: Record<string, string> = {


### PR DESCRIPTION
In the back-office, a dataset blocked (or still running) in conversion showed no button to download its original file. This was downloadable in the legacy UI and is a regression.

**What changed:**
- `dataset-actions.vue`: `isFileDataset` no longer requires `dataset.file`; it now accepts `dataset.originalFile` too (`d.file || d.originalFile`).

**Why:** the downloads section and the `sourceFiles` list are gated behind `isFileDataset`, which required `dataset.file`. That field is only set after a *successful* conversion (`store-file.ts` only sets `file` for basic types; otherwise it is produced later by the normalize step). So a dataset stuck in conversion has `originalFile` set but `file` unset → the whole downloads block was hidden. In ui-legacy the list came from the `/data-files` endpoint, driven by files actually present on disk, so the original file stayed available regardless of `file`.

The original file is served by `GET /datasets/:id/raw` (with `?draft=true`), which only needs `originalFile` and supports drafts — so nothing else was missing, only the UI gate.

**Regression risks:**
- `isFileDataset` also gates the "Mettre à jour les données" upload dialog and `canUpdateData`. Both now also become available when only `originalFile` is set (no `file` yet) — desirable, as re-uploading is the way to unblock a stuck conversion.
- The "Fichier converti" entry stays hidden while `file` is unset (its own condition in `dataset-store.ts` is independent).