### PR TITLE
fix(datasets): reject geojson files with colliding column keys

### DIFF
--- a/api/src/workers/files-processor/analyze-geojson.ts
+++ b/api/src/workers/files-processor/analyze-geojson.ts
@@ -38,6 +38,9 @@ export default async function (dataset: FileDataset) {
   const sampleValues = await getSampleValues(dataset, ['geometry'], (decodedData: any) => crsParser.write(decodedData))
   crsParser.end()
 
+  // keep track of the original name behind each key to detect collisions
+  // (e.g. a feature top-level "id" and a property "_id" both escape to "id")
+  const originalNamesByKey = new Map<string, string>([['geometry', 'geometry']])
   for (const property in sampleValues) {
     const key = fieldsSniffer.escapeKey(property, dataset?.analysis?.escapeKeyAlgorithm)
     const existingField = dataset.schema?.find(f => f.key === key)
@@ -46,7 +49,13 @@ export default async function (dataset: FileDataset) {
       'x-originalName': property,
       ...fieldsSniffer.sniff([...sampleValues[property]], attachments, existingField)
     }
-    if (field.type !== 'empty') schema.push(field)
+    if (field.type === 'empty') continue
+    const collidingName = originalNamesByKey.get(key)
+    if (collidingName !== undefined) {
+      throw httpError(400, `[noretry] Échec de l'analyse du fichier, les colonnes "${collidingName}" et "${property}" correspondent à la même clé "${key}".`)
+    }
+    originalNamesByKey.set(key, property)
+    schema.push(field)
   }
 
   dataset.status = 'analyzed'

--- a/tests/features/datasets/upload/geo-files.api.spec.ts
+++ b/tests/features/datasets/upload/geo-files.api.spec.ts
@@ -114,6 +114,24 @@ test.describe('geo files support', () => {
     assert.ok(!res.data.results[0]._vt)
   })
 
+  test('Reject geojson with colliding column keys (feature id and _id property)', async () => {
+    // a feature top-level `id` is mapped to a property `id`, and a property `_id`
+    // is escaped to the same `id` key: this collision must produce a clear error
+    // instead of silently creating two confusing columns
+    const datasetFd = fs.readFileSync('./tests/resources/geo/geojson-duplicate-id-key.geojson')
+    const form = new FormData()
+    form.append('file', datasetFd, 'geojson-duplicate-id-key.geojson')
+    const ax = testUser1
+    const res = await ax.post('/api/v1/datasets', form, { headers: { 'Content-Length': form.getLengthSync(), ...form.getHeaders() } })
+    assert.equal(res.status, 201)
+
+    const errorDataset = await waitForDatasetError(ax, res.data.id)
+    assert.equal(errorDataset.status, 'error')
+    const journal = (await ax.get(`/api/v1/datasets/${res.data.id}/journal`)).data
+    const errorEvent = journal.find((e: any) => e.type === 'error')
+    assert.ok(errorEvent.data.includes('"id"'), `expected error to mention the colliding key, got: ${errorEvent.data}`)
+  })
+
   test('Upload geojson with geometry type GeometryCollection', async () => {
     // Send dataset
     const datasetFd = fs.readFileSync('./tests/resources/geo/geojson-geometry-collection.geojson')

--- a/tests/resources/geo/geojson-duplicate-id-key.geojson
+++ b/tests/resources/geo/geojson-duplicate-id-key.geojson
@@ -1,0 +1,29 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "id": "feat1",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [103.5, 0.5]
+      },
+      "properties": {
+        "_id": "prop1",
+        "label": "value1"
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "feat2",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [104.5, 1.5]
+      },
+      "properties": {
+        "_id": "prop2",
+        "label": "value2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
A geojson feature top-level `id` is exposed as a column `id`, while a property `_id` is escaped to the same `id` key (the leading underscore is reserved for data-fair calculated fields and stripped). This silently produced two confusing columns sharing the same key. The geojson analyzer had no duplicate-key guard, unlike the CSV analyzer.

**What changed:** the geojson analyzer now rejects a file whose columns collide on the same key, with an error naming both original columns and the conflicting key — mirroring the existing CSV check. This also covers every format normalized to geojson (shapefile, gpx, kml, mapinfo).

**Why:** uploading such a file should fail with a clear message instead of producing a broken schema with duplicate keys.

**Heads-up:** this triggers at analyze time, not on read. An existing dataset that was created with colliding columns keeps working until its next data reload, at which point that reload will now fail with the new error until a column is renamed. No retroactive migration is performed.
