### PR TITLE
feat(agent): application config, metadata writers & page guidance

### DIFF
--- a/docs/architecture/agent-integration-gaps.md
+++ b/docs/architecture/agent-integration-gaps.md
@@ -11,7 +11,8 @@ This document identifies areas of Data Fair where AI assistance would be valuabl
 - **Dataset description**: set description (1 tool + 1 subagent)
 - **Dataset changes**: read diff (1 tool + 1 subagent)
 - **Dataset expressions**: context, sample, test, set (4 tools + 1 subagent)
-- **Applications**: list, describe, list base apps (3 tools)
+- **Applications**: list, describe, get config, list base apps (4 tools)
+- **Application metadata**: set summary, set description (2 tools + 2 subagents + 2 action buttons)
 - **Application config**: VJSF sub-agent (1 subagent)
 - **Geolocation**: geocode, user location (2 tools)
 - **Connectors**: list/describe processings and catalogs (0-4 conditional tools)
@@ -19,7 +20,9 @@ This document identifies areas of Data Fair where AI assistance would be valuabl
 - **Application creation**: wizard stepper tools (4 tools + 1 action button)
 - **Dataset creation**: wizard stepper tools (5 tools + 1 action button)
 
-**Total: 34 tools, 8 subagents, 10 action buttons**
+- **Page guidance**: dataset and application detail pages (shared renderer)
+
+**Total: 37 tools, 10 subagents, 12 action buttons**
 
 ---
 

--- a/docs/architecture/agent-integration.md
+++ b/docs/architecture/agent-integration.md
@@ -11,7 +11,7 @@ The integration follows a **browser-side tool exposure** pattern: the main appli
 - **Tools execute in the browser**: all tool logic runs client-side in the main application frame, with the user's session and permissions. The agent service never directly accesses the Data Fair API.
 - **Bilingual**: all tool annotations, subagent prompts, and the system prompt support French and English.
 - **Progressive activation**: the feature is gated behind an environment variable, an organization setting, and responsive UI rules.
-- **Read-heavy, write-light**: of 36 tools, only 7 perform writes (navigate, set_expression, set_dataset_summary, set_dataset_description, set_property_config, open_add_line_dialog, open_edit_line_dialog). The creation wizard tools manipulate client-side form state only — no server-side writes.
+- **Read-heavy, write-light**: of 39 tools, only 9 perform writes (navigate, set_expression, set_dataset_summary, set_dataset_description, set_application_summary, set_application_description, set_property_config, open_add_line_dialog, open_edit_line_dialog). These metadata "writes" set the edit-form field client-side — the user still saves. The creation wizard tools manipulate client-side form state only — no server-side writes.
 
 ### Activation flow
 
@@ -35,8 +35,8 @@ graph TB
             FS["Frame Server<br/>(BroadcastChannel)"]
             TR["Tool Registry<br/>(useAgentTool)"]
             SR["Subagent Registry<br/>(useAgentSubAgent)"]
-            Tools["36 Tools"]
-            SubAgents["8 Subagents"]
+            Tools["39 Tools"]
+            SubAgents["10 Subagents"]
             TR --> Tools
             SR --> SubAgents
             FS --> TR
@@ -295,6 +295,16 @@ The capability → operation mapping is a single source of truth: `FILTER_CAPABI
 | **Tools** | `list_services_versions`, `explore_github` |
 | **Source** | `ui/src/composables/agent/releases-tools.ts`, `ui/src/pages/admin/info.vue` |
 
+### 4.16 Write Application Summary / Description
+
+| | |
+|---|---|
+| **Trigger** | Action buttons next to the summary textarea and the description markdown editor on the application detail page (Metadata → Info tab) |
+| **Action IDs** | `summarize-application`, `describe-application` |
+| **Subagents** | `application_summarizer` (model `summarizer`) — ≤300 char plain-text summary; `application_description_writer` — 500-2000 char markdown description |
+| **Pattern** | Same as the dataset summary/description flow. The parent passes the current `applicationId` to the subagent (via the action button's hidden-context); the subagent reads context with the global `describe_application` + `get_application_config` tools. Generated text is presented and applied on approval via `set_application_summary` / `set_application_description` (which write the edit-form field — the user still saves). `set_application_summary` validates ≤300 chars and rejects generic openings ("This application is…" / "Cette application est…"), forcing a retry. |
+| **Source** | `ui/src/composables/application/agent-metadata-tools.ts`, `ui/src/components/application/metadata/application-metadata-form.vue`, `ui/src/pages/application/[id]/index.vue` |
+
 ## 5. Tool Reference
 
 | Tool | Category | R/W | Source |
@@ -325,7 +335,10 @@ The capability → operation mapping is a single source of truth: `FILTER_CAPABI
 | `get_user_geolocation` | Geolocation | R | `agent/geo-tools.ts` |
 | `list_applications` | Applications | R | `application/agent-tools.ts` |
 | `describe_application` | Applications | R | `application/agent-tools.ts` |
+| `get_application_config` | Applications | R | `application/agent-tools.ts` |
 | `list_base_applications` | Applications | R | `application/agent-tools.ts` |
+| `set_application_summary` | Application metadata | **W** | `application/agent-metadata-tools.ts` |
+| `set_application_description` | Application metadata | **W** | `application/agent-metadata-tools.ts` |
 | `select_creation_type` | App creation | W* | `application/agent-creation-tools.ts` |
 | `select_base_application` | App creation | W* | `application/agent-creation-tools.ts` |
 | `select_copy_application` | App creation | W* | `application/agent-creation-tools.ts` |
@@ -339,11 +352,11 @@ The capability → operation mapping is a single source of truth: `FILTER_CAPABI
 | `describe_processing` | Connectors | R | `agent/connector-tools.ts` |
 | `list_catalogs` | Connectors | R | `agent/connector-tools.ts` |
 | `describe_catalog` | Connectors | R | `agent/connector-tools.ts` |
-| `page_guidance` | Page guidance | R | `dataset/agent-page-guidance-tools.ts` (dataset detail page) |
+| `page_guidance` | Page guidance | R | `dataset/agent-page-guidance-tools.ts`, `application/agent-page-guidance-tools.ts` |
 | `list_services_versions` | Service info | R | `agent/releases-tools.ts` |
 | `explore_github` | Service info | R | `agent/releases-tools.ts` |
 
-All source paths are relative to `ui/src/composables/` unless otherwise noted. **W*** = client-side state only (no server write). Connector tools are conditional on integration flags. **`page_guidance`** is a page-scoped fallback tool: each page that registers it (currently only the dataset detail page) carries its own essential anti-misroute facts in the tool description and a full page structure / interaction guide in the returned content. The agent is instructed to call it only when unsure how to help the user on the current page.
+All source paths are relative to `ui/src/composables/` unless otherwise noted. **W*** = client-side state only (no server write). Connector tools are conditional on integration flags. **`page_guidance`** is a page-scoped fallback tool: each page that registers it (currently the dataset and application detail pages) carries its own essential anti-misroute facts in the tool description and a full page structure / interaction guide in the returned content. The renderer (`buildGuidance` + the `Guided*` types) is shared in `composables/agent/page-guidance.ts`; each page composable supplies its own heading, intro, and `agentDesc`-annotated `sections`. The agent is instructed to call it only when unsure how to help the user on the current page.
 
 ## 6. Subagent Reference
 
@@ -357,6 +370,8 @@ All source paths are relative to `ui/src/composables/` unless otherwise noted. *
 | `expression_helper` | default | Write and test expr-eval expressions | `get_expression_context`, `get_sample_data`, `test_expression` |
 | `schema_annotator` | summarizer | Suggest column titles and descriptions | Schema annotation tools |
 | `property_config_advisor` | summarizer | Suggest type overrides and capability optimizations | `read_property_config`, `set_property_config` |
+| `application_summarizer` | summarizer | Generate ≤300 char application summaries | `describe_application`, `get_application_config` |
+| `application_description_writer` | default | Generate 500-2000 char markdown application descriptions | `describe_application`, `get_application_config` |
 | `appConfig_form` | VJSF-managed | Fill application configuration form via natural language | VJSF form tools |
 | `editLine_form` | VJSF-managed | Fill add/edit line form via natural language | VJSF form tools |
 
@@ -383,7 +398,11 @@ All source paths are relative to `ui/src/composables/` unless otherwise noted. *
 | `ui/src/composables/dataset/agent-expression-tools.ts` | Expression tools (4) + `expression_helper` subagent |
 | `ui/src/composables/dataset/agent-schema-annotation-tools.ts` | Schema annotation tools (2) + `schema_annotator` subagent |
 | `ui/src/composables/dataset/agent-property-config-tools.ts` | Property config tools (2) + `property_config_advisor` subagent |
-| `ui/src/composables/application/agent-tools.ts` | Application tools (3) |
+| `ui/src/composables/agent/page-guidance.ts` | Shared page-guidance renderer (`buildGuidance` + `Guided*` types) for dataset + application |
+| `ui/src/composables/application/agent-tools.ts` | Application tools (4): list, describe, `get_application_config`, list base apps |
+| `ui/src/composables/application/agent-metadata-tools.ts` | Application summary + description set-tools (2) + `application_summarizer` & `application_description_writer` subagents |
+| `ui/src/composables/application/agent-page-guidance-tools.ts` | Application detail page `page_guidance` tool (thin renderer over the shared module) |
+| `ui/src/components/application/metadata/application-metadata-form.vue` | `summarize-application` and `describe-application` action buttons |
 | `ui/src/composables/application/agent-creation-tools.ts` | Application creation wizard tools (4) |
 | `ui/src/composables/dataset/agent-creation-tools.ts` | Dataset creation wizard tools (5) |
 | `ui/src/components/dataset/dataset-info.vue` | `summarize-dataset` and `describe-dataset` action buttons |

--- a/tests/features/agent-tools/application-config-tools.unit.spec.ts
+++ b/tests/features/agent-tools/application-config-tools.unit.spec.ts
@@ -1,0 +1,19 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { formatApplicationConfig } from '../../../ui/src/composables/application/agent-tools-logic.ts'
+
+test.describe('formatApplicationConfig', () => {
+  test('returns a not-configured message for empty config', () => {
+    assert.equal(formatApplicationConfig(null), 'This application is not configured yet.')
+    assert.equal(formatApplicationConfig(undefined), 'This application is not configured yet.')
+    assert.equal(formatApplicationConfig({}), 'This application is not configured yet.')
+  })
+
+  test('pretty-prints a non-empty config inside a json code fence', () => {
+    const out = formatApplicationConfig({ datasets: [{ id: 'd1' }], title: 'X' })
+    assert.ok(out.startsWith('```json\n'))
+    assert.ok(out.endsWith('\n```'))
+    assert.ok(out.includes('"datasets"'))
+    assert.ok(out.includes('  '))
+  })
+})

--- a/tests/features/agent-tools/application-metadata-tools.unit.spec.ts
+++ b/tests/features/agent-tools/application-metadata-tools.unit.spec.ts
@@ -1,0 +1,25 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { validateApplicationSummary } from '../../../ui/src/composables/application/agent-metadata-tools-logic.ts'
+
+test.describe('validateApplicationSummary', () => {
+  test('accepts a concise specific summary', () => {
+    assert.equal(validateApplicationSummary('Interactive map of EV charging stations in France.'), null)
+  })
+
+  test('rejects a summary longer than 300 characters', () => {
+    const long = 'a'.repeat(301)
+    const err = validateApplicationSummary(long)
+    assert.ok(err && err.includes('301 characters'))
+  })
+
+  test('rejects a generic English opening', () => {
+    const err = validateApplicationSummary('This application is a dashboard.')
+    assert.ok(err && err.includes('generic phrase'))
+  })
+
+  test('rejects a generic French opening (case-insensitive)', () => {
+    const err = validateApplicationSummary('Cette application est un tableau de bord.')
+    assert.ok(err && err.includes('generic phrase'))
+  })
+})

--- a/tests/features/agent-tools/page-guidance.unit.spec.ts
+++ b/tests/features/agent-tools/page-guidance.unit.spec.ts
@@ -1,0 +1,31 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { buildGuidance, type GuidedSections } from '../../../ui/src/composables/agent/page-guidance.ts'
+
+test.describe('buildGuidance', () => {
+  test('renders heading, intro, sections and tabs that have an agentDesc', () => {
+    const sections: GuidedSections = {
+      a: { title: 'Section A', agentDesc: 'Does A.' },
+      b: {
+        title: 'Section B',
+        tabs: [
+          { key: 't1', title: 'Tab 1', agentDesc: 'Tab one.' },
+          { key: 't2', title: 'Tab 2' }
+        ]
+      }
+    }
+    const out = buildGuidance('My page', 'Intro line.', sections)
+    assert.ok(out.startsWith('# My page\n\nIntro line.\n'))
+    assert.ok(out.includes('## Section A'))
+    assert.ok(out.includes('Does A.'))
+    assert.ok(out.includes('## Section B'))
+    assert.ok(out.includes('- **Tab 1** — Tab one.'))
+    assert.ok(!out.includes('Tab 2'))
+  })
+
+  test('skips sections with neither agentDesc nor described tabs', () => {
+    const sections: GuidedSections = { a: { title: 'Empty' } }
+    const out = buildGuidance('P', 'I.', sections)
+    assert.ok(!out.includes('## Empty'))
+  })
+})

--- a/ui/src/components/application/metadata/application-metadata-form.vue
+++ b/ui/src/components/application/metadata/application-metadata-form.vue
@@ -18,27 +18,47 @@
         class="mb-4"
       />
 
-      <v-textarea
-        v-model="application.summary"
-        :disabled="!can('writeDescription')"
-        :label="t('summary')"
-        :base-color="fieldColor('summary')"
-        :color="fieldColor('summary')"
-        rows="3"
-        variant="outlined"
-        density="compact"
-        hide-details
-        class="mb-4"
-      />
+      <div class="d-flex align-start gap-1 mb-4">
+        <v-textarea
+          v-model="application.summary"
+          :disabled="!can('writeDescription')"
+          :label="t('summary')"
+          :base-color="fieldColor('summary')"
+          :color="fieldColor('summary')"
+          rows="3"
+          variant="outlined"
+          density="compact"
+          hide-details
+          class="flex-grow-1"
+        />
+        <df-agent-chat-action
+          v-if="can('writeDescription')"
+          action-id="summarize-application"
+          :visible-prompt="t('summarizePrompt')"
+          :hidden-context="summarizeContext"
+          :btn-props="{ class: 'ml-1' }"
+          :title="t('summarizePrompt')"
+        />
+      </div>
 
-      <markdown-editor
-        v-model="application.description"
-        :read-only="!can('writeDescription')"
-        :label="t('description')"
-        :locale="locale"
-        :csp-nonce="$cspNonce"
-        :input-props="{ class: 'flex-grow-1' }"
-      />
+      <div class="d-flex align-start gap-1 mb-3">
+        <markdown-editor
+          v-model="application.description"
+          :read-only="!can('writeDescription')"
+          :label="t('description')"
+          :locale="locale"
+          :csp-nonce="$cspNonce"
+          :input-props="{ class: 'flex-grow-1' }"
+        />
+        <df-agent-chat-action
+          v-if="can('writeDescription')"
+          action-id="describe-application"
+          :visible-prompt="t('describePrompt')"
+          :hidden-context="describeContext"
+          :btn-props="{ class: 'ml-1 mt-6' }"
+          :title="t('describePrompt')"
+        />
+      </div>
     </v-col>
 
     <!-- Right column: secondary fields -->
@@ -86,17 +106,22 @@ fr:
   description: Description
   topics: Thématiques
   image: Adresse d'une image utilisée comme vignette
+  summarizePrompt: Aide-moi à rédiger un résumé pour cette application
+  describePrompt: Aide-moi à rédiger une description pour cette application
 en:
   title: Title
   summary: Summary
   description: Description
   topics: Topics
   image: URL of an image used as thumbnail
+  summarizePrompt: Help me write a summary for this application
+  describePrompt: Help me write a description for this application
 </i18n>
 
 <script setup lang="ts">
 import equal from 'fast-deep-equal'
 import { MarkdownEditor } from '@koumoul/vjsf-markdown'
+import { DfAgentChatAction } from '@data-fair/lib-vuetify-agents'
 import { $cspNonce } from '~/context'
 
 const application = defineModel<any>({ required: true })
@@ -106,6 +131,21 @@ const props = defineProps<{
 }>()
 
 const { t, locale } = useI18n()
+
+const summarizeContext = computed(() =>
+  `The user wants help writing a summary for application "${application.value?.id}". ` +
+  'Use the application_summarizer subagent to produce a summary, passing it that applicationId. ' +
+  'Once you receive the summary, present it to the user and ask for their approval before applying it. ' +
+  'If approved, use the set_application_summary tool to set it. If the user wants changes, adjust accordingly.'
+)
+const describeContext = computed(() =>
+  `The user wants help writing a description for application "${application.value?.id}". ` +
+  'The description field supports markdown and should be more detailed than the summary. ' +
+  'Ask the user what aspects they want to emphasize or any specific requirements, then use the ' +
+  'application_description_writer subagent, passing it that applicationId. ' +
+  'Once you receive the description, present it to the user and ask for their approval before applying it. ' +
+  'If approved, use the set_application_description tool to set it. If the user wants changes, adjust accordingly.'
+)
 
 const can = (op: string) => application.value?.userPermissions?.includes(op) ?? false
 

--- a/ui/src/composables/agent/page-guidance.ts
+++ b/ui/src/composables/agent/page-guidance.ts
@@ -1,0 +1,22 @@
+// Generic renderer for page-guidance tools. Section/tab descriptions are
+// co-located with each page's `sections` computed; this is a thin renderer.
+export type GuidedTab = { key: string, title: string, agentDesc?: string }
+export type GuidedSection = { title: string, agentDesc?: string, tabs?: GuidedTab[] }
+export type GuidedSections = Record<string, GuidedSection>
+
+export function buildGuidance (heading: string, intro: string, sections: GuidedSections): string {
+  const lines: string[] = [`# ${heading}`, '', intro, '']
+
+  for (const section of Object.values(sections)) {
+    const tabsWithDesc = section.tabs?.filter(t => t.agentDesc) ?? []
+    if (!section.agentDesc && !tabsWithDesc.length) continue
+    lines.push(`## ${section.title}`)
+    if (section.agentDesc) lines.push(section.agentDesc)
+    for (const tab of tabsWithDesc) {
+      lines.push(`- **${tab.title}** — ${tab.agentDesc}`)
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n').trimEnd()
+}

--- a/ui/src/composables/application/agent-metadata-tools-logic.ts
+++ b/ui/src/composables/application/agent-metadata-tools-logic.ts
@@ -1,0 +1,12 @@
+// Pure validation for set_application_summary, extracted for unit testing.
+// Returns an error message to feed back to the agent, or null when valid.
+export function validateApplicationSummary (summary: string): string | null {
+  if (summary.length > 300) {
+    return `Error: summary is ${summary.length} characters long, it must be 300 characters or less. Please shorten it and try again.`
+  }
+  const genericStarts = ['this application is', 'cette application est']
+  if (genericStarts.some(s => summary.toLowerCase().startsWith(s))) {
+    return 'Error: the summary must not start with a generic phrase like "This application is..." or "Cette application est...". Please rephrase with a more direct and specific opening.'
+  }
+  return null
+}

--- a/ui/src/composables/application/agent-metadata-tools.ts
+++ b/ui/src/composables/application/agent-metadata-tools.ts
@@ -1,0 +1,144 @@
+import type { Ref } from 'vue'
+import { useAgentTool, useAgentSubAgent } from '@data-fair/lib-vue-agents'
+import { createAgentTranslator } from '~/composables/agent/utils'
+import { validateApplicationSummary } from './agent-metadata-tools-logic'
+
+const messages: Record<string, Record<string, string>> = {
+  fr: {
+    setApplicationSummary: 'Définir le résumé de l\'application',
+    setApplicationDescription: 'Définir la description de l\'application',
+    summarizerSubAgent: 'Résumer une application',
+    summarizerSubAgentDesc: 'Lire les métadonnées et la configuration de l\'application, puis produire un résumé concis.',
+    descriptionWriterSubAgent: 'Rédiger une description d\'application',
+    descriptionWriterSubAgentDesc: 'Lire les métadonnées et la configuration de l\'application, puis rédiger une description détaillée.'
+  },
+  en: {
+    setApplicationSummary: 'Set the application summary',
+    setApplicationDescription: 'Set the application description',
+    summarizerSubAgent: 'Summarize an application',
+    summarizerSubAgentDesc: 'Read the application metadata and configuration, then produce a concise summary.',
+    descriptionWriterSubAgent: 'Write an application description',
+    descriptionWriterSubAgentDesc: 'Read the application metadata and configuration, then write a detailed description.'
+  }
+}
+
+export function useAgentApplicationMetadataTools (
+  locale: Ref<string>,
+  setSummary: (summary: string) => void,
+  setDescription: (description: string) => void
+) {
+  const t = createAgentTranslator(messages, locale)
+
+  useAgentTool({
+    name: 'set_application_summary',
+    description: 'Set the summary field of the application currently being edited.',
+    annotations: { title: t('setApplicationSummary') },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        summary: { type: 'string' as const, description: 'The summary text to set' }
+      },
+      required: ['summary'] as const
+    },
+    execute: async (params) => {
+      const error = validateApplicationSummary(params.summary)
+      if (error) return error
+      setSummary(params.summary)
+      return 'Summary updated successfully.'
+    }
+  })
+
+  useAgentTool({
+    name: 'set_application_description',
+    description: 'Set the description field of the application currently being edited. The description supports markdown formatting.',
+    annotations: { title: t('setApplicationDescription') },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        description: { type: 'string' as const, description: 'The markdown description text to set' }
+      },
+      required: ['description'] as const
+    },
+    execute: async (params) => {
+      setDescription(params.description)
+      return 'Description updated successfully.'
+    }
+  })
+
+  const summarizerPrompts: Record<string, string> = {
+    fr: `Tu es un expert en résumé d'applications de visualisation de données pour Data Fair. Les résumés sont affichés dans les catalogues pour aider les utilisateurs à comprendre rapidement ce que fait une application.
+
+Tâche :
+1. Appelle describe_application puis get_application_config avec l'identifiant d'application fourni par l'agent parent pour obtenir les métadonnées et la configuration.
+2. Rédige un résumé décrivant ce que montre et permet l'application (type de visualisation, jeux de données utilisés, objectif).
+3. Renvoie le texte du résumé comme réponse finale.
+
+Format :
+- 300 caractères maximum (entre 200 et 300 idéalement)
+- Texte brut uniquement : pas de formatage, pas de markdown, pas de retours à la ligne
+- Ton accessible — le public va des analystes de données au grand public
+- Rédige dans la même langue que le titre et les métadonnées existantes
+- Ne commence JAMAIS par "Cette application est..." ou une formulation générique similaire. Commence directement par le sujet concret.`,
+    en: `You are an expert at summarizing data-visualization applications for Data Fair. Summaries are displayed in catalogs to help users quickly understand what an application does.
+
+Task:
+1. Call describe_application then get_application_config with the application id provided by the parent agent to get the metadata and configuration.
+2. Write a summary describing what the application shows and lets users do (visualization type, datasets used, purpose).
+3. Return the summary text as your final response.
+
+Format:
+- 300 characters maximum (ideally between 200 and 300)
+- Plain text only: no formatting, no markdown, no line breaks
+- Use an accessible tone — the audience ranges from data analysts to general public users
+- Write in the same language as the title and existing metadata
+- NEVER start with "This application is..." or similar generic phrasing. Start directly with the concrete subject.`
+  }
+
+  useAgentSubAgent({
+    name: 'application_summarizer',
+    title: t('summarizerSubAgent'),
+    description: t('summarizerSubAgentDesc'),
+    model: 'summarizer',
+    prompt: summarizerPrompts[locale.value] ?? summarizerPrompts.en,
+    tools: ['describe_application', 'get_application_config']
+  })
+
+  const descriptionWriterPrompts: Record<string, string> = {
+    fr: `Tu es un expert en documentation d'applications de visualisation de données pour Data Fair. Les descriptions sont affichées sur les pages d'application pour aider les utilisateurs à comprendre l'application en détail.
+
+Tâche :
+1. Appelle describe_application puis get_application_config avec l'identifiant d'application fourni par l'agent parent pour obtenir les métadonnées et la configuration.
+2. Rédige une description détaillée de l'application : ce qu'elle montre, comment l'utiliser, quels jeux de données elle exploite.
+3. Renvoie le texte de la description comme réponse finale.
+
+Format :
+- Entre 500 et 2000 caractères
+- Le formatage markdown est encouragé : titres (##), listes à puces, gras pour les termes clés
+- Structure : vue d'ensemble, contenu / interactions, notes d'utilisation
+- Ton accessible — le public va des analystes de données au grand public
+- Rédige dans la même langue que le titre et les métadonnées existantes
+- Ne répète pas simplement le résumé ; la description doit apporter de la profondeur et du contexte`,
+    en: `You are a documentation expert for data-visualization applications on Data Fair. Descriptions are displayed on application pages to help users understand the application in detail.
+
+Task:
+1. Call describe_application then get_application_config with the application id provided by the parent agent to get the metadata and configuration.
+2. Write a detailed description of the application: what it shows, how to use it, which datasets it draws on.
+3. Return the description text as your final response.
+
+Format:
+- Between 500 and 2000 characters
+- Markdown formatting is encouraged: headings (##), bullet lists, bold for key terms
+- Structure: overview, content / interactions, usage notes
+- Use an accessible tone — the audience ranges from data analysts to general public users
+- Write in the same language as the title and existing metadata
+- Do not simply repeat the summary; the description should add depth and context`
+  }
+
+  useAgentSubAgent({
+    name: 'application_description_writer',
+    title: t('descriptionWriterSubAgent'),
+    description: t('descriptionWriterSubAgentDesc'),
+    prompt: descriptionWriterPrompts[locale.value] ?? descriptionWriterPrompts.en,
+    tools: ['describe_application', 'get_application_config']
+  })
+}

--- a/ui/src/composables/application/agent-page-guidance-tools.ts
+++ b/ui/src/composables/application/agent-page-guidance-tools.ts
@@ -1,0 +1,39 @@
+import type { Ref } from 'vue'
+import { useAgentTool } from '@data-fair/lib-vue-agents'
+import { createAgentTranslator } from '~/composables/agent/utils'
+import { buildGuidance, type GuidedSections } from '~/composables/agent/page-guidance'
+
+const messages: Record<string, Record<string, string>> = {
+  fr: { pageGuidance: 'Guide de la page' },
+  en: { pageGuidance: 'Page guide' }
+}
+
+// Always-on description, read on every turn. Keep concise; the rich content
+// is in the returned guide, called on demand when the agent is unsure.
+const description =
+  'Page guide for the application detail page — registered only while the ' +
+  'user is viewing that page, so its presence in your tool list signals the ' +
+  'current location. Returns the page structure (sections, tabs, and agent ' +
+  'help buttons not in the global tool list). Call only when unsure how to ' +
+  'help the user here; if another tool obviously fits the need, use it.'
+
+export function useAgentApplicationPageGuidance (locale: Ref<string>, sections: Ref<GuidedSections>) {
+  const t = createAgentTranslator(messages, locale)
+
+  useAgentTool({
+    name: 'page_guidance',
+    description,
+    annotations: { title: t('pageGuidance'), readOnlyHint: true },
+    inputSchema: { type: 'object' as const, properties: {} },
+    execute: async () => ({
+      content: [{
+        type: 'text' as const,
+        text: buildGuidance(
+          'Application detail page',
+          'Collapsible sections; some have tabs. Only sections and tabs currently visible to this user are listed.',
+          sections.value
+        )
+      }]
+    })
+  })
+}

--- a/ui/src/composables/application/agent-tools-logic.ts
+++ b/ui/src/composables/application/agent-tools-logic.ts
@@ -1,0 +1,7 @@
+// Pure formatting for the get_application_config tool, extracted for unit testing.
+export function formatApplicationConfig (config: any): string {
+  if (!config || (typeof config === 'object' && Object.keys(config).length === 0)) {
+    return 'This application is not configured yet.'
+  }
+  return '```json\n' + JSON.stringify(config, null, 2) + '\n```'
+}

--- a/ui/src/composables/application/agent-tools.ts
+++ b/ui/src/composables/application/agent-tools.ts
@@ -2,17 +2,20 @@ import type { Ref } from 'vue'
 import { useAgentTool } from '@data-fair/lib-vue-agents'
 import { $fetch } from '~/context'
 import { createAgentTranslator, buildPaginatedQuery } from '~/composables/agent/utils'
+import { formatApplicationConfig } from './agent-tools-logic'
 
 const messages: Record<string, Record<string, string>> = {
   fr: {
     listApplications: 'Lister les applications',
     describeApplication: 'Décrire une application',
-    listBaseApplications: 'Lister les modèles d\'application'
+    listBaseApplications: 'Lister les modèles d\'application',
+    getApplicationConfig: 'Lire la configuration de l\'application'
   },
   en: {
     listApplications: 'List applications',
     describeApplication: 'Describe an application',
-    listBaseApplications: 'List application models'
+    listBaseApplications: 'List application models',
+    getApplicationConfig: 'Read application configuration'
   }
 }
 
@@ -97,6 +100,28 @@ export function useAgentApplicationTools (locale: Ref<string>) {
     execute: async (params) => {
       const app = await $fetch<any>(`applications/${encodeURIComponent(params.applicationId)}`)
       return serializeApplicationInfo(app)
+    }
+  })
+
+  useAgentTool({
+    name: 'get_application_config',
+    description: 'Get the current validated configuration of an application (the live config, not the editable draft). Returns the configuration as JSON: selected datasets, display options, and other settings defined by the application model. Read-only — use the appConfig_form subagent to change the configuration.',
+    annotations: { title: t('getApplicationConfig'), readOnlyHint: true },
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        applicationId: { type: 'string' as const, description: 'The exact application ID' }
+      },
+      required: ['applicationId'] as const
+    },
+    execute: async (params) => {
+      let config: any
+      try {
+        config = await $fetch<any>(`applications/${encodeURIComponent(params.applicationId)}/configuration`)
+      } catch {
+        return 'This application is not configured yet.'
+      }
+      return formatApplicationConfig(config)
     }
   })
 

--- a/ui/src/composables/dataset/agent-page-guidance-tools.ts
+++ b/ui/src/composables/dataset/agent-page-guidance-tools.ts
@@ -1,6 +1,9 @@
 import type { Ref } from 'vue'
 import { useAgentTool } from '@data-fair/lib-vue-agents'
 import { createAgentTranslator } from '~/composables/agent/utils'
+import { buildGuidance, type GuidedSections } from '~/composables/agent/page-guidance'
+
+export type { GuidedTab, GuidedSection, GuidedSections } from '~/composables/agent/page-guidance'
 
 const messages: Record<string, Record<string, string>> = {
   fr: { pageGuidance: 'Guide de la page' },
@@ -16,35 +19,6 @@ const description =
   'help buttons not in the global tool list). Call only when unsure how to ' +
   'help the user here; if another tool obviously fits the need, use it.'
 
-// Section/tab descriptions are co-located with the page's `sections` computed
-// so they evolve together with structural and permission-conditional logic.
-// This composable is a thin renderer.
-export type GuidedTab = { key: string, title: string, agentDesc?: string }
-export type GuidedSection = { title: string, agentDesc?: string, tabs?: GuidedTab[] }
-export type GuidedSections = Record<string, GuidedSection>
-
-function buildGuidance (sections: GuidedSections): string {
-  const lines: string[] = [
-    '# Dataset detail page',
-    '',
-    'Collapsible sections; some have tabs. Only sections and tabs currently visible to this user are listed.',
-    ''
-  ]
-
-  for (const section of Object.values(sections)) {
-    const tabsWithDesc = section.tabs?.filter(t => t.agentDesc) ?? []
-    if (!section.agentDesc && !tabsWithDesc.length) continue
-    lines.push(`## ${section.title}`)
-    if (section.agentDesc) lines.push(section.agentDesc)
-    for (const tab of tabsWithDesc) {
-      lines.push(`- **${tab.title}** — ${tab.agentDesc}`)
-    }
-    lines.push('')
-  }
-
-  return lines.join('\n').trimEnd()
-}
-
 export function useAgentDatasetPageGuidance (locale: Ref<string>, sections: Ref<GuidedSections>) {
   const t = createAgentTranslator(messages, locale)
 
@@ -56,7 +30,11 @@ export function useAgentDatasetPageGuidance (locale: Ref<string>, sections: Ref<
     execute: async () => ({
       content: [{
         type: 'text' as const,
-        text: buildGuidance(sections.value)
+        text: buildGuidance(
+          'Dataset detail page',
+          'Collapsible sections; some have tabs. Only sections and tabs currently visible to this user are listed.',
+          sections.value
+        )
       }]
     })
   })

--- a/ui/src/pages/application/[id]/index.vue
+++ b/ui/src/pages/application/[id]/index.vue
@@ -496,6 +496,8 @@ import securitySvg from '~/assets/svg/Security_Two Color.svg?raw'
 import { useApplicationVersions } from '~/composables/application/versions'
 import { useApplicationWatch } from '~/composables/application/watch'
 import { useBreadcrumbs } from '~/composables/layout/use-breadcrumbs'
+import { useAgentApplicationMetadataTools } from '~/composables/application/agent-metadata-tools'
+import { useAgentApplicationPageGuidance } from '~/composables/application/agent-page-guidance-tools'
 import { $uiConfig, $apiPath } from '~/context'
 
 const { t, locale } = useI18n()
@@ -545,6 +547,13 @@ watch(() => application.value?.image, (newImage) => {
 })
 
 useLeaveGuard(metadataEditFetch.hasDiff, { locale })
+
+// Agent tools for metadata editing
+useAgentApplicationMetadataTools(
+  locale,
+  (s) => { if (metadataEditFetch.data.value) metadataEditFetch.data.value.summary = s },
+  (d) => { if (metadataEditFetch.data.value) metadataEditFetch.data.value.description = d }
+)
 
 const cancelMetadata = () => {
   metadataEditFetch.data.value = JSON.parse(JSON.stringify(metadataEditFetch.serverData.value))
@@ -610,64 +619,66 @@ const confirmRemove = useAsyncAction(async () => {
 }, { success: t('deleteAppSuccess') })
 
 const sections = computedDeepDiff(() => {
-  if (!application.value) return {} as Record<string, { title: string, subtitle?: string, tabs?: any[] }>
+  if (!application.value) return {} as Record<string, { title: string, subtitle?: string, tabs?: any[], agentDesc?: string }>
 
-  const result: Record<string, { title: string, subtitle?: string, tabs?: any[] }> = {}
+  const result: Record<string, { title: string, subtitle?: string, tabs?: any[], agentDesc?: string }> = {}
 
   // Informations section
   result.informations = {
     title: t('info'),
-    subtitle: t('informationsSubtitle')
+    subtitle: t('informationsSubtitle'),
+    agentDesc: 'Read-only overview of the application: owner, application model (base app) and version, key dates. No edit controls here — descriptive metadata is edited in the Metadata section below.'
   }
 
   // Metadata section
   const metadataTabs = [
-    { key: 'info', title: t('info'), icon: mdiInformation, color: metadataEditFetch.hasDiff.value ? 'accent' : undefined },
-    { key: 'attachments', title: t('attachments'), icon: mdiPaperclip }
+    { key: 'info', title: t('info'), icon: mdiInformation, color: metadataEditFetch.hasDiff.value ? 'accent' : undefined, agentDesc: 'Edit form for descriptive metadata: title, summary, description (markdown), topics, thumbnail image. Two in-form help buttons: next to the summary → application_summarizer subagent (≤300 char summary); next to the description → application_description_writer subagent (500-2000 char markdown).' },
+    { key: 'attachments', title: t('attachments'), icon: mdiPaperclip, agentDesc: 'Upload/edit/delete file attachments for the application; an attachment can be set as the thumbnail.' }
   ]
   if (datasets.value.length) {
-    metadataTabs.push({ key: 'datasets', title: t('datasets'), icon: mdiDatabase })
+    metadataTabs.push({ key: 'datasets', title: t('datasets'), icon: mdiDatabase, agentDesc: 'The datasets used by this application (read-only cards).' })
   }
   if (childrenApps.value.length) {
-    metadataTabs.push({ key: 'children-apps', title: t('childrenApps'), icon: mdiImageMultiple })
+    metadataTabs.push({ key: 'children-apps', title: t('childrenApps'), icon: mdiImageMultiple, agentDesc: 'Other applications used by this application (read-only cards).' })
   }
-  result.metadata = { title: t('metadata'), tabs: metadataTabs }
+  result.metadata = { title: t('metadata'), tabs: metadataTabs, agentDesc: 'Descriptive metadata edition. Save / cancel buttons appear in the section header when there are unsaved changes.' }
 
   // Render section
   result.render = {
     title: t('render'),
-    tabs: [{ key: 'config', title: t('config'), icon: mdiSquareEditOutline }]
+    tabs: [{ key: 'config', title: t('config'), icon: mdiSquareEditOutline, agentDesc: 'Live preview of the application with an "Edit configuration" button leading to the full-screen config editor (where the appConfig_form subagent assists). Use get_application_config to read the current validated configuration.' }],
+    agentDesc: 'Rendered application and entry point to its configuration.'
   }
 
   const shareTabs = []
   if (can('getPermissions')) {
-    shareTabs.push({ key: 'permissions', title: t('permissions'), icon: mdiSecurity })
+    shareTabs.push({ key: 'permissions', title: t('permissions'), icon: mdiSecurity, agentDesc: 'Grant read / admin permissions to users, organisations, departments or partners, or open access to "anyone".' })
   }
   if (can('getKeys')) {
-    shareTabs.push({ key: 'protected-links', title: t('protectedLink'), icon: mdiCloudKey })
+    shareTabs.push({ key: 'protected-links', title: t('protectedLink'), icon: mdiCloudKey, agentDesc: 'Manage protected links — unconnected access to the application via signed URLs.' })
   }
   if (!$uiConfig.disablePublicationSites) {
-    shareTabs.push({ key: 'publication-sites', title: t('publicationSites'), icon: mdiPresentation })
+    shareTabs.push({ key: 'publication-sites', title: t('publicationSites'), icon: mdiPresentation, agentDesc: 'Publish or unpublish this application on the organisation\'s data portals.' })
   }
-  shareTabs.push({ key: 'integration', title: t('integration'), icon: mdiCodeTags })
+  shareTabs.push({ key: 'integration', title: t('integration'), icon: mdiCodeTags, agentDesc: 'Ready-to-copy iframe / embed snippets to integrate this application into external pages.' })
   if (shareTabs.length) {
-    result.share = { title: t('share'), tabs: shareTabs }
+    result.share = { title: t('share'), tabs: shareTabs, agentDesc: 'Access control and publication settings for this application.' }
   }
 
   if ($uiConfig.eventsIntegration) {
     const activityTabs = []
     if (can('readJournal')) {
-      activityTabs.push({ key: 'traceability', title: t('traceability'), icon: mdiClipboardTextClock })
+      activityTabs.push({ key: 'traceability', title: t('traceability'), icon: mdiClipboardTextClock, agentDesc: 'Audit trail of user actions on this application (who did what, when).' })
     }
-    activityTabs.push({ key: 'notifications', title: t('notifications'), icon: mdiBell })
+    activityTabs.push({ key: 'notifications', title: t('notifications'), icon: mdiBell, agentDesc: 'Subscribe to in-app / email notifications for events on this application.' })
     if (can('setPermissions')) {
-      activityTabs.push({ key: 'webhooks', title: t('webhooks'), icon: mdiWebhook })
+      activityTabs.push({ key: 'webhooks', title: t('webhooks'), icon: mdiWebhook, agentDesc: 'Configure webhooks fired on events for this application.' })
     }
-    result.activity = { title: t('tracking'), tabs: activityTabs }
+    result.activity = { title: t('tracking'), tabs: activityTabs, agentDesc: 'Activity tracking for this application.' }
   }
 
   if (can('delete')) {
-    result.dangerZone = { title: t('dangerZone'), tabs: [] }
+    result.dangerZone = { title: t('dangerZone'), tabs: [], agentDesc: 'Destructive operations: change owner, delete the application.' }
   }
 
   return result
@@ -679,4 +690,6 @@ const tocSections = computed(() => {
     title: s.title
   }))
 })
+
+useAgentApplicationPageGuidance(locale, sections)
 </script>


### PR DESCRIPTION
Add agent assistance to the application detail page, mirroring what already exists for datasets: a `get_application_config` read tool, summary/description writer tools + subagents + action buttons, and a `page_guidance` tool. Also extracts the page-guidance renderer into a shared module now that a second page consumes it.

**Why:** the application page lagged the dataset page — the assistant had no way to read an application's configuration, help write its summary/description, or understand the page structure.

**What changed:**
- `get_application_config` — global read tool returning the *validated* config (`GET applications/{id}/configuration`) as JSON; deliberately separate from the draft/schema form-edit tools.
- `set_application_summary` (≤300 chars, generic-opening rejection) + `set_application_description`, each with a writer subagent (`application_summarizer`, `application_description_writer`) and a `DfAgentChatAction` button on the metadata form, gated on `writeDescription`.
- `page_guidance` on the application detail page + `agentDesc` annotations across its sections/tabs.
- Refactor: shared `composables/agent/page-guidance.ts` renderer consumed by both dataset and application page-guidance composables.
- Docs: `agent-integration.md` and `agent-integration-gaps.md` updated.

**Regression risks:**
- `application-metadata-form.vue`: the summary textarea and markdown editor are now wrapped in flex containers to seat the action buttons (margins moved: summary `mb-4` to the wrapper, editor newly wrapped in `mb-3`). Cosmetic — confirm spacing renders as before. Mirrors the dataset metadata form.
- `get_application_config` maps any fetch failure to "This application is not configured yet." — a genuine 403/500/network error would read as "unconfigured" to the agent rather than surfacing the error. Intentional simplification; flagging in case stricter handling is wanted.
- `buildGuidance` signature changed (now takes `heading, intro, sections`); the sole caller (dataset composable) is updated in the same branch and output is byte-identical (unit-tested). The moved `Guided*` types are re-exported from the dataset module for safety; no external callers existed.