### PR TITLE
feat(applications): show parent applications that use a visualization

### DIFF
--- a/api/src/applications/service.ts
+++ b/api/src/applications/service.ts
@@ -27,6 +27,7 @@ const filterFields = {
   url: 'url',
   'base-application': 'url',
   dataset: 'configuration.datasets.id',
+  application: 'configuration.applications.id',
   topics: 'topics.id',
   publicationSites: 'publicationSites',
   requestedPublicationSites: 'requestedPublicationSites'

--- a/tests/features/applications/applications.api.spec.ts
+++ b/tests/features/applications/applications.api.spec.ts
@@ -159,6 +159,35 @@ test.describe('Applications', () => {
     assert.equal(dataset.extras.applications.length, 1)
   })
 
+  test('Filter applications by a child application they use', async () => {
+    const ax = testUser1
+
+    // a child application (a visualization used by others)
+    const { data: childApp } = await ax.post('/api/v1/applications', { url: mockAppUrl('monapp1') })
+    const childRef = (await ax.get('/api/v1/applications', { params: { id: childApp.id, select: 'id' } })).data.results[0]
+
+    // a parent application referencing the child in its configuration
+    const { data: parentApp } = await ax.post('/api/v1/applications', { url: mockAppUrl('monapp1') })
+    let res = await ax.put('/api/v1/applications/' + parentApp.id + '/config', {
+      applications: [{ id: childApp.id, href: childRef.href }]
+    })
+    assert.equal(res.status, 200)
+
+    // querying applications using an unknown child returns nothing
+    res = await ax.get('/api/v1/applications', { params: { application: 'nope' } })
+    assert.equal(res.data.count, 0)
+
+    // querying applications using the child returns the parent
+    res = await ax.get('/api/v1/applications', { params: { application: childApp.id } })
+    assert.equal(res.data.count, 1)
+    assert.equal(res.data.results[0].id, parentApp.id)
+
+    // size=0 returns only the count (used by the "used by" link)
+    res = await ax.get('/api/v1/applications', { params: { application: childApp.id, size: 0 } })
+    assert.equal(res.data.count, 1)
+    assert.equal(res.data.results.length, 0)
+  })
+
   test('Use an application through the application proxy', async () => {
     const ax = testUser1
     const adminAx = alban

--- a/ui/src/components/application/metadata/application-metadata-details.vue
+++ b/ui/src/components/application/metadata/application-metadata-details.vue
@@ -70,6 +70,24 @@
           <div>{{ application.createdBy?.name }} {{ formatDate(application.createdAt) }}</div>
         </v-list-item>
       </v-col>
+
+      <v-col
+        v-if="nbParentApps > 0"
+        cols="12"
+        md="6"
+        lg="4"
+      >
+        <v-list-item :prepend-icon="mdiImageMultiple">
+          <div class="text-body-small text-medium-emphasis">
+            {{ t('usedByLabel') }}
+          </div>
+          <div>
+            <router-link :to="`/applications?application=${application.id}`">
+              {{ t('nbParentApps', nbParentApps) }}
+            </router-link>
+          </div>
+        </v-list-item>
+      </v-col>
     </v-row>
   </template>
 </template>
@@ -81,20 +99,24 @@ fr:
   version: version
   metadataUpdated: Métadonnées mises à jour
   created: Création
+  usedByLabel: Utilisée par
+  nbParentApps: aucune application | 1 application | {count} applications
 en:
   owner: Owner
   baseApp: Application model
   version: version
   metadataUpdated: Metadata updated
   created: Created
+  usedByLabel: Used by
+  nbParentApps: no application | 1 application | {count} applications
 </i18n>
 
 <script setup lang="ts">
-import { mdiPencil, mdiPlusCircleOutline, mdiSquareEditOutline } from '@mdi/js'
+import { mdiImageMultiple, mdiPencil, mdiPlusCircleOutline, mdiSquareEditOutline } from '@mdi/js'
 import useLocaleDayjs from '@data-fair/lib-vue/locale-dayjs.js'
 import useApplicationStore from '~/composables/application/application-store'
 
-const { application, baseAppFetch } = useApplicationStore()
+const { application, baseAppFetch, nbParentApps } = useApplicationStore()
 
 const { t } = useI18n()
 const { dayjs } = useLocaleDayjs()

--- a/ui/src/composables/application/application-store.ts
+++ b/ui/src/composables/application/application-store.ts
@@ -145,6 +145,15 @@ const createApplicationStore = (id: string) => {
     watch: false
   })
 
+  // number of parent applications using this one (reverse reference, like virtual datasets for a dataset)
+  const nbParentAppsFetch = useFetch<{ count: number }>(() => {
+    if (!application.value) return null
+    return `${$apiPath}/applications`
+  }, {
+    query: computed(() => ({ application: id, size: 0 }))
+  })
+  const nbParentApps = computed(() => nbParentAppsFetch.data.value?.count ?? 0)
+
   const permissionsFetch = useFetch<Permission[]>($apiPath + `/applications/${id}/permissions`, { immediate: false, watch: false })
   const permissions = ref<Permission[] | null>(null)
   watch(permissionsFetch.data, () => {
@@ -201,6 +210,7 @@ const createApplicationStore = (id: string) => {
     savePermissions,
     datasetsFetch,
     childrenAppsFetch,
+    nbParentApps,
     remove,
     changeOwner,
   }

--- a/ui/src/pages/applications/index.vue
+++ b/ui/src/pages/applications/index.vue
@@ -223,6 +223,9 @@ const facetTopics = useStringsArraySearchParam('topics')
 const facetPublicationSites = useStringsArraySearchParam('publicationSites')
 const facetRequestedPublicationSites = useStringsArraySearchParam('requestedPublicationSites')
 
+// Parent applications filter (applications using a specific application)
+const parentApp = useStringSearchParam('application')
+
 // Include shared applications for a given owner
 const shared = useStringSearchParam('shared')
 
@@ -256,6 +259,7 @@ const applicationsQuery = computed(() => {
   if (facetTopics.value?.length) params.topics = facetTopics.value.join(',')
   if (facetPublicationSites.value?.length) params.publicationSites = facetPublicationSites.value.join(',')
   if (facetRequestedPublicationSites.value?.length) params.requestedPublicationSites = facetRequestedPublicationSites.value.join(',')
+  if (parentApp.value) params.application = parentApp.value
   if (shared.value) params.shared = shared.value
   else if (showAll.value !== 'true') params.shared = 'false'
   return params


### PR DESCRIPTION
On a child visualization's page, add a "Used by N application(s)" link in the info block (mirroring the "virtual datasets" link on a dataset), pointing to the applications list filtered to the parents that embed it. Backed by a new `application` filter on `GET /api/v1/applications` (matches `configuration.applications.id`); the supporting index already exists.

**Why:** a visualization used inside another (e.g. a dashboard) gave no indication on its own page that it was used elsewhere. First step of a broader effort to surface links between platform resources.

**Regression risks:**
- `application` is added to `filterFields`, which is spread into `facetFields`/`fieldsMap`; the list page doesn't request it as a facet, so no behavior change there — it's just now a valid filter/facet field.
