### PR TITLE
fix(ui): RGAA accessibility fixes for search, map and download menu

### DIFF
--- a/ui/src/components/common/search-field.vue
+++ b/ui/src/components/common/search-field.vue
@@ -22,7 +22,8 @@
         <v-btn
           :icon="mdiMagnify"
           :title="t('searchSubmit')"
-          density="compact"
+          density="comfortable"
+          size="small"
           variant="text"
           @click="q = pendingQ"
         />

--- a/ui/src/components/common/search-field.vue
+++ b/ui/src/components/common/search-field.vue
@@ -1,29 +1,43 @@
 <template>
-  <v-text-field
-    v-model="pendingQ"
-    :append-inner-icon="mdiMagnify"
-    :label="t('search')"
-    class="mx-2"
-    color="primary"
-    density="compact"
-    max-width="250"
-    min-width="175"
-    variant="outlined"
-    hide-details
-    single-line
-    clearable
-    rounded
-    @keyup.enter="q = pendingQ"
-    @click:append-inner="q = pendingQ"
-    @click:clear="q = ''"
-  />
+  <div
+    :aria-label="t('search')"
+    role="search"
+    class="mx-2 flex-1-1"
+    style="max-width: 250px; min-width: 175px;"
+  >
+    <v-text-field
+      v-model="pendingQ"
+      :label="t('search')"
+      color="primary"
+      density="compact"
+      variant="outlined"
+      hide-details
+      single-line
+      clearable
+      rounded
+      @keyup.enter="q = pendingQ"
+      @click:clear="q = ''"
+    >
+      <template #append-inner>
+        <v-btn
+          :icon="mdiMagnify"
+          :title="t('searchSubmit')"
+          density="compact"
+          variant="text"
+          @click="q = pendingQ"
+        />
+      </template>
+    </v-text-field>
+  </div>
 </template>
 
 <i18n lang="yaml">
 fr:
   search: Rechercher
+  searchSubmit: Lancer la recherche
 en:
   search: Search
+  searchSubmit: Submit search
 </i18n>
 
 <script setup lang="ts">
@@ -35,7 +49,7 @@ const { t } = useI18n()
 const q = defineModel<string>({ default: '' })
 
 /** Local buffer holding the in-progress input. Acts as a manual debounce: the parent model is
- *  only updated on Enter or icon click, unless `immediate` is set. */
+ *  only updated on Enter or magnifier click, unless `immediate` is set. */
 const pendingQ = ref('')
 watch(q, () => { pendingQ.value = q.value }, { immediate: true })
 watch(pendingQ, () => { if (immediate) q.value = pendingQ.value })

--- a/ui/src/components/dataset/dataset-download-results-menu.vue
+++ b/ui/src/components/dataset/dataset-download-results-menu.vue
@@ -2,7 +2,7 @@
   <v-menu
     v-model="menu"
     :close-on-content-click="false"
-    max-width="300"
+    max-width="400"
   >
     <template #activator="{ props }">
       <v-btn

--- a/ui/src/components/dataset/dataset-download-results.vue
+++ b/ui/src/components/dataset/dataset-download-results.vue
@@ -152,21 +152,21 @@ fr:
   downloadTitle: Télécharger les résultats
   alert1: Ces téléchargements tiennent compte du tri et de la recherche.
   alert2: Les formats suivants sont limités aux 10 000 premières lignes.
-  csv: Format CSV
-  xlsx: Format XLSX
-  ods: Format ODS
-  geojson: Format GeoJSON
-  shp: Format Shapefile
+  csv: Télécharger au format CSV
+  xlsx: Télécharger au format XLSX
+  ods: Télécharger au format ODS
+  geojson: Télécharger au format GeoJSON
+  shp: Télécharger au format Shapefile
   cancel: Annuler
 en:
   downloadTitle: Download results
   alert1: These downloads take into consideration the current filters and sorting.
   alert2: The next formats are limited to the 10,000 first lines.
-  csv: CSV format
-  xlsx: XLSX format
-  ods: ODS format
-  geojson: GeoJSON format
-  shp: Shapefile format
+  csv: Download as CSV
+  xlsx: Download as XLSX
+  ods: Download as ODS
+  geojson: Download as GeoJSON
+  shp: Download as Shapefile
   cancel: Cancel
 </i18n>
 

--- a/ui/src/components/dataset/map/dataset-map.vue
+++ b/ui/src/components/dataset/map/dataset-map.vue
@@ -3,21 +3,31 @@
     <v-text-field
       v-if="search && !noInteraction"
       v-model="editQ"
-      :append-inner-icon="mdiMagnify"
-      :placeholder="t('search')"
+      :label="t('search')"
       style="position:absolute;z-index:2;"
-      variant="solo"
+      variant="outlined"
       color="primary"
-      bg-color="white"
+      bg-color="surface"
       density="compact"
       width="250"
       class="ma-2"
       hide-details
+      single-line
       clearable
       @keyup.enter="q = editQ"
-      @click:append-inner="q = editQ"
       @click:clear="q = ''"
-    />
+    >
+      <template #append-inner>
+        <v-btn
+          :icon="mdiMagnify"
+          :title="t('searchSubmit')"
+          density="comfortable"
+          size="small"
+          variant="text"
+          @click="q = editQ"
+        />
+      </template>
+    </v-text-field>
     <div
       id="map"
       :style="'height:' + height + 'px'"
@@ -28,11 +38,13 @@
 <i18n lang="yaml">
 fr:
   search: Rechercher
+  searchSubmit: Lancer la recherche
   noGeoData: Aucune donnée géographique valide.
   noData: Aucune donnée à afficher
   mapError: "Erreur pendant le rendu de la carte :"
 en:
   search: Search
+  searchSubmit: Submit search
   noGeoData: No valid geo data
   noData: No data to display
   mapError: "Error while rendering the map:"
@@ -91,7 +103,7 @@ const fetchBBOX = useFetch<{ bbox: [number, number, number, number] }>(`${$apiPa
   })
 })
 
-useMap(tileUrl, selectable, selectedItem, noInteraction, cols, navigationPosition, computed(() => fetchBBOX.data.value?.bbox))
+useMap(tileUrl, selectable, selectedItem, noInteraction, cols, navigationPosition, computed(() => fetchBBOX.data.value?.bbox), t)
 
 </script>
 

--- a/ui/src/components/dataset/map/use-map.ts
+++ b/ui/src/components/dataset/map/use-map.ts
@@ -14,10 +14,10 @@ export const useMap = (
   noInteraction: boolean,
   cols: string[],
   navigationPosition: ControlPosition,
-  bbox: Ref<LngLatBoundsLike | undefined>
+  bbox: Ref<LngLatBoundsLike | undefined>,
+  t: (key: string) => string
 ) => {
   const { sendUiNotif } = useUiNotif()
-  const { t } = useI18n()
   const { style, dataLayers } = useMapStyle()
   const { id, dataset } = useDatasetStore()
 
@@ -62,14 +62,36 @@ export const useMap = (
     // Create a popup, but don't add it to the map yet.
     const popup = new maplibregl.Popup({ closeButton: true, closeOnClick: true })
 
+    const emptyFilter: LegacyFilterSpecification = ['==', '_id', '']
+    const pointFilter: LegacyFilterSpecification = ['==', '$type', 'Point']
+
+    const clearHoverFilter = () => {
+      map.setFilter('results_hover', emptyFilter)
+      map.setFilter('results_point_hover', ['all', pointFilter, emptyFilter])
+    }
+
+    popup.on('close', () => {
+      // Guard against the brief window during which the tileUrl watcher has
+      // removed every data layer and not yet re-added them.
+      if (map.getLayer('results_selected')) {
+        map.setFilter('results_selected', emptyFilter)
+      }
+      if (map.getLayer('results_point_selected')) {
+        map.setFilter('results_point_selected', ['all', pointFilter, emptyFilter])
+      }
+    })
+
+    let hoveredId: string | undefined
     const moveCallback = (e: any) => {
       const feature = map.queryRenderedFeatures(e.point).find(f => f.source === 'data-fair')
       if (!feature) return
 
-      if (feature.properties._id !== undefined) {
-        const itemFilter: LegacyFilterSpecification = ['==', '_id', feature.properties._id]
+      const id = feature.properties._id
+      if (id !== undefined && id !== hoveredId) {
+        hoveredId = id
+        const itemFilter: LegacyFilterSpecification = ['==', '_id', id]
         map.setFilter('results_hover', itemFilter)
-        map.setFilter('results_point_hover', ['all', ['==', '$type', 'Point'], itemFilter])
+        map.setFilter('results_point_hover', ['all', pointFilter, itemFilter])
       }
       // Change the cursor style as a UI indicator.
       map.getCanvas().style.cursor = 'pointer'
@@ -101,7 +123,7 @@ export const useMap = (
           .filter(field => !cols.length || cols.includes(field.key))
           .filter(field => item[field.key] !== undefined)
           .map(field => {
-            return `<li style="list-style-type: none;">${field.title || field['x-originalName'] || field.key}: ${item[field.key]}</li>`
+            return `<li style="list-style-type: none;"><strong>${field.title || field['x-originalName'] || field.key}:</strong> ${item[field.key]}</li>`
           })
           .join('\n')
         const html = `<ul style="padding-left: 0;">${htmlList}</ul>`
@@ -111,18 +133,33 @@ export const useMap = (
         popup.setLngLat(e.lngLat)
           .setHTML(html)
           .addTo(map)
+
+        const itemFilter: LegacyFilterSpecification = ['==', '_id', feature.properties._id]
+        map.setFilter('results_selected', itemFilter)
+        map.setFilter('results_point_selected', ['all', pointFilter, itemFilter])
       }
     }
 
+    const debouncedMoveCallback = debounce(moveCallback, 30)
+
     const leaveCallback = () => {
+      debouncedMoveCallback.clear()
       map.getCanvas().style.cursor = ''
+      hoveredId = undefined
+      clearHoverFilter()
     }
 
-    dataLayers.forEach(layer => {
-      map.on('mousemove', layer.id, debounce(moveCallback, 30))
-      map.on('mouseleave', layer.id, leaveCallback)
+    const interactiveLayers: Array<{ id: string, move: typeof moveCallback }> = [
+      { id: 'results_polygon', move: debouncedMoveCallback },
+      { id: 'results_line', move: debouncedMoveCallback },
+      { id: 'results_point', move: moveCallback },
+    ]
+    interactiveLayers.forEach(({ id, move }) => {
+      if (!dataLayers.some(layer => layer.id === id)) return
+      map.on('mousemove', id, move)
+      map.on('mouseleave', id, leaveCallback)
       if (!noInteraction) {
-        map.on('click', layer.id, clickCallback)
+        map.on('click', id, clickCallback)
       }
     })
 

--- a/ui/src/components/dataset/table/dataset-table-select-display.vue
+++ b/ui/src/components/dataset/table/dataset-table-select-display.vue
@@ -29,6 +29,7 @@
         density="compact"
       >
         <v-list-item
+          :aria-current="displayMode === 'table' ? 'true' : undefined"
           :active="displayMode === 'table'"
           :title="t('displayTable')"
           @click="displayMode = 'table'"
@@ -38,6 +39,7 @@
           </template>
         </v-list-item>
         <v-list-item
+          :aria-current="displayMode === 'table-dense' ? 'true' : undefined"
           :active="displayMode === 'table-dense'"
           :title="t('displayTableDense')"
           @click="displayMode = 'table-dense'"
@@ -48,6 +50,7 @@
         </v-list-item>
         <v-list-item
           v-if="!edit"
+          :aria-current="displayMode === 'list' ? 'true' : undefined"
           :active="displayMode === 'list'"
           :title="t('displayList')"
           @click="displayMode = 'list'"


### PR DESCRIPTION
Low-risk slice of the accessibility (RGAA) audit, split out of #387 so it can be reviewed and merged on its own, ahead of the larger dataset-table work.

**What changed:**
- `search-field` (shared component): wrapped in a `role="search"` landmark with a real labelled submit button instead of a decorative icon (RGAA 7.1 / 12.6). The landmark wrapper keeps the field's flex sizing and width bounds so the toolbar layout is unchanged.
- Dataset map: search field aligned to the same accessible outlined pattern (RGAA 7.1 / 12.6); plus a few co-located map fixes — hover-id dedup, popup labels in `<strong>`, and the selected-feature highlight cleared on popup close / layer leave.
- Download menu: format links carry an explicit accessible name like "Télécharger au format CSV" instead of "Format CSV" (RGAA 6.1); menu widened to fit the longer labels.
- Display-mode selector: the active mode now carries `aria-current="true"`.

**Heads-up:**
- `use-map.ts` now wires interaction handlers only to `results_polygon` / `results_line` / `results_point` (previously every layer from `useMapStyle()`); confirm no other interactive layer id exists.
- `search-field` is shared (4 usages); its DOM is now a `<div role="search">` wrapper — verify the field renders at its previous size in each toolbar.

No tests in this slice (the table-view e2e suite stays with #387).
