### PR TITLE
fix(agent-tools): correct output schemas and surface search_data cursor

### DIFF
--- a/agent-tools/calculate-metric.ts
+++ b/agent-tools/calculate-metric.ts
@@ -25,7 +25,10 @@ export const schema = {
       datasetId: { type: 'string' as const, description: 'The dataset ID that was queried' },
       fieldKey: { type: 'string' as const, description: 'The column key that was queried' },
       total: { type: 'number' as const, description: 'Total number of rows included in the calculation' },
-      metric: { type: 'object' as const, description: 'The calculated metric value. For avg/sum/min/max/value_count/cardinality: a single number. For stats: an object {count, min, max, avg, sum}. For percentiles: an object mapping percentage strings to values, e.g. {"25": 30000, "50": 42000, "75": 55000}.' }
+      // polymorphic: a number for avg/sum/min/max/value_count/cardinality on numeric columns,
+      // a string for min/max on string columns, an object for stats/percentiles. Left untyped so
+      // the MCP output-schema validation accepts every shape the metric_agg endpoint returns.
+      metric: { description: 'The calculated metric value. For avg/sum/min/max/value_count/cardinality: a single number (or a string for min/max on string columns). For stats: an object {count, min, max, avg, sum}. For percentiles: an object mapping percentage strings to values, e.g. {"25": 30000, "50": 42000, "75": 55000}.' }
     },
     required: ['datasetId', 'fieldKey', 'total', 'metric'] as const
   }

--- a/agent-tools/describe-dataset.ts
+++ b/agent-tools/describe-dataset.ts
@@ -51,7 +51,7 @@ export const schema = {
         description: 'Dataset license information (must be included in responses)'
       },
       topics: { type: 'array' as const, items: { type: 'string' as const }, description: 'Topics/categories the dataset belongs to' },
-      spatial: { type: 'object' as const, description: 'Spatial coverage information' },
+      spatial: { type: 'string' as const, description: 'Spatial coverage information (free-text description)' },
       temporal: { type: 'object' as const, description: 'Temporal coverage information' },
       frequency: { type: 'string' as const, description: 'Update frequency of the dataset' },
       geolocalized: { type: 'boolean' as const, description: 'Whether the dataset has geographic data' },

--- a/agent-tools/search-data.ts
+++ b/agent-tools/search-data.ts
@@ -81,7 +81,10 @@ export function formatResult (data: any, params: Params): { text: string, struct
     toCsv(rows)
   ]
   if (data.next) {
-    lines.push('', 'Next page available.')
+    // The cursor only travels back to the model through this text (the harness forwards
+    // tool text, not structuredContent). Emit the URL verbatim so the model can pass it as
+    // the `next` param instead of fabricating one. See structuredContent.next below.
+    lines.push('', `Next page available — call search_data again with next set to this URL:\n${data.next}`)
   }
   if (filterQueryString) {
     lines.push('', `Filter query: ${filterQueryString}`)

--- a/tests/features/datasets/agent-tools-output-schema.unit.spec.ts
+++ b/tests/features/datasets/agent-tools-output-schema.unit.spec.ts
@@ -1,0 +1,103 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import Ajv from 'ajv'
+import * as calculateMetric from '../../../agent-tools/calculate-metric.ts'
+import * as describeDataset from '../../../agent-tools/describe-dataset.ts'
+import * as searchData from '../../../agent-tools/search-data.ts'
+
+// The agent tools declare an `outputSchema` and return a `structuredContent`.
+// The MCP SDK strictly validates the latter against the former (ajv). When they
+// disagree the tool call fails with "Output validation error: Invalid structured
+// content ... Instance type X is invalid. Expected Y." and the assistant loses
+// access to the tool. These tests pin structuredContent to its declared schema
+// using real-world data shapes returned by the data-fair API.
+
+const ajv = new Ajv({ strict: false, allErrors: true })
+
+const validate = (outputSchema: any, structuredContent: any) => {
+  const fn = ajv.compile(outputSchema)
+  const ok = fn(structuredContent)
+  return { ok, errors: ajv.errorsText(fn.errors) }
+}
+
+test.describe('calculate_metric output schema', () => {
+  // sum/avg/min/max/value_count/cardinality return a single number
+  test('numeric metric (sum) matches outputSchema', () => {
+    const { structuredContent } = calculateMetric.formatResult(
+      { total: 16, metric: 4721525 },
+      { datasetId: 'd1', fieldKey: 'energieannuelleglissanteinjectee', metric: 'sum' }
+    )
+    const { ok, errors } = validate(calculateMetric.schema.outputSchema, structuredContent)
+    assert.ok(ok, errors)
+  })
+
+  // min/max on a string column return a string
+  test('string metric (max on string column) matches outputSchema', () => {
+    const { structuredContent } = calculateMetric.formatResult(
+      { total: 16, metric: 'Solaire' },
+      { datasetId: 'd1', fieldKey: 'filiere', metric: 'max' }
+    )
+    const { ok, errors } = validate(calculateMetric.schema.outputSchema, structuredContent)
+    assert.ok(ok, errors)
+  })
+
+  // stats/percentiles return an object — must still validate
+  test('object metric (stats) matches outputSchema', () => {
+    const { structuredContent } = calculateMetric.formatResult(
+      { total: 16, metric: { count: 16, min: 0, max: 4721525, avg: 1000, sum: 6000000 } },
+      { datasetId: 'd1', fieldKey: 'puismaxinstallee', metric: 'stats' }
+    )
+    const { ok, errors } = validate(calculateMetric.schema.outputSchema, structuredContent)
+    assert.ok(ok, errors)
+  })
+})
+
+test.describe('describe_dataset output schema', () => {
+  // data-fair models `spatial` as a free-text string (api/types/dataset spatial?: string)
+  test('dataset with string spatial coverage matches outputSchema', () => {
+    const { structuredContent } = describeDataset.formatResult({
+      id: 'd1',
+      title: 'Agrégats de production électrique',
+      page: 'https://opendata.enedis.fr/datasets/prod',
+      count: 5679072,
+      spatial: 'France métropolitaine',
+      temporal: { start: '2020-01-01', end: '2024-12-31' },
+      license: { title: 'Licence Ouverte', href: 'https://example.org/licence' }
+    })
+    const { ok, errors } = validate(describeDataset.schema.outputSchema, structuredContent)
+    assert.ok(ok, errors)
+  })
+})
+
+test.describe('search_data output schema (regression guard)', () => {
+  test('result rows match outputSchema', () => {
+    const { structuredContent } = searchData.formatResult(
+      { total: 16, results: [{ commune: 'Nanterre', filiere: 'Solaire' }] },
+      { datasetId: 'd1' }
+    )
+    const { ok, errors } = validate(searchData.schema.outputSchema, structuredContent)
+    assert.ok(ok, errors)
+  })
+})
+
+test.describe('search_data pagination cursor', () => {
+  // The harness forwards only the tool text to the model, not structuredContent. The next
+  // cursor must therefore appear verbatim in the text, otherwise the model fabricates a URL.
+  test('text includes the next URL when another page exists', () => {
+    const nextUrl = 'https://opendata.enedis.fr/api/v1/datasets/d1/lines?page=2&after=xyz'
+    const { text, structuredContent } = searchData.formatResult(
+      { total: 16, results: [{ commune: 'Nanterre' }], next: nextUrl },
+      { datasetId: 'd1' }
+    )
+    assert.ok(text.includes(nextUrl), 'next URL must be present in the text sent to the model')
+    assert.equal(structuredContent.next, nextUrl)
+  })
+
+  test('no next URL when on the last page', () => {
+    const { text } = searchData.formatResult(
+      { total: 5, results: [{ commune: 'Nanterre' }] },
+      { datasetId: 'd1' }
+    )
+    assert.ok(!text.includes('Next page available'), text)
+  })
+})


### PR DESCRIPTION
Fix three output bugs in `agent-tools` that broke the data assistant against real datasets (observed in an Enedis portal session where `describe_dataset` and `calculate_metric` failed validation and `search_data` then dead-ended on pagination).

**Why:** a captured assistant session failed every `describe_dataset`/`calculate_metric` call with MCP "Output validation error" and then got stuck fabricating a `search_data` pagination URL.

- `calculate_metric`: `metric` was typed `object`, but it's a number for sum/avg/min/max/value_count/cardinality (and a string for min/max on string columns). Strict MCP output validation rejected the call. Now untyped to accept every `metric_agg` shape.
- `describe_dataset`: `spatial` was typed `object`, but data-fair models it as a free-text string (`api/types/dataset spatial?: string`), so any dataset with spatial coverage failed validation. Fixed to `string`.
- `search_data`: the pagination cursor (`data.next`) lived only in `structuredContent`, which the agents harness discards (it forwards tool text only). The model never saw the URL and fabricated a bogus one. Now emitted verbatim in the text so it can be passed back as the `next` param.

Added unit tests validating each tool's `structuredContent` against its own `outputSchema` for real data shapes, plus the `search_data` cursor surfacing.

**Regression risks:**
- `metric` is now untyped (only loosens validation — cannot reject previously-valid output).
- `spatial` retyped object→string (matches the data model; risk only if a dataset emits a non-string spatial, which the type disallows).
- `search_data` text now includes the absolute `next` URL — model-facing only, no user-facing or snapshot impact.
