### PR TITLE
fix(ui): make REST line edit dialogs persistent

### DIFF
--- a/ui/src/components/dataset/table/dataset-table-header-actions.vue
+++ b/ui/src/components/dataset/table/dataset-table-header-actions.vue
@@ -77,6 +77,7 @@
   <v-dialog
     v-model="editSelectedResultsDialog"
     max-width="500"
+    persistent
   >
     <v-card :title="t('editAllLines', {nbLines: editingLines?.length})">
       <template v-if="bulkActionResult">
@@ -132,6 +133,7 @@
   <v-dialog
     v-model="deleteSelectedResultsDialog"
     max-width="500"
+    persistent
   >
     <v-card :title="t('deleteAllLines', {nbLines: deletingResults?.length})">
       <template v-if="bulkActionResult">
@@ -181,6 +183,7 @@
   <v-dialog
     v-model="addLineDialog"
     max-width="800"
+    persistent
   >
     <v-card :title="t('addLine')">
       <v-form

--- a/ui/src/components/dataset/table/dataset-table.vue
+++ b/ui/src/components/dataset/table/dataset-table.vue
@@ -320,6 +320,7 @@
     :model-value="!!showMapPreview"
     :scrim="false"
     max-width="800"
+    @update:model-value="showMapPreview = undefined"
   >
     <v-card v-if="showMapPreview">
       <v-btn
@@ -352,6 +353,7 @@
     v-if="edit"
     :model-value="!!showDeleteDialog"
     max-width="500"
+    persistent
   >
     <v-card :title="t('deleteLine')">
       <v-card-text>
@@ -382,6 +384,7 @@
     v-if="edit"
     :model-value="!!showEditDialog"
     max-width="800"
+    persistent
   >
     <v-card
       :loading="!editedLine"


### PR DESCRIPTION
On editable (REST) datasets, the table-view dialogs for entering or confirming changes — edit line, delete line, edit/delete selection, add line — are now `persistent`, so they only close via their cancel/OK buttons instead of an outside click.

**Why:** clicking outside an edit dialog discarded input unexpectedly, and worse, left the single-line edit/delete state (`showEditDialog`/`showDeleteDialog`, bound one-way with no reset) pointing at the dismissed row — reopening that row reassigned the same object reference, so the dialog never reopened. Making the dialogs persistent removes the outside-close path and fixes the stuck-state reopen bug. The read-only map preview dialog stays dismissible but gets the missing reset handler.

**Heads-up:** `persistent` also disables Esc-to-close on these dialogs, which is the intended behavior here.
