### PR TITLE
fix(settings): prevent duplicate topic ids

### DIFF
--- a/api/src/settings/service.ts
+++ b/api/src/settings/service.ts
@@ -162,8 +162,12 @@ const writeSettings = async (ctx: SettingsWriteContext, existingSettings: Settin
   }
 
   if (isMainSettings(settings) && settings.topics) {
+    const seenIds = new Map<string, string>()
     for (const topic of settings.topics) {
       if (!topic.id) topic.id = nanoid()
+      const existing = seenIds.get(topic.id)
+      if (existing) throw httpError(400, `Les thématiques "${existing}" et "${topic.title}" ont le même identifiant`)
+      seenIds.set(topic.id, topic.title)
     }
   }
 

--- a/api/types/settings/schema.js
+++ b/api/types/settings/schema.js
@@ -264,6 +264,7 @@ export default {
       layout: {
         title: '',
         listEditMode: 'inline',
+        listActions: ['sort', 'delete'],
         messages: {
           addItem: 'Add a topic',
           'x-i18n-addItem': {


### PR DESCRIPTION
Reject settings writes where two topics share the same `id`, returning a 400 with a message identifying the conflicting pair.

**Why:** duplicate topic ids could corrupt topic references elsewhere in the platform.

Also enables `sort` and `delete` list actions on the topics UI form.