### PR TITLE
fix(ui): render multi-valued extension fields in the line edit form

### DIFF
--- a/shared/schema.js
+++ b/shared/schema.js
@@ -89,6 +89,9 @@ export const cleanJsonSchemaProperty = (p, defaultPublicUrl, publicBaseUrl, flat
         readOnly: cleanProp.readOnly,
         items: itemsProps
       }
+      // keep the extension marker on the array itself, not only on its items, so the edit
+      // form recognizes multi-valued extension fields (otherwise they are never rendered)
+      if (cleanProp['x-extension']) array['x-extension'] = cleanProp['x-extension']
       if (layout.getItems) {
         array.layout = { getItems: layout.getItems }
       }

--- a/tests/features/datasets/master-data/master-data-extensions.api.spec.ts
+++ b/tests/features/datasets/master-data/master-data-extensions.api.spec.ts
@@ -166,6 +166,15 @@ test.describe('master data - Define/use master-data as remote-service, extend ge
     assert.deepEqual(extraMultiProp.enum, ['multi1', 'multi2'])
     assert.ok(slave.schema.find((p: any) => p.key === '_siret._error'))
     assert.ok(!slave.schema.find((p: any) => p.key === '_siret.siret'))
+
+    const formSchema = (await ax.get('/api/v1/datasets/slave/schema', {
+      params: { mimeType: 'application/schema+json', extension: 'true', arrays: true }
+    })).data
+    const extraMultiFormProp = formSchema.properties['_siret.extraMulti']
+    assert.equal(extraMultiFormProp.type, 'array')
+    assert.ok(extraMultiFormProp['x-extension'], 'multi-valued extension field must keep x-extension at the array level')
+    assert.ok(formSchema.properties['_siret.extra']['x-extension'])
+
     let results = (await ax.get('/api/v1/datasets/slave/lines')).data.results
     assert.equal(results.length, 4)
     assert.equal(results[0]['_siret.extra'], 'Extra information')

--- a/tests/features/datasets/master-data/master-data-extensions.api.spec.ts
+++ b/tests/features/datasets/master-data/master-data-extensions.api.spec.ts
@@ -175,6 +175,9 @@ test.describe('master data - Define/use master-data as remote-service, extend ge
     assert.ok(extraMultiFormProp['x-extension'], 'multi-valued extension field must keep x-extension at the array level')
     assert.ok(formSchema.properties['_siret.extra']['x-extension'])
 
+    const simulated = (await ax.post('/api/v1/datasets/slave/_simulate-extension?arrays=true', { siret: '82898347800011' })).data
+    assert.deepEqual(simulated['_siret.extraMulti'], ['multi1', 'multi2'])
+
     let results = (await ax.get('/api/v1/datasets/slave/lines')).data.results
     assert.equal(results.length, 4)
     assert.equal(results[0]['_siret.extra'], 'Extra information')

--- a/ui/src/components/dataset/form/dataset-edit-line-form.vue
+++ b/ui/src/components/dataset/form/dataset-edit-line-form.vue
@@ -132,7 +132,7 @@ watch(simulateExtensionInputStr, () => {
 })
 
 const simulateExtension = useAsyncAction(async (body) => {
-  const res = Object.keys(body).length && await $fetch<Record<string, any>>(`/datasets/${id}/_simulate-extension`, { method: 'POST', body })
+  const res = Object.keys(body).length && await $fetch<Record<string, any>>(`/datasets/${id}/_simulate-extension`, { method: 'POST', body, params: { arrays: true } })
   const newValue = { ...model.value }
   for (const key of extensionKeys.value) {
     if (res && res[key] !== undefined) newValue[key] = res[key]


### PR DESCRIPTION
Multi-valued (separator-based) extension fields were missing from the REST line edit form even though the API returned their values, so a multi-valued field never showed up after entering a valid code.

**Why:** two issues combined. The JSON-schema conversion kept the `x-extension` marker only on the array's `items`, never on the top-level array, so the form (which detects extension fields via the top-level marker) excluded these fields from `extensionKeys` and never populated them. And once rendered as an array, the form filled them from `/_simulate-extension` called without `arrays=true`, getting back the separator-joined string — which failed array validation ("doit être de type array") and showed as a single chip.

**What:**
- `shared/schema.js`: propagate `x-extension` onto the array itself in `cleanJsonSchemaProperty`, so multi-valued extension fields are recognized and populated like single-valued ones.
- `dataset-edit-line-form.vue`: call `/_simulate-extension` with `arrays=true`, matching the edited-line fetch (`/lines/:id?arrays=true`), so multi-valued fields arrive as arrays (one chip per value).
- Assertions grafted onto the existing master-data extension test.

**Heads-up:** `shared/schema.js` feeds every consumer of the JSON-schema form; the change is purely additive (a marker already present on `items`). The `arrays=true` parameter is already supported by the `_simulate-extension` route, only affects multi-valued fields, and the form is its sole caller — single-valued fields are unchanged.
