### PR TITLE
feat(ui): report which column conflicts when overriding a key

### DIFF
--- a/ui/src/components/dataset/extension/dataset-extension-remote-service-card.vue
+++ b/ui/src/components/dataset/extension/dataset-extension-remote-service-card.vue
@@ -47,11 +47,11 @@
                 <v-text-field
                   :model-value="extension.overwrite?.[propKey]?.['x-originalName']"
                   :placeholder="extension.propertyPrefix + '.' + propKey"
-                  :rules="[v => validPropertyOverwrite(propKey, v) || '']"
+                  :rules="[v => validPropertyOverwrite(propKey, v)]"
                   :label="propKey"
                   validate-on="eager"
                   density="comfortable"
-                  hide-details
+                  hide-details="auto"
                   class="mb-2"
                   @update:model-value="val => setOverwriteOriginalName(propKey, val)"
                 />
@@ -133,6 +133,7 @@
 fr:
   additionalCols: Colonnes additionnelles
   allColsOut: Toutes les colonnes
+  duplicateKeyCol: "Cette clé est déjà utilisée par la colonne \"{col}\""
   confirmDeleteTooltip: Supprimer l'extension
   confirmDeleteTitle: Supprimer l'extension
   confirmDeleteText: Êtes-vous sûr de vouloir supprimer cette extension ? Les colonnes ajoutées par cet enrichissement seront supprimées.
@@ -149,6 +150,7 @@ fr:
 en:
   additionalCols: Additional columns
   allColsOut: All the columns
+  duplicateKeyCol: "This key is already used by column \"{col}\""
   confirmDeleteTooltip: Delete the extension
   confirmDeleteTitle: Delete the extension
   confirmDeleteText: Are you sure you want to delete this extension? The columns added by this enrichment will be removed.
@@ -226,23 +228,43 @@ const overwriteKeys = computed(() =>
     : selectFieldsData.value?.fieldsAndTags?.map((p: any) => p.name).filter(Boolean)
 )
 
-function validPropertyOverwrite (name: string, newName: string | null) {
+function validPropertyOverwrite (name: string, newName: string | null): true | string {
   newName = newName?.trim() ?? null
   if (!newName) return true
   const key = escapeKey(newName)
-  return !props.dataset.schema.some((f: any) => {
-    if (f['x-extension'] === extension.value.remoteService + '/' + extension.value.action) {
-      if (extension.value.select?.includes(newName) && name !== newName) return true
-      if (extension.value.overwrite) {
-        for (const [overwriteKey, overwriteValue] of Object.entries(extension.value.overwrite)) {
-          if (overwriteKey !== name && (overwriteValue as any)['x-originalName']?.trim() && escapeKey((overwriteValue as any)['x-originalName'].trim()) === key) return true
-        }
-      }
-      return false
+  const extId = extension.value.remoteService + '/' + extension.value.action
+
+  // conflict with a non-extension schema field
+  for (const f of props.dataset.schema) {
+    if (f['x-extension'] !== extId && f.key === key) {
+      return t('duplicateKeyCol', { col: f.title || f['x-originalName'] || f.key })
     }
-    return f.key === key
-  })
+  }
+
+  // conflict with a selected column name in the same extension
+  if (extension.value.select?.includes(newName) && name !== newName) {
+    return t('duplicateKeyCol', { col: newName })
+  }
+
+  // conflict with another overwrite in the same extension
+  if (extension.value.overwrite) {
+    for (const [overwriteKey, overwriteValue] of Object.entries(extension.value.overwrite as Record<string, any>)) {
+      const otherName = overwriteValue['x-originalName']?.trim()
+      if (overwriteKey !== name && otherName && escapeKey(otherName) === key) {
+        return t('duplicateKeyCol', { col: otherName })
+      }
+    }
+  }
+
+  return true
 }
+
+watch(() => extension.value.select, (newSelect) => {
+  if (!extension.value.overwrite || !newSelect?.length) return
+  for (const key of Object.keys(extension.value.overwrite)) {
+    if (!newSelect.includes(key)) delete extension.value.overwrite[key]
+  }
+})
 
 function setOverwriteOriginalName (propKey: string, value: string) {
   value = value?.trim()

--- a/ui/src/components/dataset/schema/dataset-add-column-dialog.vue
+++ b/ui/src/components/dataset/schema/dataset-add-column-dialog.vue
@@ -22,7 +22,7 @@
             <v-text-field
               v-model="newColumnKey"
               :label="t('columnName')"
-              :rules="[v => !!v || t('required'), v => validNewColumnKey(v) || t('keyExists')]"
+              :rules="[v => !!v || t('required'), v => validNewColumnKey(v)]"
               hide-details="auto"
               class="mb-4"
               autofocus
@@ -62,7 +62,7 @@ fr:
   columnName: Nom de la colonne
   columnType: Type
   required: Champ requis
-  keyExists: Cette clé existe déjà
+  keyExistsFor: "Cette clé est déjà utilisée par la colonne \"{col}\""
   cancel: Annuler
   add: Ajouter
 en:
@@ -70,7 +70,7 @@ en:
   columnName: Column name
   columnType: Type
   required: Required field
-  keyExists: This key already exists
+  keyExistsFor: "This key is already used by column \"{col}\""
   cancel: Cancel
   add: Add
 </i18n>
@@ -96,10 +96,12 @@ const isFormValid = ref(false)
 const newColumnKey = ref('')
 const newColumnType = ref(propertyTypes[0])
 
-const validNewColumnKey = (name: string) => {
-  if (!name) return false
+const validNewColumnKey = (name: string): true | string => {
+  if (!name) return true
   const key = escapeKey(name)
-  return !props.schema.find((p: any) => p.key === key)
+  const conflict = props.schema.find((p: any) => p.key === key)
+  if (!conflict) return true
+  return t('keyExistsFor', { col: conflict.title || conflict['x-originalName'] || conflict.key })
 }
 
 const addColumn = () => {

--- a/ui/src/composables/dataset/expr-eval-validation.ts
+++ b/ui/src/composables/dataset/expr-eval-validation.ts
@@ -1,6 +1,7 @@
 import type { MaybeRefOrGetter } from 'vue'
 // @ts-ignore -- shared module
 import exprEvalFactory from '#shared/expr-eval.js'
+import { escapeKey } from '~/utils/escape-key'
 
 const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
 const exprEval = exprEvalFactory(timezone)
@@ -67,3 +68,28 @@ export const useExprEvalValidation = (
 }
 
 export default useExprEvalValidation
+
+/**
+ * True when any `remoteService` extension has overwrite keys that conflict with each
+ * other or with an existing non-extension schema column.
+ */
+export const hasInvalidRemoteServiceExtension = (dataset: any): boolean => {
+  const extensions = (dataset?.extensions ?? []).filter((e: any) => e.type === 'remoteService')
+  for (const ext of extensions) {
+    if (!ext.overwrite) continue
+    const seenKeys = new Set<string>()
+    for (const overwriteValue of Object.values(ext.overwrite as Record<string, any>)) {
+      const originalName = overwriteValue?.['x-originalName']?.trim()
+      if (!originalName) continue
+      const key = escapeKey(originalName)
+      if (seenKeys.has(key)) return true
+      seenKeys.add(key)
+      const conflictsWithSchema = (dataset?.schema ?? []).some((f: any) => {
+        if (f['x-extension'] === ext.remoteService + '/' + ext.action) return false
+        return f.key === key
+      })
+      if (conflictsWithSchema) return true
+    }
+  }
+  return false
+}

--- a/ui/src/pages/dataset/[id]/index.vue
+++ b/ui/src/pages/dataset/[id]/index.vue
@@ -687,7 +687,7 @@ import { useAgentExpressionTools } from '~/composables/dataset/agent-expression-
 import { useAgentSchemaAnnotationTools } from '~/composables/dataset/agent-schema-annotation-tools'
 import { useAgentPropertyConfigTools } from '~/composables/dataset/agent-property-config-tools'
 import { useAgentDatasetPageGuidance } from '~/composables/dataset/agent-page-guidance-tools'
-import { hasInvalidExprEvalExtension } from '~/composables/dataset/expr-eval-validation'
+import { hasInvalidExprEvalExtension, hasInvalidRemoteServiceExtension } from '~/composables/dataset/expr-eval-validation'
 
 const { t, locale } = useI18n()
 const route = useRoute<'/dataset/[id]/'>()
@@ -756,7 +756,10 @@ function normalizeStructureData (d: any) {
 }
 
 const masterDataFormValid = ref(true)
-const hasInvalidExtension = computed(() => hasInvalidExprEvalExtension(structureEditFetch.data.value))
+const hasInvalidExtension = computed(() =>
+  hasInvalidExprEvalExtension(structureEditFetch.data.value) ||
+  hasInvalidRemoteServiceExtension(structureEditFetch.data.value)
+)
 
 // Sync store.dataset with both editFetch instances
 watch(structureEditFetch.serverData, (d) => {


### PR DESCRIPTION
Improve key-conflict detection in the dataset structure editor.

When a key collides — whether overriding a remote-service extension column or
adding a new column — the error now names the exact column already using that
key, instead of a generic "key already exists" message. Conflict detection for
overridden extension keys also covers collisions with sibling selected columns
and other overrides, and stale overrides are cleaned up when their column is
deselected. The dataset structure can no longer be saved while a remote-service
override key is in conflict.

**Heads-up:** the structure-level guard (`hasInvalidRemoteServiceExtension`)
does not flag a collision between an override key and a sibling selected column
in the same extension — the per-field validation already blocks the form in
that case, so it's a secondary safety net only.
