### PR TITLE
fix(ui): keep detailed permissions block visible after client navigation

### DIFF
--- a/ui/src/components/permissions/permissions-editor.vue
+++ b/ui/src/components/permissions/permissions-editor.vue
@@ -528,7 +528,7 @@ watch(detailedMode, async (newVal) => {
   if (newVal) {
     if (!ownerDetails.value) await fetchOwnerDetails()
   }
-})
+}, { immediate: true })
 
 // --- Fetch owner details from simple-directory ---
 


### PR DESCRIPTION
Make the `detailedMode` watcher in `permissions-editor.vue` immediate so the owner-details fetch runs whenever detailed mode is active.

**Why:** when returning to a dataset page via the breadcrumb, the store still holds the permissions in memory, so on remount the `modelValue` watcher enables `detailedMode` synchronously during setup — before the `detailedMode` watcher is registered. Since that watcher was not immediate, it missed the transition, `fetchOwnerDetails()` never ran, and the add/table block stayed hidden while the toggle remained active. Making it immediate triggers the fetch regardless of initialization order; the existing `ownerDetails` guard prevents any double-fetch.
