### PR TITLE
fix(datasets): make row-attachment column detection non-blocking

### DIFF
--- a/api/src/datasets/utils/operations.ts
+++ b/api/src/datasets/utils/operations.ts
@@ -36,10 +36,8 @@ const checkInteger = (val: string): boolean => {
   return Number.isInteger(number)
 }
 
-// detect an attachment-path column as soon as a majority of non-empty sample
-// values point to an uploaded attachment file. Per-value mismatches are not
-// blocking: the column is still recognized, and the user can fix the data or
-// designate the column manually.
+// recognize an attachment-path column when a majority of non-empty values match an
+// uploaded file; per-value mismatches don't block detection.
 const matchesMostAttachments = (values: string[], attachmentsPaths: string[]): boolean => {
   const definedValues = values
     .filter(v => !!v)

--- a/api/src/datasets/utils/operations.ts
+++ b/api/src/datasets/utils/operations.ts
@@ -36,7 +36,19 @@ const checkInteger = (val: string): boolean => {
   return Number.isInteger(number)
 }
 
-const isOneOf = (value: string, values: string[]): boolean => values.includes(value)
+// detect an attachment-path column as soon as a majority of non-empty sample
+// values point to an uploaded attachment file. Per-value mismatches are not
+// blocking: the column is still recognized, and the user can fix the data or
+// designate the column manually.
+const matchesMostAttachments = (values: string[], attachmentsPaths: string[]): boolean => {
+  const definedValues = values
+    .filter(v => !!v)
+    .map(v => v.trim())
+    .filter(v => !!v)
+  if (!definedValues.length) return false
+  const validCount = definedValues.filter(v => attachmentsPaths.includes(v)).length
+  return validCount > definedValues.length / 2
+}
 const booleanRegexp = new RegExp(`^${trimablePrefix}(0|1|-1|true|false|vrai|faux|oui|non|yes|no)${trimablePrefix}$`, 'i')
 const dateTimeSchema = ajv.compile({ type: 'string', format: 'date-time' })
 const dateSchema = ajv.compile({ type: 'string', format: 'date' })
@@ -53,33 +65,14 @@ const hasDateFormat = (format: string) => {
   return (value: string): boolean => moment(value, formats, true).isValid()
 }
 
-function checkAll (values: string[], check: (val: string, param?: any) => boolean, param?: any, throwIfAlmost?: string): boolean {
+function checkAll (values: string[], check: (val: string) => boolean): boolean {
   const definedValues = values
     .filter(v => !!v)
     .map(v => v.trim())
     .filter(v => !!v)
 
   if (!definedValues.length) return false
-  const invalidValues: string[] = []
-  const validValues: string[] = []
-  for (const value of definedValues) {
-    if (check(value, param)) {
-      validValues.push(value)
-    } else {
-      invalidValues.push(value)
-    }
-  }
-  if (throwIfAlmost) {
-    if (invalidValues.length && invalidValues.length <= (definedValues.length / 2)) {
-      const invalidValuesMsg = invalidValues.slice(0, 3).join(', ') + (invalidValues.length > 3 ? '...' : '.')
-      const validValuesMsg = validValues.slice(0, 3).join(', ') + (validValues.length > 3 ? '...' : '.')
-      throw new Error(`${throwIfAlmost}
-Valeurs invalides : ${invalidValuesMsg}
-Valeurs valides : ${validValuesMsg}
-`)
-    }
-  }
-  return !invalidValues.length
+  return definedValues.every(value => check(value))
 }
 
 const defaultSniffDateConfig: SniffDateConfig = {
@@ -107,7 +100,7 @@ export const sniff = (values: string[], attachmentsPaths: string[] = [], existin
 
   const { dateTimeFormats, dateFormats } = dateConfig ?? defaultSniffDateConfig
 
-  if (attachmentsPaths && attachmentsPaths.length && checkAll(values, isOneOf, attachmentsPaths, '[noretry] Vous avez chargé des pièces jointes, et une colonne semble contenir des chemins vers ces pièces jointes. Mais certaines valeurs sont erronées.')) {
+  if (attachmentsPaths && attachmentsPaths.length && matchesMostAttachments(values, attachmentsPaths)) {
     return { type: 'string', 'x-refersTo': 'http://schema.org/DigitalDocument' }
   }
   if (checkAll(values, val => booleanRegexp.test(val))) return { type: 'boolean' }

--- a/api/src/workers/files-processor/analyze-csv.ts
+++ b/api/src/workers/files-processor/analyze-csv.ts
@@ -74,11 +74,17 @@ export default async function (dataset: FileDataset) {
       }
     }
   }
-  if (attachments.length && !dataset.file.schema.find(f => f['x-refersTo'] === 'http://schema.org/DigitalDocument')) {
-    // non-blocking: keep the attachments and let the user designate the column manually
+  // the concept counts whether auto-detected on this analysis (file.schema) or manually
+  // designated on a previous cycle (schema, kept across re-analysis) — otherwise the
+  // warning would re-appear on every re-upload of an already-designated dataset.
+  const hasDocumentConcept = dataset.file.schema.some(f => f['x-refersTo'] === 'http://schema.org/DigitalDocument') ||
+    !!dataset.schema?.some(f => f['x-refersTo'] === 'http://schema.org/DigitalDocument')
+  if (attachments.length && !hasDocumentConcept) {
+    // non-blocking: attachments are dropped at finalize; the message tells the user to
+    // designate the column before re-uploading (re-uploading first would just drop them again).
     await journals.log('datasets', dataset, {
       type: 'error',
-      data: `Des pièces jointes ont été chargées mais aucune colonne n'a pu être associée automatiquement aux fichiers. Vous pouvez désigner la colonne contenant les chemins vers les pièces jointes en y attribuant le concept « Document Numérique Attaché ». Exemples de fichiers attendus : ${attachments.slice(0, 3).join(', ')}.`
+      data: `Des pièces jointes ont été chargées mais aucune colonne n'a pu être associée automatiquement aux fichiers ; elles n'ont donc pas été conservées. Attribuez le concept « Document Numérique Attaché » à la colonne contenant les chemins vers les pièces jointes, puis rechargez les pièces jointes. Exemples de fichiers attendus : ${attachments.slice(0, 3).join(', ')}.`
     } as Event)
   }
   const emptyCols = dataset.file.schema.filter(p => p.type === 'empty')

--- a/api/src/workers/files-processor/analyze-csv.ts
+++ b/api/src/workers/files-processor/analyze-csv.ts
@@ -19,7 +19,7 @@ export default async function (dataset: FileDataset) {
 
   debug('extract file sample')
   const fileSample = await filesStorage.fileSample(datasetUtils.filePath(dataset))
-  if (!fileSample) throw httpError(400, '[noretry] Échec d\'échantillonage du fichier tabulaire, il est vide')
+  if (!fileSample) throw httpError(400, '[noretry] Échec d\'échantillonnage du fichier tabulaire, il est vide')
   let decodedSample
   try {
     decodedSample = (dataset.file.encoding === 'UTF-8' || !dataset.file.encoding)
@@ -75,7 +75,11 @@ export default async function (dataset: FileDataset) {
     }
   }
   if (attachments.length && !dataset.file.schema.find(f => f['x-refersTo'] === 'http://schema.org/DigitalDocument')) {
-    throw httpError(400, `[noretry] Vous avez chargé des pièces jointes, mais aucune colonne ne contient les chemins vers ces pièces jointes. Valeurs attendues : ${attachments.slice(0, 3).join(', ')}.`)
+    // non-blocking: keep the attachments and let the user designate the column manually
+    await journals.log('datasets', dataset, {
+      type: 'error',
+      data: `Des pièces jointes ont été chargées mais aucune colonne n'a pu être associée automatiquement aux fichiers. Vous pouvez désigner la colonne contenant les chemins vers les pièces jointes en y attribuant le concept « Document Numérique Attaché ». Exemples de fichiers attendus : ${attachments.slice(0, 3).join(', ')}.`
+    } as Event)
   }
   const emptyCols = dataset.file.schema.filter(p => p.type === 'empty')
   if (emptyCols.length) {

--- a/tests/features/datasets/upload/attachments.api.spec.ts
+++ b/tests/features/datasets/upload/attachments.api.spec.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import fs from 'fs-extra'
 import FormData from 'form-data'
 import { axiosAuth, clean, checkPendingTasks } from '../../../support/axios.ts'
-import { waitForFinalize } from '../../../support/workers.ts'
+import { waitForFinalize, lsAttachments } from '../../../support/workers.ts'
 
 const testUser1 = await axiosAuth('test_user1@test.com')
 const testUser3 = await axiosAuth('test_user3@test.com')
@@ -148,6 +148,41 @@ test.describe('Attachments', () => {
     assert.ok(errorEvent.data.includes('aucune colonne n\'a pu être associée automatiquement'))
     assert.ok(errorEvent.data.includes('Document Numérique Attaché'))
     assert.ok(errorEvent.data.includes('test.odt'))
+    // the warning must guide recovery: designate the column, then reload the attachments
+    assert.ok(errorEvent.data.includes('rechargez les pièces jointes'))
+    // unmatched attachments are not kept (they are dropped at finalize)
+    const attachments = await lsAttachments(dataset.id)
+    assert.equal(attachments.length, 0)
+  })
+
+  test('Do not warn again once the attachment column is designated manually', async () => {
+    const ax = testUser3
+    const warnCount = (journal: any[]) => journal.filter((e: any) => e.type === 'error' && typeof e.data === 'string' && e.data.includes('aucune colonne n\'a pu être associée')).length
+
+    const form = new FormData()
+    form.append('dataset', fs.readFileSync('./tests/resources/datasets/attachments-no-paths.csv'), 'attachments-no-paths.csv')
+    form.append('attachments', fs.readFileSync('./tests/resources/datasets/files.zip'), 'files.zip')
+    let dataset = (await ax.post('/api/v1/datasets', form, { headers: { 'Content-Length': form.getLengthSync(), ...form.getHeaders() } })).data
+    dataset = await waitForFinalize(ax, dataset.id)
+    // auto-detection failed: exactly one warning was emitted
+    assert.equal(warnCount((await ax.get(`/api/v1/datasets/${dataset.id}/journal`)).data), 1)
+
+    // recovery step 1: designate the attachment-path column manually
+    const schema = dataset.schema.map((f: any) => f.key === 'comment' ? { ...f, 'x-refersTo': 'http://schema.org/DigitalDocument' } : f)
+    await ax.patch(`/api/v1/datasets/${dataset.id}`, { schema })
+    dataset = await waitForFinalize(ax, dataset.id)
+
+    // recovery step 2: reload the attachments now that the concept is present
+    const form2 = new FormData()
+    form2.append('dataset', fs.readFileSync('./tests/resources/datasets/attachments-no-paths.csv'), 'attachments-no-paths.csv')
+    form2.append('attachments', fs.readFileSync('./tests/resources/datasets/files.zip'), 'files.zip')
+    await ax.put(`/api/v1/datasets/${dataset.id}`, form2, { headers: { 'Content-Length': form2.getLengthSync(), ...form2.getHeaders() } })
+    dataset = await waitForFinalize(ax, dataset.id)
+
+    // the concept is already present, so no new warning must be emitted...
+    assert.equal(warnCount((await ax.get(`/api/v1/datasets/${dataset.id}/journal`)).data), 1)
+    // ...and this time the reloaded attachments are kept
+    assert.ok((await lsAttachments(dataset.id)).length > 0)
   })
 
   // sendMetadataAttachment helper

--- a/tests/features/datasets/upload/attachments.api.spec.ts
+++ b/tests/features/datasets/upload/attachments.api.spec.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import fs from 'fs-extra'
 import FormData from 'form-data'
 import { axiosAuth, clean, checkPendingTasks } from '../../../support/axios.ts'
-import { waitForFinalize, waitForDatasetError } from '../../../support/workers.ts'
+import { waitForFinalize } from '../../../support/workers.ts'
 
 const testUser1 = await axiosAuth('test_user1@test.com')
 const testUser3 = await axiosAuth('test_user3@test.com')
@@ -104,13 +104,9 @@ test.describe('Attachments', () => {
     const form2 = new FormData()
     form2.append('attachments', fs.readFileSync('./tests/resources/datasets/files2.zip'), 'files2.zip')
     await ax.put(`/api/v1/datasets/${dataset.id}`, form2, { headers: { 'Content-Length': form2.getLengthSync(), ...form2.getHeaders() } })
-    await assert.rejects(
-      waitForFinalize(ax, dataset.id),
-      (err: any) => {
-        assert.ok(err.message.includes('Valeurs invalides : dir1/test.pdf'))
-        return true
-      }
-    )
+    // a now-missing attachment (dir1/test.pdf is absent from files2.zip) is no longer blocking
+    dataset = await waitForFinalize(ax, dataset.id)
+    assert.equal(dataset.status, 'finalized')
     const form3 = new FormData()
     form3.append('dataset', fs.readFileSync('./tests/resources/datasets/attachments2.csv'), 'attachments2.csv')
     await ax.put('/api/v1/datasets/' + dataset.id, form3, { headers: { 'Content-Length': form3.getLengthSync(), ...form3.getHeaders() } })
@@ -121,38 +117,37 @@ test.describe('Attachments', () => {
     assert.equal(lines.results[0]['_file.content'], 'This is another test libreoffice file.')
   })
 
-  test('Detect wrong attachment path', async () => {
+  test('Keep processing when some attachment paths are wrong', async () => {
     const ax = testUser3
     const form = new FormData()
     form.append('dataset', fs.readFileSync('./tests/resources/datasets/attachments-wrong-paths.csv'), 'attachments-wrong-paths.csv')
     form.append('attachments', fs.readFileSync('./tests/resources/datasets/files.zip'), 'files.zip')
     const res = await ax.post('/api/v1/datasets', form, { headers: { 'Content-Length': form.getLengthSync(), ...form.getHeaders() } })
-    const dataset = res.data
     assert.equal(res.status, 201)
-    const errorDataset = await waitForDatasetError(ax, dataset.id)
-    assert.equal(errorDataset.status, 'error')
-    const journal = (await ax.get(`/api/v1/datasets/${dataset.id}/journal`)).data
-    const errorEvent = journal.find((e: any) => e.type === 'error')
-    assert.ok(errorEvent.data.includes('une colonne semble contenir des chemins'))
-    assert.ok(errorEvent.data.includes('Valeurs invalides : BADFILE.txt'))
+    // a majority of values match attachments (only BADFILE.txt is wrong), so the
+    // column is still detected and the dataset is processed normally
+    const dataset = await waitForFinalize(ax, res.data.id)
+    assert.equal(dataset.status, 'finalized')
+    assert.ok(dataset.schema.find((f: any) => f['x-refersTo'] === 'http://schema.org/DigitalDocument'))
+    const lines = (await ax.get(`/api/v1/datasets/${dataset.id}/lines`)).data
+    assert.equal(lines.total, 4)
   })
 
-  test('Detect missing attachment paths', async () => {
+  test('Warn without blocking when no column matches the attachments', async () => {
     const ax = testUser3
     const form = new FormData()
     form.append('dataset', fs.readFileSync('./tests/resources/datasets/attachments-no-paths.csv'), 'attachments-no-paths.csv')
     form.append('attachments', fs.readFileSync('./tests/resources/datasets/files.zip'), 'files.zip')
     const res = await ax.post('/api/v1/datasets', form, { headers: { 'Content-Length': form.getLengthSync(), ...form.getHeaders() } })
-    const dataset = res.data
     assert.equal(res.status, 201)
-    const errorDataset = await waitForDatasetError(ax, dataset.id)
-    assert.equal(errorDataset.status, 'error')
+    // no column can be associated with the attachments, but the dataset is still processed
+    const dataset = await waitForFinalize(ax, res.data.id)
+    assert.equal(dataset.status, 'finalized')
     const journal = (await ax.get(`/api/v1/datasets/${dataset.id}/journal`)).data
     const errorEvent = journal.find((e: any) => e.type === 'error')
-    assert.ok(errorEvent.data.includes('aucune colonne ne contient les chemins'))
-    assert.ok(errorEvent.data.includes('Valeurs attendues :'))
+    assert.ok(errorEvent.data.includes('aucune colonne n\'a pu être associée automatiquement'))
+    assert.ok(errorEvent.data.includes('Document Numérique Attaché'))
     assert.ok(errorEvent.data.includes('test.odt'))
-    assert.ok(errorEvent.data.includes('dir1/test.pdf'))
   })
 
   // sendMetadataAttachment helper

--- a/tests/features/datasets/upload/datasets-drafts-advanced.api.spec.ts
+++ b/tests/features/datasets/upload/datasets-drafts-advanced.api.spec.ts
@@ -67,10 +67,10 @@ test.describe('datasets in draft mode - advanced', () => {
     const form2 = new FormData()
     form2.append('attachments', fs.readFileSync('./tests/resources/datasets/files2.zip'), 'files2.zip')
     await ax.put(`/api/v1/datasets/${dataset.id}`, form2, { headers: { 'Content-Length': form2.getLengthSync(), ...form2.getHeaders() }, params: { draft: true } })
-    dataset = await waitForDatasetError(ax, dataset.id, { draft: true })
-    assert.equal(dataset.status, 'error')
-    assert.equal(dataset.errorStatus, 'stored')
-    assert.ok(!dataset.errorRetry)
+    // a now-missing attachment (dir1/test.pdf is absent from files2.zip) is no longer blocking
+    await waitForFinalize(ax, dataset.id)
+    dataset = await getRawDataset(dataset.id)
+    assert.equal(dataset.draft.status, 'finalized')
 
     // then update the data
     const form3 = new FormData()

--- a/tests/support/workers.ts
+++ b/tests/support/workers.ts
@@ -37,7 +37,7 @@ export const waitForFinalize = async (
   } catch (err: any) {
     // ignore some non-blocking errors
     // TODO: these should have a different type, like "warning"
-    if (err.message.includes('le fichier contient une ou plusieurs colonnes') || err.message.includes('% des lignes')) {
+    if (err.message.includes('le fichier contient une ou plusieurs colonnes') || err.message.includes('% des lignes') || err.message.includes('aucune colonne n\'a pu être associée')) {
       return await waitForFinalize(ax, datasetId)
     } else {
       throw err


### PR DESCRIPTION
Make detection of the attachment-path column non-blocking when uploading a file dataset together with an attachments archive.

Previously the column was detected with an all-or-nothing rule: a single sample value not pointing to an uploaded file would throw and leave the dataset in error.

**What changed:**
- `sniff` now tags the column as `DigitalDocument` as soon as a **majority** of non-empty sample values point to an uploaded attachment (`matchesMostAttachments`), instead of requiring every value to match.
- Removed the now-unused `throwIfAlmost` / `invalidValues` machinery from `checkAll`, simplified to a plain `every`.
- When attachments are uploaded but no column can be matched, the analyzer logs a non-blocking journal warning instead of throwing. The dataset is processed normally; the unmatched attachments are dropped at finalize (unchanged prior behavior), and the warning guides the user through recovery: designate the column manually via the « Document Numérique Attaché » concept, then re-upload the attachments.
- The "no match" check now also looks at `dataset.schema` (which survives re-analysis), not just the freshly analyzed `dataset.file.schema`, so once the column has been designated manually the warning does not reappear on every later re-upload.
- Adjusted the related API specs and the test worker helper; fixed an « échantillonnage » typo along the way.

**Why:** uploading a dataset with an attachments archive failed entirely on a single mismatched cell, leaving the dataset in error with no easy recovery. Detection is now tolerant, and the no-match case is recoverable instead of terminal.

**Heads-up:** an upload that used to error out now succeeds with a journal warning when no column matches — a behavior change for callers relying on the previous hard failure. The attachments themselves are still dropped in that case, same as before; only the failure mode changes, from blocking error to recoverable warning.
