### PR TITLE
fix(ui): escape all unsafe chars in table header css keys

### DIFF
--- a/ui/src/components/dataset/table/use-headers.ts
+++ b/ui/src/components/dataset/table/use-headers.ts
@@ -29,6 +29,10 @@ export type TableHeader = {
 
 export type TableHeaderWithProperty = Omit<TableHeader, 'property'> & Required<Pick<TableHeader, 'property'>>
 
+// transform a schema key into a string usable in a CSS selector (id/class/activator) ;
+// keys can contain dots but also slashes, accents, spaces, etc. that would break querySelector
+const toCssKey = (key: string) => key.replace(/[^a-zA-Z0-9_-]/g, '__')
+
 export const useHeaders = (
   selectedCols: Ref<string[]>,
   noInteraction: boolean,
@@ -46,7 +50,7 @@ export const useHeaders = (
     const useKeyAsTitle = toValue(headerKeys) === true
     let headers: TableHeader[] | undefined = dataset.value?.schema?.filter(p => selectedCols.value.includes(p.key)).map((p) => ({
       key: p.key,
-      cssKey: p.key.replace(/\./g, '__'),
+      cssKey: toCssKey(p.key),
       title: useKeyAsTitle ? p.key : (p.title || p['x-originalName'] || p.key),
       sortable:
         (!p['x-capabilities'] || p['x-capabilities'].values !== false) && (
@@ -80,7 +84,7 @@ export const useHeaders = (
         for (const col of synth) {
           const header: TableHeader = {
             key: col.key,
-            cssKey: col.key.replace(/\./g, '__'),
+            cssKey: toCssKey(col.key),
             title: col.title,
             tooltip: col.titleHint,
             sticky: col.sticky,


### PR DESCRIPTION
Dans la vue tableau d'un jeu de données, chaque en-tête de colonne génère un `id` puis un activator de menu sous la forme `#header-${cssKey}`. Le `cssKey` n'échappait que les points (`.` → `__`), donc une clé contenant un `/` produisait un sélecteur invalide (ex. `#header-secteur_public/privé`), faisant lever une `SyntaxError` non catchée à `querySelector` dans VOverlay, ce qui cassait ensuite la navigation. Le `cssKey` échappe désormais tout caractère non valide dans un identifiant CSS, pas seulement les points.

**Why:** cela ne concerne que les anciens jeux de données où les `/` étaient encore acceptés dans les clés de colonnes. Les nouveaux jeux de données normalisent les clés et n'autorisent plus les `/` (les `_` restent possibles), mais les jeux existants peuvent toujours en contenir et déclenchaient le bug.

**Regression risks:**
- Le `.` reste mappé sur `__` comme avant ; le changement ne fait qu'étendre l'échappement aux autres caractères (`/`, accents, espaces…). Risque de collision théorique entre deux clés distinctes produisant le même `cssKey` (donc le même activator) — déjà présent pour le `.`, négligeable en pratique.
- Modification limitée au sélecteur CSS / DOM : le `key` réel utilisé pour le tri et les filtres est inchangé, aucun impact API ni données.
