### PR TITLE
fix(applications): repair PUT route and four dormant bugs

### DIFF
--- a/api/src/applications/middlewares.ts
+++ b/api/src/applications/middlewares.ts
@@ -95,11 +95,13 @@ export const readBaseApp: RequestHandler = async (req, res, next) => {
 // in case of conflict go on with the update scenario
 export const attemptInsert: RequestHandler = async (req, res, next) => {
   if (typeof req.params.applicationId !== 'string') throw httpError(400, 'invalid path parameters')
-  const { returnValid } = await import('#types/application/index.ts')
+  // validate the request body (not the curated application), like the POST route: the curated object
+  // carries internal fields (_uniqueRefs) and a generated id that are absent from the input schema
+  const { body } = (await import('#doc/applications/post-req/index.js')).returnValid(req)
   // reqUserAuthenticated (below) throws 401 for an anonymous request — same as the legacy code,
   // where initNew() called reqUserAuthenticated() before the session/permission checks. So an
   // anonymous PUT 401s here, exactly as before; it does not fall through to readApplication.
-  const newApplication = returnValid(await service.initNewApplication(req.body, usersUtils.owner(req) as AccountKeys, reqUserAuthenticated(req), req.params.applicationId)) as Application
+  const newApplication = await service.initNewApplication(body, usersUtils.owner(req) as AccountKeys, reqUserAuthenticated(req), req.params.applicationId)
   const ctx = { sessionState: reqSessionAuthenticated(req), logCtx: reqEventLogContext(req) }
 
   permissions.initResourcePermissions(newApplication)

--- a/api/src/applications/router.ts
+++ b/api/src/applications/router.ts
@@ -27,7 +27,7 @@ import { reqEventLogContext } from '../misc/utils/req-context.ts'
 import { downloadFileFromStorage } from '../files-storage/utils.ts'
 import resolvePath from 'resolve-path'
 import filesStorage from '#files-storage'
-import type { Application, PublicationSite, Request, RequestWithResource } from '#types'
+import type { Application, Request, RequestWithResource } from '#types'
 
 const validateKeys = ajv.compile(applicationKeys)
 
@@ -65,8 +65,7 @@ router.post('', async (req, res) => {
 
   const ctx = { sessionState: reqSessionAuthenticated(req), logCtx: reqEventLogContext(req) }
   const created = await service.createApplication(ctx, application)
-  // NOTE: preserved bug — old code passes publicationSite as publicUrl arg and publicBaseUrl as publicationSite arg (swapped vs clean's signature). Preserved verbatim; casts encode the deliberate mismatch.
-  res.status(201).json(clean(created, reqPublicationSite(req), reqPublicBaseUrl(req) as unknown as PublicationSite))
+  res.status(201).json(clean(created, reqPublicBaseUrl(req), reqPublicationSite(req)))
 })
 
 router.use('/:applicationId/permissions', readApplication, permissions.router('applications', 'application', async (req, patchedApplication) => {
@@ -150,7 +149,7 @@ const writeConfig: express.RequestHandler = async (req, res) => {
   const { returnValid } = await import('#types/app-config/index.js')
   const appConfig = returnValid(req.body)
   const ctx = { sessionState: reqSessionAuthenticated(req), logCtx: reqEventLogContext(req) }
-  await service.writeApplicationConfig(ctx, reqApplication(req), appConfig, req.body)
+  await service.writeApplicationConfig(ctx, reqApplication(req), appConfig)
   res.status(200).json(req.body)
 }
 router.put('/:applicationId/config', readApplication, permissionMiddleware('writeConfig', 'write'), writeConfig)

--- a/api/src/applications/service.ts
+++ b/api/src/applications/service.ts
@@ -213,7 +213,7 @@ export const tryInsertApplication = async (ctx: ApplicationWriteContext, newAppl
 export const replaceApplication = async (ctx: ApplicationWriteContext, existingApplication: Application, newApplication: any, isNew: boolean) => {
   // preserve all readonly properties, the rest is overwritten
   for (const key of Object.keys(existingApplication)) {
-    if (!(patchKeys as unknown[]).includes([key])) {
+    if (!(patchKeys as string[]).includes(key)) {
       newApplication[key] = (existingApplication as any)[key]
     }
   }
@@ -357,7 +357,7 @@ export const deleteApplication = async (ctx: ApplicationWriteContext, applicatio
   await mongo.applicationsKeys.deleteOne({ _id: application.id })
   clearApplicationKeysCaches()
   try {
-    await filesStorage.removeFile(await (capture as any).path(application))
+    await filesStorage.removeFile(capture.captureFilePath(application))
   } catch (err) {
     console.warn('Failure to remove capture file')
   }
@@ -382,9 +382,7 @@ export const deleteApplication = async (ctx: ApplicationWriteContext, applicatio
   await syncDatasets(application)
 }
 
-// NOTE: preserved bug — router passes `req.body` (raw) as rawBody while `appConfig` is the validated value.
-// syncDatasets receives rawBody (the raw body) instead of the validated appConfig. Preserved verbatim.
-export const writeApplicationConfig = async (ctx: ApplicationWriteContext, application: Application, appConfig: any, rawBody: any) => {
+export const writeApplicationConfig = async (ctx: ApplicationWriteContext, application: Application, appConfig: any) => {
   const db = mongo.db
   await db.collection('applications').updateOne(
     { id: application.id },
@@ -407,7 +405,8 @@ export const writeApplicationConfig = async (ctx: ApplicationWriteContext, appli
   eventsLog.info('df.applications.writeConfig', `wrote application config ${application.slug} (${application.id})`, { ...ctx.logCtx, account: application.owner })
 
   await journals.log('applications', application, { type: 'config-updated' } as Event)
-  await syncDatasets({ configuration: rawBody })
+  // sync the validated config and reconcile back-references against the previous configuration
+  await syncDatasets({ configuration: appConfig }, application)
 }
 
 export const writeConfigDraft = async (ctx: ApplicationWriteContext, application: Application, appConfig: any) => {

--- a/api/src/misc/utils/capture.ts
+++ b/api/src/misc/utils/capture.ts
@@ -19,6 +19,9 @@ const captureUrl = config.privateCaptureUrl || config.captureUrl
 
 const capturesDir = path.resolve(config.dataDir, 'captures')
 
+// path of the capture artifact for an application, used to clean it up when the application is deleted
+export const captureFilePath = (application: { id: string }) => resolvePath(capturesDir, application.id + '.png')
+
 const screenshotRequestOpts = (req: RequestWithResource, isDefaultThumbnail = false): AxiosRequestConfig => {
   const resource = reqResource(req)
   const screenshotUrl = (captureUrl + '/api/v1/screenshot')

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -130,7 +130,7 @@ services:
       - DEBUG=capture
       - PUBLIC_URL=http://${DEV_HOST}:${NGINX_PORT1}/capture
       - ONLY_SAME_HOST=false
-      - PROMETHEUS_ACTIVE=false
+      - OBSERVER_ACTIVE=false
       - PUPPETEER_ARGS=["--no-sandbox"]
 
   events:

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -20,25 +20,6 @@ Related docs: dormant correctness bugs from the perf scan in
 
 ## Suggested PR candidates (grouped)
 
-### PR 1 — Applications dormant bugs `P2 · M`
-All in `applications/service.ts` / `router.ts`, all surfaced in Phase 4. Four independent small fixes
-+ a test each; coherent as one PR.
-- `2e` **PUT readonly-key preservation is a no-op** — `if (!patchKeys.includes([key]))` compares against
-  an **array literal**, always true → every existing field is copied onto the new application. Fix:
-  `!patchKeys.includes(key)`. (`replaceApplication`)
-- `2f` **delete: capture-file removal always throws** — calls `capture.path(application)` but
-  `misc/utils/capture.ts` exports only `screenshot`/`print`; `TypeError` swallowed by try/catch →
-  capture artifacts never cleaned on delete. (`deleteApplication`)
-- `2g` **writeConfig syncs the raw, unvalidated body** — `syncDatasets({ configuration: rawBody })`
-  passes `req.body` not the validated `appConfig`, and omits `oldApp` → back-refs not reconciled
-  against the previous config. (`writeApplicationConfig`)
-- `2h` **POST `clean()` args swapped** — `applications/router.ts:69` (the POST 201 response):
-  `clean(created, reqPublicationSite(req), reqPublicBaseUrl(req) as unknown as PublicationSite)` —
-  `publicationSite` and `publicBaseUrl` are in each other's slots (the `as unknown as PublicationSite`
-  cast is the tell); the canonical order is `clean(app, publicBaseUrl, publicationSite)` as in the other
-  three call sites. On a secondary domain the 201-response links/image URLs are built wrong (invisible
-  on the main domain where publicationSite is undefined).
-
 ### PR 2 — Datasets draft / notification correctness `P2 · M`
 All in `datasets/routes/{write,metadata,misc}.ts`, surfaced in Phase 6d.
 - `12` **draft-validated notification `localizedParams` mis-shaped** — emits `{ cause: { fr, en } }`
@@ -122,6 +103,17 @@ enabler); (3) compact redundant API specs.
 ---
 
 ## Resolved during the series (for the record)
+- **PR 1 — Applications dormant bugs** (`2e`/`2f`/`2g`/`2h`) → fixed, each with a test:
+  - `2e` `replaceApplication`'s readonly-preservation no-op (`!patchKeys.includes([key])` → `!patchKeys.includes(key)`).
+    Reaching it required also fixing the PUT route: `attemptInsert` validated the *curated* application
+    (which carries the internal `_uniqueRefs` field + a generated, possibly mixed-case id) against the
+    `additionalProperties:false` application schema, so **every** PUT 400'd before `replaceApplication`
+    ran (pre-existing, untested). Now it validates `req.body` via the post-req schema, like POST/datasets.
+  - `2f` `deleteApplication` capture cleanup — restored a `captureFilePath` export on `misc/utils/capture.ts`
+    (modern captures are stored only as `.png`) and call it instead of the non-existent `capture.path`.
+  - `2g` `writeApplicationConfig` now `syncDatasets({ configuration: appConfig }, application)` — validated
+    config + previous app as `oldApp` so old dataset back-refs are reconciled (dropped the unused `rawBody`).
+  - `2h` POST 201 response now uses the canonical `clean(app, publicBaseUrl, publicationSite)` order.
 - clamav `middleware` DOM-`Response` cast → fixed in Phase 6d.
 - `/app-sw.js` reading raw `req.application` → migrated to `reqApplicationOptional` (still benign-undefined).
 - `esAbortContext` legacyProp, and the whole `legacyProp` dual-write mechanism → removed at series end.

--- a/tests/features/applications/applications.api.spec.ts
+++ b/tests/features/applications/applications.api.spec.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import FormData from 'form-data'
 import { axios, axiosAuth, clean, checkPendingTasks, config, mockAppUrl, mockAppId } from '../../support/axios.ts'
-import { sendDataset } from '../../support/workers.ts'
+import { sendDataset, fileExists, clearDatasetCache } from '../../support/workers.ts'
 
 const anonymous = axios()
 const testUser1 = await axiosAuth('test_user1@test.com')
@@ -293,6 +293,31 @@ test.describe('Applications', () => {
     assert.equal(res.headers['content-type'], 'application/pdf')
   })
 
+  test('Delete an application removes its capture file', async () => {
+    const ax = testUser1
+    try {
+      await ax.get(captureUrl + '/api/v1/api-docs.json')
+    } catch (err: any) {
+      console.warn('capture is not available in this test environment')
+      assert.equal(err.status, 502)
+      return
+    }
+
+    const { data: app } = await ax.post('/api/v1/applications', { url: mockAppUrl('monapp1') })
+    const { data: dataset } = await ax.post('/api/v1/datasets', { isRest: true, title: 'a rest dataset' })
+    await ax.put('/api/v1/applications/' + app.id + '/config', { datasets: [{ href: dataset.href, id: dataset.id }] })
+
+    // generate the capture file
+    const res = await ax.get('/api/v1/applications/' + app.id + '/capture')
+    assert.equal(res.status, 200)
+    const capturePath = `captures/${app.id}.png`
+    assert.ok(await fileExists(capturePath), 'capture file should exist after generation')
+
+    // deleting the application must remove its capture artifact (capture.captureFilePath must resolve it)
+    await ax.delete('/api/v1/applications/' + app.id)
+    assert.equal(await fileExists(capturePath), false)
+  })
+
   test('Sort applications by title', async () => {
     const ax = testUser1
 
@@ -316,6 +341,43 @@ test.describe('Applications', () => {
     })
     res = await ax.post('/api/v1/applications', { url: mockAppUrl('monapp1'), title: 'test slug 2', slug: 'test-slug' })
     assert.equal(res.data.slug, 'test-slug-2')
+  })
+
+  test('PUT updates writable fields instead of preserving them', async () => {
+    const ax = testUser1
+    const { data: created } = await ax.post('/api/v1/applications', { url: mockAppUrl('monapp1'), title: 'original title' })
+    const { id, createdAt, slug } = created
+
+    const res = await ax.put('/api/v1/applications/' + id, { url: mockAppUrl('monapp1'), slug, title: 'updated title' })
+    assert.equal(res.status, 200)
+    // writable field must be overwritten by the PUT body (the readonly-preservation loop must not copy it back)
+    assert.equal(res.data.title, 'updated title')
+    // readonly field must be preserved across the replace
+    assert.equal(res.data.createdAt, createdAt)
+  })
+
+  test('Reconfiguring an application reconciles old dataset back-references', async () => {
+    const ax = testUser1
+    const datasetA = await sendDataset('datasets/split.csv', ax)
+    const datasetB = await sendDataset('datasets/split.csv', ax)
+    const refA = (await ax.get('/api/v1/datasets', { params: { id: datasetA.id, select: 'id' } })).data.results[0]
+    const refB = (await ax.get('/api/v1/datasets', { params: { id: datasetB.id, select: 'id' } })).data.results[0]
+
+    const { data: app } = await ax.post('/api/v1/applications', { url: mockAppUrl('monapp1') })
+    // first configure referencing dataset A, then reconfigure to reference only dataset B
+    await ax.put('/api/v1/applications/' + app.id + '/config', { datasets: [{ id: datasetA.id, href: refA.href }] })
+    await ax.put('/api/v1/applications/' + app.id + '/config', { datasets: [{ id: datasetB.id, href: refB.href }] })
+
+    // bust the 30s dataset memoize cache so the GETs below reflect the back-reference sync
+    await clearDatasetCache()
+
+    // dataset A must no longer reference the application: the old config has to be reconciled, which
+    // requires syncDatasets to receive the previous application as oldApp
+    const dsA = (await ax.get('/api/v1/datasets/' + datasetA.id)).data
+    assert.equal(dsA.extras?.applications?.length ?? 0, 0)
+    // dataset B is now referenced
+    const dsB = (await ax.get('/api/v1/datasets/' + datasetB.id)).data
+    assert.equal(dsB.extras.applications.length, 1)
   })
 
   test('Upload a simple attachment on an application', async () => {

--- a/tests/features/applications/publication-sites.api.spec.ts
+++ b/tests/features/applications/publication-sites.api.spec.ts
@@ -126,6 +126,20 @@ test.describe('publication sites', () => {
     assert.equal(publishedApp.image, `${publicUrl2}/uploads/app-image.png`)
   })
 
+  test('POST application targeting a publication site builds well-formed links', async () => {
+    const ax = testUser1Org
+    await ax.post('/api/v1/settings/organization/test_org1/publication-sites', { type: 'data-fair-portals', id: 'portal1', url: 'http://portal.com' })
+    await clearPublicationSitesCache()
+
+    // on the main domain a publication site is put in context through the publicationSites query param;
+    // the POST 201 response must then build links with the canonical clean(app, publicBaseUrl, publicationSite) order
+    const res = await ax.post('/api/v1/applications?publicationSites=data-fair-portals:portal1', { url: mockAppUrl('monapp1'), title: 'pub app' })
+    assert.equal(res.status, 201)
+    // swapped clean() args put the publicationSite object in the publicUrl slot -> "[object Object]" in URLs
+    assert.ok(res.data.href && !res.data.href.includes('[object Object]'), `unexpected href: ${res.data.href}`)
+    assert.ok(res.data.exposedUrl && !res.data.exposedUrl.includes('[object Object]'), `unexpected exposedUrl: ${res.data.exposedUrl}`)
+  })
+
   test('department admin should fail to publish dataset on org site', async () => {
     const portal = { type: 'data-fair-portals', id: 'portal1', url: 'http://portal.com' }
     await testUser1Org.post('/api/v1/settings/organization/test_org1/publication-sites', portal)

--- a/tests/fixtures/login.ts
+++ b/tests/fixtures/login.ts
@@ -9,6 +9,15 @@ async function performLogin (page: any, context: any, baseUrl: string, url: stri
   await page.getByLabel('Adresse mail').fill(`${user}@test.com`)
   await page.getByLabel('Mot de passe').fill('passwd')
   await page.getByRole('button', { name: 'Se connecter' }).click()
+  // super-admin accounts get an "activate admin mode for this session?" interstitial that blocks
+  // the redirect; keep a normal session (the dedicated adminMode fixtures handle the admin case).
+  // Regular users redirect straight to fullUrl, so race the two outcomes to avoid a fixed wait.
+  const normalSession = page.getByRole('button', { name: 'Session Normale' })
+  const sawInterstitial = await Promise.race([
+    normalSession.waitFor({ state: 'visible', timeout: 10000 }).then(() => true, () => false),
+    page.waitForURL(fullUrl, { timeout: 10000 }).then(() => false, () => false)
+  ])
+  if (sawInterstitial) await normalSession.click()
   await page.waitForURL(fullUrl, { timeout: 10000 })
   const cookies = await context.cookies()
   cookieCache.set(user, cookies)


### PR DESCRIPTION
Fixes four bugs preserved bit-for-bit during the express-decoupling refactor (PR 1 of the `docs/TODO.md` follow-ups), each with a failing-test-first.

**What changed:**
- `2e` `replaceApplication` readonly-preservation was a no-op (`!patchKeys.includes([key])` compared against an array literal). Reaching it required repairing the PUT route: `attemptInsert` validated the *curated* application (carrying internal `_uniqueRefs` + a generated, possibly mixed-case id) against the `additionalProperties:false` schema, so every PUT 400'd before `replaceApplication` ran. It now validates `req.body` via the post-req schema, like the POST route and the datasets module.
- `2f` `deleteApplication` capture cleanup called a non-existent `capture.path` and swallowed the `TypeError`, leaking capture artifacts. Restored a `captureFilePath` export (captures are `.png`-only now) and use it.
- `2g` `writeApplicationConfig` synced the raw unvalidated body and omitted `oldApp`; now `syncDatasets({ configuration: appConfig }, application)` so old dataset back-refs are reconciled.
- `2h` POST 201 response used swapped `clean()` args (`[object Object]` URLs on a publication site); now canonical `clean(app, publicBaseUrl, publicationSite)`.

**Also on this branch (separate concerns):**
- `test(e2e)`: the shared `goToWithAuth` login fixture now dismisses simple-directory's super-admin "activate admin mode?" interstitial (raced against the redirect, no penalty for regular users) — was hanging every super-admin e2e login.
- `chore`: dev-only `docker-compose.yaml` capture container uses `OBSERVER_ACTIVE=false`.

**Why:** dormant correctness bugs distilled from the refactor series, each scoped to a dedicated test.

**Regression risks:**
- `attemptInsert` enables the previously-broken PUT route. The now-live PUT-create path does not generate a slug (a create-via-PUT body without `slug` yields an app with no slug/`_uniqueRefs`), and self-chosen PUT ids are no longer pattern-validated. The intended/tested path is PUT-update of an existing app.
- `writeApplicationConfig` dropped its `rawBody` param (single caller updated) and now reconciles previous-config back-refs.
- `tests/fixtures/login.ts` is shared by all e2e specs; the added race is verified non-regressive for regular and admin logins.
