### PR TITLE
fix(ui): show name beside avatar and fix avatar cropping in dataset table

### DIFF
--- a/ui/src/components/dataset/table/dataset-table-value.vue
+++ b/ui/src/components/dataset/table/dataset-table-value.vue
@@ -19,21 +19,25 @@
   </template>
 
   <div v-else>
-    <v-avatar
-      v-if="property.key === '_updatedByName' && extendedValue.formatted.startsWith($sdUrl)"
-      :size="28"
-      :title="extendedValue.raw"
-    >
-      <img :src="extendedValue.formatted">
-    </v-avatar>
+    <!-- color pin is an extra decoration displayed alongside the value -->
     <div
       v-if="property['x-refersTo'] === 'https://schema.org/color' && extendedValue.raw"
       class="item-value-color-pin"
       :style="`background-color:${extendedValue.raw}`"
     />
 
+    <!-- updatedByName / ownerName: show the user/owner avatar followed by their name (not the avatar URL) -->
+    <template v-if="(property.key === '_updatedByName' || property.key === '_ownerName') && extendedValue.formatted.startsWith($sdUrl)">
+      <v-avatar
+        :size="28"
+        :image="extendedValue.formatted"
+        class="me-2"
+      />
+      <span class="pr-2">{{ extendedValue.raw }}</span>
+    </template>
+
     <v-tooltip
-      v-if="property['x-refersTo'] === 'https://github.com/data-fair/lib/account' && extendedValue.raw"
+      v-else-if="property['x-refersTo'] === 'https://github.com/data-fair/lib/account' && extendedValue.raw"
       location="top"
     >
       <template #activator="{props}">
@@ -41,9 +45,10 @@
           class="text-body-medium"
           v-bind="props"
         >
-          <v-avatar :size="28">
-            <img :src="extendedValue.formatted">
-          </v-avatar>
+          <v-avatar
+            :size="28"
+            :image="extendedValue.formatted"
+          />
         </span>
       </template>
       <!-- TODO: fetch account name ? -->

--- a/ui/src/composables/dataset/lines.ts
+++ b/ui/src/composables/dataset/lines.ts
@@ -99,6 +99,9 @@ export const useLines = (displayMode: MaybeRefOrGetter<string>, pageSize: MaybeR
           if (property.key === '_updatedByName' && raw._updatedBy && !raw._updatedBy.startsWith('apiKey:')) {
             extendedValue.formatted = `${$sdUrl}/api/avatars/user/${raw._updatedBy}/avatar.png`
           }
+          if (property.key === '_ownerName' && raw._owner) {
+            extendedValue.formatted = `${$sdUrl}/api/avatars/${raw._owner.split(':').join('/')}/avatar.png`
+          }
           if (property['x-refersTo'] === 'https://github.com/data-fair/lib/account' && raw[property.key]) {
             extendedValue.formatted = `${$sdUrl}/api/avatars/${raw[property.key].split(':').join('/')}/avatar.png`
           }


### PR DESCRIPTION
Improve the rendering of the user/owner columns in the datasets table view.

- `_updatedByName` and `_ownerName` now show the avatar followed by the person's name (with spacing), instead of the avatar followed by the raw avatar URL.
- Avatars are no longer zoomed/cropped: they use the `v-avatar` `:image` prop (object-fit cover) instead of a nested `<img>`.

**Why:** these columns are meant to identify *who* updated / owns a row — the name is the useful information, and the cropped avatars looked broken.

**Heads-up:** the avatar/name block now sits in the same `v-if`/`v-else-if`/`v-else` chain as the account-concept tooltip and the fallback span, so the branches are mutually exclusive (keyed distinctly: `_updatedByName`/`_ownerName` by `property.key`, the account branch by `x-refersTo`). The `_owner` column keeps its separate dedicated rendering in `dataset-table-cell.vue` for now (and is still shown by default since it is not yet a calculated field); a follow-up will mark `_owner`/`_ownerName` as calculated server-side and clean that up.
