### PR TITLE
fix(datasets): restore row attachments upload broken by Vuetify 4

### DIFF
--- a/api/src/datasets/utils/patch.ts
+++ b/api/src/datasets/utils/patch.ts
@@ -146,6 +146,8 @@ export const preparePatch = async (app: any, patch: any, dataset: any, sessionSt
   const coordYProp = dataset.schema.find((p: any) => p['x-refersTo'] === 'http://data.ign.fr/def/geometrie#coordY')
   const projectGeomProp = dataset.schema.find((p: any) => p['x-refersTo'] === 'http://data.ign.fr/def/geometrie#Geometry')
 
+  const digitalDocumentKey = (schema: any[]): string | undefined => schema?.find((f: any) => f['x-refersTo'] === 'http://schema.org/DigitalDocument')?.key
+
   let attemptMappingUpdate = false
 
   const reindexerStatus = dataset.file ? 'validated' : 'analyzed'
@@ -170,6 +172,9 @@ export const preparePatch = async (app: any, patch: any, dataset: any, sessionSt
     patch.status = reindexerStatus
   } else if (patch.schema && geo.geoFieldsKey(patch.schema) !== geo.geoFieldsKey(dataset.schema)) {
     // geo concepts haved changed, trigger full re-indexing
+    patch.status = reindexerStatus
+  } else if (patch.schema && digitalDocumentKey(patch.schema) !== digitalDocumentKey(dataset.schema)) {
+    // digitalDocument concept changed: full re-indexing to (re)compute _attachment_url per row (a mapping update would leave it empty)
     patch.status = reindexerStatus
   } else if (patch.schema && patch.schema.find((f: any) => dataset.schema.find((df: any) => df.key === f.key && df.separator !== f.separator))) {
     // some separator has changed on a field, trigger full re-indexing

--- a/ui/src/components/dataset/dataset-upload-dialog.vue
+++ b/ui/src/components/dataset/dataset-upload-dialog.vue
@@ -122,9 +122,9 @@ const { id: datasetId, datasetFetch, digitalDocumentField } = useDatasetStore()
 
 const showDialog = ref(false)
 const fileInputValue = ref<File[]>([])
-const attachmentsInputValue = ref<File[]>([])
+const attachmentsInputValue = ref<File | null>(null)
 const file = ref<File | null>(null)
-const attachments = computed(() => attachmentsInputValue.value?.[0] ?? null)
+const attachments = computed(() => attachmentsInputValue.value ?? null)
 const encoding = ref('')
 
 const encodingOptions = [
@@ -151,7 +151,7 @@ function onFileChange (val: File | File[]) {
 watch(showDialog, (val) => {
   if (val) {
     fileInputValue.value = []
-    attachmentsInputValue.value = []
+    attachmentsInputValue.value = null
     file.value = null
     encoding.value = ''
     uploadProgress.value = { loaded: 0 }

--- a/ui/src/pages/new-dataset.vue
+++ b/ui/src/pages/new-dataset.vue
@@ -513,8 +513,8 @@ function onInitFromNext () {
 // ---- File params ----
 const fileInputValue = ref<File[]>([])
 const file = ref<File | null>(null)
-const attachmentsInputValue = ref<File[]>([])
-const attachments = computed(() => attachmentsInputValue.value?.[0] ?? null)
+const attachmentsInputValue = ref<File | null>(null)
+const attachments = computed(() => attachmentsInputValue.value ?? null)
 const fileTitle = ref('')
 const lastAutoFilledTitle = ref('')
 const attachmentsAsImage = ref(false)


### PR DESCRIPTION
Vuetify 4's `v-file-input` (without `multiple`) emits a single `File` instead of the `File[]` it returned in Vuetify 3. The attachment inputs still read the selected file as `attachmentsInputValue.value?.[0]`, which is `undefined` on a single `File`, so the zip was silently never appended to the upload — and on the creation page the "display attachments as images" checkbox (gated on `attachments`) never appeared.

- Update dialog (`dataset-upload-dialog.vue`): the attachments zip is sent again.
- Creation page (`new-dataset.vue`): the zip is sent and the `attachmentsAsImage` checkbox shows once a zip is selected.
- API (`patch.ts`): force a full re-indexing when the `DigitalDocument` concept is added/removed/moved on an existing dataset, so `_attachment_url` is (re)computed for existing rows instead of being added empty by a mapping-only update.

**Why:** uploading row attachments (a zip matched to a column) was broken — images returned 404 because the zip never reached the server, and assigning the concept afterwards left the per-row attachment URL empty.

**Heads-up:** the `patch.ts` change makes a column gaining/losing the `DigitalDocument` concept trigger a full re-index (mirroring the existing geo-concept branch) — heavier than the previous no-op mapping update, but required for correctness.
