### PR TITLE
fix(ui): repair grouped column selector in dataset table view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3879,9 +3879,9 @@
       "license": "MIT"
     },
     "node_modules/@koumoul/vjsf": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@koumoul/vjsf/-/vjsf-4.5.1.tgz",
-      "integrity": "sha512-6vtTUXc0G0EBf+cIH9xYTIb+HTyo0F+HG9VAGD81P2qU/UkaK+H78gJKcgYJF+kxcX/1RaSOmxXg9mHR3PlYBg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@koumoul/vjsf/-/vjsf-4.5.3.tgz",
+      "integrity": "sha512-PBXBjJ6SUVC6Kep7fYhT0gYVst6Zy+KjRJF3DKG8EGYZ5UterKPDyk4iTVFv79PcEOQ+DhocPCRivMsg5WOH3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3892,7 +3892,7 @@
       },
       "peerDependencies": {
         "vue": "^3.4.3",
-        "vuetify": "^4.0.0"
+        "vuetify": "^4.1.0"
       }
     },
     "node_modules/@koumoul/vjsf-markdown": {
@@ -22729,9 +22729,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.0.5.tgz",
-      "integrity": "sha512-pFysKOHuY3dROTVh9PdlhVz50ZR0E5/goY5ecTXc8F8tajUA2ee3xZ8Lqs1WtEw/X3w93wx/LogyjgaQCAL/Ig==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-4.1.2.tgz",
+      "integrity": "sha512-2SUzXt2Q71/cVmSZhU6kOmAo1ev3NZaI/ynj55TTcu6jXAc9kezoqZKY+Xm+0STnAOcCoTseF0qPSs01LjUaaA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -23275,7 +23275,7 @@
         "vue-router": "^5.0.0",
         "vue-tsc": "^3.2.6",
         "vuedraggable": "^4.1.0",
-        "vuetify": "^4.0.0"
+        "vuetify": "^4.1.0"
       }
     },
     "ui/node_modules/@vueuse/core": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -59,7 +59,7 @@
     "vue-router": "^5.0.0",
     "vue-tsc": "^3.2.6",
     "vuedraggable": "^4.1.0",
-    "vuetify": "^4.0.0"
+    "vuetify": "^4.1.0"
   },
   "dependencies": {
     "@data-fair/agent-tools-data-fair": "*",

--- a/ui/src/components/dataset/metadata/dataset-metadata-form.vue
+++ b/ui/src/components/dataset/metadata/dataset-metadata-form.vue
@@ -346,7 +346,6 @@ en:
 import { withQuery } from 'ufo'
 import { MarkdownEditor } from '@koumoul/vjsf-markdown'
 import { DfAgentChatAction } from '@data-fair/lib-vuetify-agents'
-import { VDateInput } from 'vuetify/labs/VDateInput'
 import equal from 'fast-deep-equal'
 const dataset = defineModel<any>({ required: true })
 

--- a/ui/src/components/dataset/select/dataset-select-cols.vue
+++ b/ui/src/components/dataset/select/dataset-select-cols.vue
@@ -29,28 +29,22 @@
             v-if="group"
             :key="group"
             :label="group"
-            :model-value="groupStatus[group] !== 'none'"
-            :color="groupStatus[group] === 'some' ? 'grey' : 'primary'"
+            :model-value="groupStatus[group] === 'all'"
+            :indeterminate="groupStatus[group] === 'some'"
+            color="primary"
             density="compact"
             hide-details
-            @update:model-value="value => toggleGroup(group, !!value)"
+            @update:model-value="() => toggleGroup(group, groupStatus[group] !== 'all')"
           >
             <template #append>
               <v-btn
-                v-if="unfoldedGroups[group]"
-                :key="'fold-down-' + group"
-                :icon="mdiMenuDown"
-                style="margin-top:-8px;"
-                :title="t('fold')"
-                @click="unfoldedGroups[group] = false"
-              />
-              <v-btn
-                v-if="!unfoldedGroups[group]"
-                :key="'fold-up-' + group"
-                :icon="mdiMenuLeft"
-                style="margin-top:-8px;"
-                :title="t('unfold')"
-                @click="unfoldedGroups[group] = true"
+                :icon="unfoldedGroups[group] ? mdiChevronDown : mdiChevronRight"
+                variant="text"
+                size="small"
+                density="comfortable"
+                :title="unfoldedGroups[group] ? t('fold') : t('unfold')"
+                :aria-expanded="!!unfoldedGroups[group]"
+                @click.stop="unfoldedGroups[group] = !unfoldedGroups[group]"
               />
             </template>
           </v-checkbox>
@@ -60,14 +54,13 @@
           >
             <v-checkbox
               v-show="!prop['x-group'] || unfoldedGroups[prop['x-group']]"
-              :value="prop.key"
               :label="prop.title || prop['x-originalName'] || prop.key"
-              :model-value="cols"
+              :model-value="cols.includes(prop.key)"
               color="primary"
               density="compact"
               hide-details
               :class="{'ml-3': !!prop['x-group']}"
-              @update:model-value="newCols => {cols = newCols ?? []}"
+              @update:model-value="checked => toggleCol(prop.key, !!checked)"
             />
           </template>
         </template>
@@ -92,7 +85,7 @@ en:
 </i18n>
 
 <script setup lang="ts">
-import { mdiMenuLeft, mdiMenuDown, mdiTableColumnPlusAfter } from '@mdi/js'
+import { mdiChevronDown, mdiChevronRight, mdiTableColumnPlusAfter } from '@mdi/js'
 
 const cols = defineModel<string[]>({ default: [] })
 
@@ -129,6 +122,14 @@ const groupStatus = computed(() => {
   return statuses
 })
 
+const toggleCol = (key: string, checked: boolean) => {
+  if (checked) {
+    if (!cols.value.includes(key)) cols.value = [...cols.value, key]
+  } else {
+    cols.value = cols.value.filter(k => k !== key)
+  }
+}
+
 const toggleGroup = (group: string, value: boolean) => {
   if (value) {
     const newCols = [...cols.value]
@@ -140,7 +141,7 @@ const toggleGroup = (group: string, value: boolean) => {
     cols.value = newCols
   } else {
     cols.value = cols.value.filter(v => {
-      const prop = selectableProps.value.find(fh => fh.value === v)
+      const prop = selectableProps.value.find(fh => fh.key === v)
       return prop?.['x-group'] !== group
     })
   }

--- a/ui/src/components/settings/settings-api-keys.vue
+++ b/ui/src/components/settings/settings-api-keys.vue
@@ -249,7 +249,6 @@ en:
 <script setup lang="ts">
 import type { Settings } from '#api/types'
 import { mdiPlus } from '@mdi/js'
-import { VDateInput } from 'vuetify/labs/VDateInput'
 
 const { restrictedScopes } = defineProps<{
   restrictedScopes?: string[]


### PR DESCRIPTION
Fix the "visible columns" selector in the dataset table view when the schema has `x-group` groups.

**What changed:**
- Unchecking a group now works — `toggleGroup` matched props on a non-existent `value` field instead of `key`.
- Proper tri-state group checkboxes: primary-blue indeterminate `[-]`, clicking a partial group selects all, clicking a full group deselects all in one click. `model-value` is bound to `=== 'all'` so the value flips on every transition and the native input never desyncs (avoids the Vuetify "two-click to deselect" bug); the blue `[-]` is forced via a scoped CSS rule since Vuetify only colours active controls.
- The fold/unfold control is now a small flat chevron (down/right) with `aria-expanded`, replacing the two oversized circular icon buttons with a confusing left arrow.
- Each column checkbox binds to a boolean (`cols.includes(key)`) instead of the whole array, so only changed checkboxes re-render — fixing dropped clicks during rapid toggling.

**Why:** the grouped column selector was visually broken and behaved badly — groups couldn't be unselected, the toggle buttons were ugly, the indeterminate state was missing/grey, and clicking a group parent was unreliable.
