### PR TITLE
feat(ui): warn before leaving a page during a file upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1774,9 +1774,9 @@
       }
     },
     "node_modules/@data-fair/lib-vue": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@data-fair/lib-vue/-/lib-vue-1.29.0.tgz",
-      "integrity": "sha512-kV31IdGUwleOsIAcwx8OlY/hdfYErrCZ1u3iTA/6VXQKCwj+8FxUyy5Ubk850tEhOHi9Kc9nMh9bJ9Rc2Rk0gg==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@data-fair/lib-vue/-/lib-vue-1.30.0.tgz",
+      "integrity": "sha512-x23f5F/AjQMPbzw786xk8CR7yEZ2R/jputsbijIeNIAp52kHu1B0PH2uy1qn3f+Wd//m5SxxaCRDZ3rGIou8AA==",
       "license": "MIT",
       "dependencies": {
         "@data-fair/lib-common-types": "^1.7.1",
@@ -23235,7 +23235,7 @@
       },
       "devDependencies": {
         "@data-fair/frame": "^0.18.0",
-        "@data-fair/lib-vue": "^1.29.0",
+        "@data-fair/lib-vue": "^1.30.0",
         "@data-fair/lib-vue-agents": "^0.4.0",
         "@data-fair/lib-vuetify": "^2.4.0",
         "@data-fair/lib-vuetify-agents": "^0.6.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@data-fair/frame": "^0.18.0",
-    "@data-fair/lib-vue": "^1.29.0",
+    "@data-fair/lib-vue": "^1.30.0",
     "@data-fair/lib-vue-agents": "^0.4.0",
     "@data-fair/lib-vuetify": "^2.4.0",
     "@data-fair/lib-vuetify-agents": "^0.6.0",

--- a/ui/src/components/dataset/dataset-upload-dialog.vue
+++ b/ui/src/components/dataset/dataset-upload-dialog.vue
@@ -114,8 +114,9 @@ import { mdiPaperclip, mdiZipBox } from '@mdi/js'
 import axios, { type AxiosRequestConfig, type CancelTokenSource } from 'axios'
 import useDatasetStore from '~/composables/dataset/dataset-store'
 import { accepted } from '~/utils/dataset'
+import { useUploadLeaveGuard } from '~/composables/use-upload-leave-guard'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const { sendUiNotif } = useUiNotif()
 const { id: datasetId, datasetFetch, digitalDocumentField } = useDatasetStore()
 
@@ -201,4 +202,7 @@ const upload = useAsyncAction(async () => {
     }
   }
 })
+
+// Warn before leaving while a file upload is running, and cancel it on confirm.
+useUploadLeaveGuard(() => upload.loading.value, { locale, onConfirmLeave: () => cancelSource?.cancel(t('cancelled')) })
 </script>

--- a/ui/src/components/dataset/rest/dataset-rest-upload-actions.vue
+++ b/ui/src/components/dataset/rest/dataset-rest-upload-actions.vue
@@ -79,12 +79,12 @@
                 accept=".zip"
               />
             </template>
-            <v-progress-linear
+            <file-upload-progress
               v-if="upload.loading.value"
-              v-model="uploadProgress"
+              :percent="uploadProgress?.percent"
+              :total="uploadProgress?.total"
               class="my-1"
               style="max-width: 500px;"
-              color="primary"
             />
           </div>
         </v-form>
@@ -104,8 +104,7 @@
         </v-btn>
         <template v-else>
           <v-btn
-            :disabled="upload.loading.value"
-            @click="dialog = false"
+            @click="upload.loading.value ? cancelSource?.cancel(t('cancelled')) : (dialog = false)"
           >
             {{ t('cancel') }}
           </v-btn>
@@ -129,6 +128,7 @@ fr:
   loadLines: Charger plusieurs lignes depuis un fichier
   selectFile: Sélectionnez ou glissez/déposez un fichier
   cancel: Annuler
+  cancelled: Chargement annulé
   load: Charger
   ok: Ok
   separator: Séparateur
@@ -139,6 +139,7 @@ en:
   loadLines: Load multiple lines from a file
   selectFile: Select or drag and drop a file
   cancel: Cancel
+  cancelled: Loading cancelled
   load: Load
   ok: Ok
   separator: Separator
@@ -149,9 +150,10 @@ en:
 
 <script setup lang="ts">
 import { type RestActionsSummary } from '#api/types'
-import axios, { AxiosRequestConfig } from 'axios'
+import axios, { AxiosRequestConfig, type CancelTokenSource } from 'axios'
+import { useUploadLeaveGuard } from '~/composables/use-upload-leave-guard'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 
 const { dataset, id: datasetId } = useDatasetStore()
 
@@ -160,7 +162,7 @@ const dialog = ref(false)
 const file = ref<File>()
 const attachmentsFile = ref<File>()
 const result = ref<RestActionsSummary>()
-const uploadProgress = ref<number>()
+const uploadProgress = ref<{ percent?: number, total?: number }>()
 const csvSep = ref(',')
 const drop = ref(false)
 
@@ -171,19 +173,23 @@ watch(dialog, () => {
   result.value = undefined
   file.value = undefined
   attachmentsFile.value = undefined
-  uploadProgress.value = 0
+  uploadProgress.value = undefined
   csvSep.value = ','
   drop.value = false
 })
 
+let cancelSource: CancelTokenSource
+
 const upload = useAsyncAction(async () => {
   if (!file.value) return
+  cancelSource = axios.CancelToken.source()
   const options: AxiosRequestConfig = {
     onUploadProgress: (e) => {
       if (e.lengthComputable) {
-        uploadProgress.value = e.total && ((e.loaded / e.total) * 100)
+        uploadProgress.value = { percent: e.total && ((e.loaded / e.total) * 100), total: e.total }
       }
     },
+    cancelToken: cancelSource.token,
     params: { draft: true }
   }
   if (isCSV.value) {
@@ -200,6 +206,7 @@ const upload = useAsyncAction(async () => {
   try {
     result.value = await axios.post(`${$apiPath}/datasets/${datasetId}/_bulk_lines`, formData, options).then(r => r.data)
   } catch (error: any) {
+    if (axios.isCancel(error)) return
     if (typeof (error.response && error.response.data) === 'object') {
       result.value = error.response.data
     } else {
@@ -207,6 +214,9 @@ const upload = useAsyncAction(async () => {
     }
   }
 })
+
+// Warn before leaving while a file upload is running, and cancel it on confirm.
+useUploadLeaveGuard(() => upload.loading.value, { locale, onConfirmLeave: () => cancelSource?.cancel(t('cancelled')) })
 </script>
 
 <style lang="css" scoped>

--- a/ui/src/components/workflow/workflow-update-dataset.vue
+++ b/ui/src/components/workflow/workflow-update-dataset.vue
@@ -401,6 +401,7 @@ import axios, { AxiosRequestConfig, CancelTokenSource } from 'axios'
 import { type ListedDataset } from '../dataset/select/utils'
 import { type DatasetStore } from '~/composables/dataset/dataset-store'
 import DatasetStoreProvider from '~/components/provide/dataset-store-provider.vue'
+import { useUploadLeaveGuard } from '~/composables/use-upload-leave-guard'
 import Debug from 'debug'
 import { mdiCancel, mdiCheckAll, mdiCog, mdiDatabase, mdiPaperclip, mdiTable, mdiZipBox } from '@mdi/js'
 import { useWindowSize } from '@vueuse/core'
@@ -411,7 +412,7 @@ const props = defineProps({
   datasetParams: { type: Object as () => Record<string, string | undefined>, default: () => {} }
 })
 const { sendUiNotif } = useUiNotif()
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const { height } = useWindowSize()
 
 const currentStep = ref(1)
@@ -521,6 +522,9 @@ const cancelUpdateDataset = () => {
   if (!cancelUpdate) return
   cancelUpdate.cancel(t('cancelled'))
 }
+
+// Warn before leaving while a file upload is running, and cancel it on confirm.
+useUploadLeaveGuard(() => updateDataset.loading.value, { locale, onConfirmLeave: cancelUpdateDataset })
 
 /*
 export default {

--- a/ui/src/composables/use-upload-leave-guard.ts
+++ b/ui/src/composables/use-upload-leave-guard.ts
@@ -1,0 +1,28 @@
+// ui/src/composables/use-upload-leave-guard.ts
+import { type MaybeRefOrGetter, toValue } from 'vue'
+import { useLeaveGuard } from '@data-fair/lib-vue/leave-guard.js'
+
+// Upload-specific message shown when the user tries to leave while a file upload
+// is running. More explicit than the lib's generic "unsaved modifications" text.
+// It is only displayed for in-app navigation (window.confirm); on tab close /
+// reload modern browsers show their own generic prompt instead.
+const messages = {
+  fr: 'Un envoi de fichier est en cours. Si vous quittez la page maintenant, l\'envoi sera interrompu et le fichier ne sera pas chargé.',
+  en: 'A file upload is in progress. If you leave now, the upload will be interrupted and the file will not be loaded.'
+}
+
+/**
+ * Guard against leaving the page while a file upload is in progress.
+ * Thin wrapper over the shared `useLeaveGuard` that supplies the upload-specific
+ * message and forwards `onConfirmLeave`, so the caller can abort the in-flight
+ * request (and thus stop the dataset creation/update) before navigation proceeds.
+ */
+export const useUploadLeaveGuard = (
+  isUploading: MaybeRefOrGetter<boolean>,
+  options?: { locale?: MaybeRefOrGetter<string>, onConfirmLeave?: () => void }
+) => {
+  const message = messages[(options?.locale ? toValue(options.locale) : 'en') as 'fr' | 'en'] ?? messages.en
+  useLeaveGuard(isUploading, { message, onConfirmLeave: options?.onConfirmLeave })
+}
+
+export default useUploadLeaveGuard

--- a/ui/src/pages/new-dataset.vue
+++ b/ui/src/pages/new-dataset.vue
@@ -400,6 +400,7 @@ import { $apiPath } from '~/context'
 import { DfAgentChatAction } from '@data-fair/lib-vuetify-agents'
 import { useAgentDatasetCreationTools } from '~/composables/dataset/agent-creation-tools'
 import { useShowAgentChat } from '~/composables/agent/use-show-chat'
+import { useUploadLeaveGuard } from '~/composables/use-upload-leave-guard'
 import { type AccountKeys } from '@data-fair/lib-vue/session'
 import { type ListedDataset } from '~/components/dataset/select/utils'
 
@@ -682,6 +683,9 @@ const createAction = useAsyncAction(async () => {
     throw error
   }
 }, { catch: 'all' })
+
+// Warn before leaving while a file upload is running, and cancel it on confirm.
+useUploadLeaveGuard(() => datasetType.value === 'file' && createAction.loading.value, { locale, onConfirmLeave: cancelUpload })
 
 async function createFileDataset () {
   cancelSource = axios.CancelToken.source()


### PR DESCRIPTION
Add a page-leave guard to the four file-upload forms (new dataset, update-dataset workflow, upload dialog, REST bulk-lines upload) so users don't accidentally interrupt an upload, and make the REST bulk-lines cancel button actually abort the upload.

**Why:** leaving a page mid-upload silently dropped the transfer, and for in-app navigation the request kept running in the background and the dataset was still created/updated. In the REST bulk-lines dialog the cancel button was also disabled during the upload, so there was no way to stop it.

**What:**
- A shared `useUploadLeaveGuard` composable wraps `@data-fair/lib-vue`'s `useLeaveGuard` (vue-router + `beforeunload` guards), supplying an upload-specific localized message and forwarding `onConfirmLeave`. On confirmed in-app navigation it cancels the in-flight request so the upload and the dataset creation/update are actually stopped.
- The REST bulk-lines upload had no cancel token, so one was added; its cancel button now aborts the in-flight request instead of being disabled, and it reuses the shared `file-upload-progress` component.
- Bump `@data-fair/lib-vue` to `^1.30.0`, which adds the `onConfirmLeave` option the guard relies on.

**Heads-up:**
- Requires `@data-fair/lib-vue@1.30.0` (published) — the composable now delegates the guard logic to the lib instead of reimplementing it.
- The `1.30.0` bump also pulls in the `1.29.1` theme cookie/resolution fix, consumed transitively via `df-theme-switcher`.
- The REST upload is now abortable (new `CancelToken` + `axios.isCancel` early-return) — previously it couldn't be cancelled.
- The custom leave message only shows for in-app navigation; on tab close/reload browsers show their own generic prompt.
