### PR TITLE
fix(settings): correct custom-metadata cleanup & publication-site doc targeting

### DIFF
--- a/api/src/settings/service.ts
+++ b/api/src/settings/service.ts
@@ -189,13 +189,14 @@ const writeSettings = async (ctx: SettingsWriteContext, existingSettings: Settin
 const updateDatasetsMetadata = async (owner: AccountKeys, oldDatasetsMetadata: OptionsDesMetadonneesDeJeuxDeDonnees, newDatasetsMetadata: OptionsDesMetadonneesDeJeuxDeDonnees) => {
   if (equal(oldDatasetsMetadata, newDatasetsMetadata)) return
   for (const oldMeta of oldDatasetsMetadata.custom ?? []) {
-    if (newDatasetsMetadata.custom?.some(nc => nc.key === oldMeta.key)) {
+    // clean up the metadata off datasets when its definition was removed from the settings
+    if (!newDatasetsMetadata.custom?.some(nc => nc.key === oldMeta.key)) {
       await mongo.datasets.updateMany(
         { 'owner.type': owner.type, 'owner.id': owner.id, [`customMetadata.${oldMeta.key}`]: { $exists: true } },
-        { $unset: { [`customMetadata.${oldMeta}`]: 1 } })
+        { $unset: { [`customMetadata.${oldMeta.key}`]: 1 } })
       await mongo.datasets.updateMany(
         { 'owner.type': owner.type, 'owner.id': owner.id, [`draft.customMetadata.${oldMeta.key}`]: { $exists: true } },
-        { $unset: { [`draft.customMetadata.${oldMeta}`]: 1 } })
+        { $unset: { [`draft.customMetadata.${oldMeta.key}`]: 1 } })
     }
   }
 }
@@ -293,7 +294,7 @@ export const upsertPublicationSite = async (ctx: SettingsWriteContext, body: any
     settings.publicationSites[index] = { ...body, settings: { ...(settings.publicationSites[index].settings || {}), ...(body.settings || {}) } }
   }
   validateSettings(settings)
-  await mongo.settings.replaceOne(owner, settings, { upsert: true })
+  await mongo.settings.replaceOne(ownerFilter, settings, { upsert: true })
   return { created: index === -1 }
 }
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -20,16 +20,6 @@ Related docs: dormant correctness bugs from the perf scan in
 
 ## Suggested PR candidates (grouped)
 
-### PR 3 — Settings document-targeting & metadata bugs `P1 · S–M`
-- `1` **`updateDatasetsMetadata` `$unset` broken + condition inverted** — the `$unset` key interpolates
-  the object `oldMeta` (→ `customMetadata.[object Object]`) instead of `oldMeta.key`, and the guard
-  `if (newDatasetsMetadata.custom?.some(nc => nc.key === oldMeta.key))` looks inverted (cleans up when
-  the key still exists). Custom-metadata cleanup never works correctly. (`settings/service.ts`)
-- `2b` **POST publication-sites replaces the wrong settings doc** — `mongo.settings.replaceOne(owner, …)`
-  filters on `owner` with no `department: { $exists: false }` clause (PUT/PATCH/DELETE use `ownerFilter`);
-  for an org with department settings docs the POST can replace the wrong document. Failing test:
-  org-root site sync while department settings exist. `P2`.
-
 ### PR 4 — Standalone correctness fixes `P1/P2 · S each`
 Independent, different modules — can ship together or individually.
 - `2c` **activity GET 500s on every call** `P1` — `activity/router.ts` calls `findUtils.query(req, {status:'status'})`
@@ -87,6 +77,19 @@ enabler); (3) compact redundant API specs.
 ---
 
 ## Resolved during the series (for the record)
+- **PR 3 — Settings document-targeting & metadata bugs** (`1`/`2b`) → both fixed, each with a failing
+  test first:
+  - `1` **`updateDatasetsMetadata` `$unset` broken + condition inverted** → FIXED (`settings/service.ts`).
+    The guard was inverted (`if (newDatasetsMetadata.custom?.some(…))` → `if (!… .some(…))`) so cleanup
+    now runs when a custom-metadata definition is *removed*, and the `$unset` keys interpolated the whole
+    `oldMeta` object (`customMetadata.[object Object]`) → fixed to `oldMeta.key` for both the live and
+    `draft.` paths. Failing test in `settings.api.spec.ts` ("removing a custom dataset-metadata definition
+    unsets it on datasets") asserts the removed key is `$unset` off the dataset while a kept key survives.
+  - `2b` **POST publication-sites replaces the wrong settings doc** → FIXED (`settings/service.ts`).
+    `upsertPublicationSite` filtered `replaceOne(owner, …)` with no `department: { $exists: false }` clause,
+    so an org-root POST could replace a department settings doc (`replaceOne` hits the first `{type,id}`
+    match). Now uses `ownerFilter`, matching PUT/PATCH/DELETE. Failing test in `publication-sites.api.spec.ts`
+    ("POST org-root publication site must not clobber a department settings doc").
 - **PR 2 — Datasets draft / notification correctness** (`12`/`13`/`10`/`11`) → all four triaged:
   - `12` **draft-validated notification `localizedParams` mis-shaped** → FIXED. Reshaped to
     `{ fr: { cause }, en: { cause } }` and dropped the cast (`datasets/routes/write.ts`). Before the fix

--- a/tests/features/applications/publication-sites.api.spec.ts
+++ b/tests/features/applications/publication-sites.api.spec.ts
@@ -233,6 +233,23 @@ test.describe('publication sites', () => {
     }
   })
 
+  test('POST org-root publication site must not clobber a department settings doc', async () => {
+    // a department settings doc with its own publication site
+    await testUser1Org.post('/api/v1/settings/organization/test_org1:dep1/publication-sites', { type: 'data-fair-portals', id: 'dep-portal', url: 'http://portal.com' })
+
+    // create an org-root publication site (no org-root settings doc exists yet, only the department one)
+    await testUser1Org.post('/api/v1/settings/organization/test_org1/publication-sites', { type: 'data-fair-portals', id: 'org-portal', url: 'http://portal.com' })
+
+    // the department site must survive — a replaceOne filtering on owner without the
+    // department:{$exists:false} clause would replace the department doc instead
+    const depSites = (await testUser1Org.get('/api/v1/settings/organization/test_org1:dep1/publication-sites')).data
+    assert.ok(depSites.some((s: any) => s.id === 'dep-portal' && s.department === 'dep1'), 'department publication site should survive')
+
+    // and the org-root site exists too
+    const orgSites = (await testUser1Org.get('/api/v1/settings/organization/test_org1/publication-sites')).data
+    assert.ok(orgSites.some((s: any) => s.id === 'org-portal'), 'org-root publication site should exist')
+  })
+
   test('contrib can publish on a "staging" publication site', async () => {
     const portalProd = { type: 'data-fair-portals', id: 'portal-staging', url: 'http://portal.com', settings: { staging: true } }
     await testUser1Org.post('/api/v1/settings/organization/test_org1:dep1/publication-sites', portalProd)

--- a/tests/features/settings/settings.api.spec.ts
+++ b/tests/features/settings/settings.api.spec.ts
@@ -100,6 +100,33 @@ test.describe('settings API', () => {
     assert.equal(res.data.apiKeys[0].notifiedJAt, undefined, 'notifiedJAt not exposed')
   })
 
+  test('removing a custom dataset-metadata definition unsets it on datasets', async () => {
+    const ax = testUser1Org
+
+    // define two custom metadata
+    await ax.put('/api/v1/settings/organization/test_org1', {
+      datasetsMetadata: { custom: [{ title: 'Foo metadata' }, { title: 'Bar metadata' }] }
+    })
+    const settings = (await ax.get('/api/v1/settings/organization/test_org1')).data
+    const fooKey = settings.datasetsMetadata.custom.find((c: any) => c.title === 'Foo metadata').key
+    const barKey = settings.datasetsMetadata.custom.find((c: any) => c.title === 'Bar metadata').key
+    assert.ok(fooKey && barKey)
+
+    // a dataset carrying both custom metadata values
+    const dataset = (await ax.post('/api/v1/datasets', { isRest: true, title: 'with custom meta', schema: [] })).data
+    await ax.patch(`/api/v1/datasets/${dataset.id}`, { customMetadata: { [fooKey]: 'foo value', [barKey]: 'bar value' } })
+
+    // remove the Foo definition, keep Bar
+    await ax.put('/api/v1/settings/organization/test_org1', {
+      datasetsMetadata: { custom: [{ title: 'Bar metadata', key: barKey }] }
+    })
+
+    // the removed custom metadata must be unset on the dataset, the kept one preserved
+    const updated = (await ax.get(`/api/v1/datasets/${dataset.id}`)).data
+    assert.equal(updated.customMetadata?.[fooKey], undefined, 'removed custom metadata should be unset')
+    assert.equal(updated.customMetadata?.[barKey], 'bar value', 'kept custom metadata should remain')
+  })
+
   test('can still re-save settings after the worker set an expiration flag on a key', async () => {
     // create a key
     const created = (await testUser1.put('/api/v1/settings/user/test_user1', {


### PR DESCRIPTION
Fixes two settings bugs preserved bit-for-bit during the express-decoupling refactor, each with a failing-first test.

- **Custom-metadata cleanup** (`updateDatasetsMetadata`): the guard was inverted (cleaned up only when the definition still existed) and the `$unset` key interpolated the whole `oldMeta` object → `customMetadata.[object Object]`. Now cleanup runs when a definition is *removed* and `$unset`s `oldMeta.key`, on both the live and `draft.customMetadata` paths.
- **Publication-site doc targeting** (`upsertPublicationSite`): `replaceOne` filtered on `owner` with no `department:{$exists:false}` clause, so an org-root POST could replace a department settings doc. Now filters on `ownerFilter`, consistent with PUT/PATCH/DELETE — and with the `findOne` the same function already uses to read.

**Heads-up:** the cleanup fix means removing a custom-metadata definition now actually purges `customMetadata.<key>` from datasets (it never did before) — an intended but irreversible delete.
