### PR TITLE
feat(ws): authorize dataset realtime channels with application keys

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -287,6 +287,7 @@ export const run = async () => {
 
     const permissions = await import('./misc/utils/permissions.ts')
     const { readApiKey } = await import('./misc/utils/api-key.ts')
+    const { resolveApplicationKeyBypass } = await import('./misc/utils/application-key.ts')
     await Promise.all([
       (await import('./misc/utils/cache.ts')).init(),
       (await import('./remote-services/service.ts')).init(),
@@ -300,7 +301,18 @@ export const run = async () => {
         const resource = await db.collection(type).findOne({ id })
         if (!resource) throw httpError(404, `Ressource ${type}/${id} inconnue.`)
         if (message.apiKey) sessionState = await readApiKey(message.apiKey, type, message.account)
-        return permissions.can(type, resource, `realtime-${subject}`, sessionState)
+        // browsers send no Referer on a websocket handshake, so the HTTP application-key path
+        // cannot apply here; resolve the same bypass from the key passed in the subscribe message
+        let bypassPermissions
+        if (type === 'datasets' && message.applicationKey) {
+          // re-read through the typed collection (db.collection(type) above yields an untyped doc)
+          const dataset = await mongo.datasets.findOne({ id })
+          if (dataset) {
+            const match = await resolveApplicationKeyBypass(message.applicationKey, dataset, message.appId)
+            bypassPermissions = match?.bypassPermissions
+          }
+        }
+        return permissions.can(type, resource, `realtime-${subject}`, sessionState, bypassPermissions)
       })
     ])
     // At this stage the server is ready to respond to API requests

--- a/api/src/misc/utils/application-key.ts
+++ b/api/src/misc/utils/application-key.ts
@@ -6,7 +6,7 @@ import memoize from 'memoizee'
 import clone from '@data-fair/lib-utils/clone.js'
 import * as rateLimiting from './rate-limiting.ts'
 import { type Request, type Response, type NextFunction } from 'express'
-import { type ApplicationKey } from '#types'
+import { type ApplicationKey, type Resource, type BypassPermissions } from '#types'
 import { reqUser, setReqUser, session } from '@data-fair/lib-express/session.js'
 import { reqResource, setReqBypassPermissions } from './req-context.ts'
 import { reqPublicBaseUrl } from './public-base-url.ts'
@@ -70,6 +70,59 @@ const matchingHost = (req: Request) => {
   return new URL(reqPublicBaseUrl(req)).origin === req.headers.origin
 }
 
+// pure application-key matching core (no req dependency) shared by the HTTP middleware below and
+// the websocket canSubscribe handler (api/src/app.js): resolves a key + calling application against
+// a dataset and returns the permission bypass it grants (or null). `appId` is the calling
+// application (referer over HTTP, message.appId over websocket); leave it undefined for the embed
+// page context, where the key's own application must reference the dataset.
+export const resolveApplicationKeyBypass = async (applicationKeyId: string, dataset: Resource, appId?: string): Promise<{ applicationKey: ApplicationKey, bypassPermissions: BypassPermissions } | null> => {
+  const ownerType = dataset.owner.type
+  const ownerId = dataset.owner.id
+  const ownerDep = dataset.owner.department || ''
+  const datasetHref = `${config.publicUrl}/api/v1/datasets/${dataset.id}`
+
+  const applicationKey = await findApplicationKey(applicationKeyId, ownerType, ownerId, ownerDep)
+  if (!applicationKey) return null
+
+  let resolvedAppId = appId
+  if (resolvedAppId === undefined) {
+    // dataset embed page context: the key's own application must reference the dataset
+    resolvedAppId = applicationKey._id
+    if (!await countParentApplicationOfDataset(applicationKey._id, datasetHref, dataset.id, ownerType, ownerId, ownerDep)) return null
+  } else if (applicationKey._id !== resolvedAppId) {
+    // the application key can be matched to a parent application key (case of dashboards, etc)
+    if (!await countParentApplicationOfApp(applicationKey._id, resolvedAppId, ownerType, ownerId, ownerDep)) return null
+  }
+
+  const cachedMatchingApplication = await findMatchingApplication(resolvedAppId, datasetHref, dataset.id, ownerType, ownerId, ownerDep)
+  // cloned: the datasetsFilters defaults below mutate the doc, the cached copy must stay pristine
+  const matchingApplication = cachedMatchingApplication && clone(cachedMatchingApplication)
+  debug('matchingApplication', matchingApplication)
+  if (!matchingApplication) return null
+
+  // apply some permissions based on app configuration
+  // some dataset might need to be readable, some other writable only for createLine, etc
+  const datasetIndex = matchingApplication.configuration?.datasets?.findIndex(d => d && (d.href === datasetHref || d.id === dataset.id))
+  if (datasetIndex === undefined || datasetIndex === -1) {
+    debug('dataset is not referenced in app configuration')
+    return null
+  }
+  const matchingApplicationDataset = matchingApplication.configuration?.datasets?.[datasetIndex]
+  if (!matchingApplicationDataset) return null
+  debug('matchingApplicationDataset', matchingApplicationDataset)
+  const datasetFilters = matchingApplication.baseApp?.datasetsFilters?.[datasetIndex]
+  debug('matching baseApp.datasetFilters', datasetFilters)
+  if (datasetFilters?.properties) {
+    for (const key of Object.keys(datasetFilters.properties)) {
+      if (datasetFilters.properties[key].default && !(key in dataset)) matchingApplicationDataset[key] = datasetFilters.properties[key].default
+      if (datasetFilters.properties[key].const) matchingApplicationDataset[key] = datasetFilters.properties[key].const
+    }
+  }
+
+  const bypassPermissions = matchingApplicationDataset.applicationKeyPermissions || { classes: ['read'] }
+  return { applicationKey, bypassPermissions }
+}
+
 export default async (req: Request, res: Response, next: NextFunction) => {
   const referer = (req.headers.referer || req.headers.referrer) as string | undefined
   if (!referer) return next()
@@ -85,17 +138,14 @@ export default async (req: Request, res: Response, next: NextFunction) => {
 
   const dataset = reqResource(req)
 
-  const ownerType = dataset.owner.type
-  const ownerId = dataset.owner.id
-  const ownerDep = dataset.owner.department || ''
-  const datasetHref = `${config.publicUrl}/api/v1/datasets/${dataset.id}`
+  let applicationKeyId: string | null = null
+  // undefined keeps the dataset embed page context; a string marks an application as the caller
   let appId: string | undefined
-  let applicationKey: ApplicationKey | null = null
 
   if (refererUrl.pathname.startsWith('/data-fair/embed/dataset/')) {
     debug('referer is an embed page')
     let refererDatasetId = decodeURIComponent(refererUrl.pathname.replace('/data-fair/embed/dataset/', '').split('/')[0])
-    let applicationKeyId = refererUrl.searchParams && refererUrl.searchParams.get('key')
+    applicationKeyId = refererUrl.searchParams && refererUrl.searchParams.get('key')
     if (refererDatasetId !== dataset.id) {
       const keys = refererDatasetId.split(':')
       if (keys.length > 1) {
@@ -103,18 +153,10 @@ export default async (req: Request, res: Response, next: NextFunction) => {
         refererDatasetId = refererDatasetId.replace(keys[0] + ':', '')
       }
     }
-    if (!applicationKeyId) return next()
-    applicationKey = await findApplicationKey(applicationKeyId, ownerType, ownerId, ownerDep)
-    if (!applicationKey) return next()
-    appId = applicationKey._id
-    const isParentApplicationKey = await countParentApplicationOfDataset(applicationKey._id, datasetHref, dataset.id, ownerType, ownerId, ownerDep)
-    if (!isParentApplicationKey) return next()
-  }
-
-  if (refererUrl.pathname.startsWith('/data-fair/app/')) {
+  } else if (refererUrl.pathname.startsWith('/data-fair/app/')) {
     debug('referer is an app')
     appId = decodeURIComponent(refererUrl.pathname.replace('/data-fair/app/', '').split('/')[0])
-    let applicationKeyId = refererUrl.searchParams && refererUrl.searchParams.get('key')
+    applicationKeyId = refererUrl.searchParams && refererUrl.searchParams.get('key')
     debug('applicationKeyId from referer searchParams', applicationKeyId)
     if (!applicationKeyId) {
       const keys = appId.split(':')
@@ -124,87 +166,57 @@ export default async (req: Request, res: Response, next: NextFunction) => {
         appId = appId.replace(keys[0] + ':', '')
       }
     }
-    if (!applicationKeyId) return next()
-    applicationKey = await findApplicationKey(applicationKeyId, ownerType, ownerId, ownerDep)
-    debug('found applicationKey', applicationKey, appId)
-    if (!applicationKey) return next()
-    if (applicationKey._id !== appId) {
-      // the application key can be matched to a parent application key (case of dashboards, etc)
-      const isParentApplicationKey = await countParentApplicationOfApp(applicationKey._id, appId, ownerType, ownerId, ownerDep)
-      debug('found isParentApplicationKey', isParentApplicationKey)
-      if (!isParentApplicationKey) return next()
+  } else {
+    return next()
+  }
+
+  if (!applicationKeyId) return next()
+
+  const match = await resolveApplicationKeyBypass(applicationKeyId, dataset, appId)
+  if (!match) return next()
+  const { applicationKey, bypassPermissions } = match
+
+  // this is basically the "crowd-sourcing" use case
+  // we apply some anti-spam protection
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    debug('protect anonymous write operation with multiple security tools')
+    // 1rst level of anti-spam prevention, no cross origin requests on this route
+    if (!matchingHost(req)) {
+      return res.status(405).send(req.__('errors.noCrossDomain'))
+    }
+
+    // 2nd level of anti-spam protection, validate that the user was present on the page for a few seconds before sending
+    const anonymousToken = req.get('x-anonymousToken')
+    let tokenContent
+    if (!anonymousToken) return res.status(401).type('text/plain').send(req.__('errors.requireAnonymousToken'))
+    try {
+      tokenContent = await session.verifyToken(anonymousToken)
+    } catch (err: any) {
+      if (err.name === 'NotBeforeError') {
+        return res.status(429).type('text/plain').send(req.__('errors.looksLikeSpam'))
+      } else {
+        return res.status(401).type('text/plain').send('Invalid token')
+      }
+    }
+    if (!tokenContent.anonymousAction) return res.status(401).type('text/plain').send('Invalid token')
+
+    // 3rd level of anti-spam protection, simple rate limiting based on ip
+    if (!rateLimiting.consume(req, 'postApplicationKey', tokenContent.id ?? tokenContent.iat)) {
+      console.warn('Rate limit error for application key', requestIp.getClientIp(req), req.originalUrl)
+      return res.status(429).type('text/plain').send(req.__('errors.exceedAnonymousRateLimiting'))
     }
   }
 
-  if (applicationKey && appId) {
-    const cachedMatchingApplication = await findMatchingApplication(appId, datasetHref, dataset.id, ownerType, ownerId, ownerDep)
-    // cloned: the datasetsFilters defaults below mutate the doc, the cached copy must stay pristine
-    const matchingApplication = cachedMatchingApplication && clone(cachedMatchingApplication)
-    debug('matchingApplication', matchingApplication)
-    if (matchingApplication) {
-      // this is basically the "crowd-sourcing" use case
-      // we apply some anti-spam protection
-      if (req.method !== 'GET' && req.method !== 'HEAD') {
-        debug('protect anonymous write operation with multiple security tools')
-        // 1rst level of anti-spam prevention, no cross origin requests on this route
-        if (!matchingHost(req)) {
-          return res.status(405).send(req.__('errors.noCrossDomain'))
-        }
-
-        // 2nd level of anti-spam protection, validate that the user was present on the page for a few seconds before sending
-        const anonymousToken = req.get('x-anonymousToken')
-        let tokenContent
-        if (!anonymousToken) return res.status(401).type('text/plain').send(req.__('errors.requireAnonymousToken'))
-        try {
-          tokenContent = await session.verifyToken(anonymousToken)
-        } catch (err: any) {
-          if (err.name === 'NotBeforeError') {
-            return res.status(429).type('text/plain').send(req.__('errors.looksLikeSpam'))
-          } else {
-            return res.status(401).type('text/plain').send('Invalid token')
-          }
-        }
-        if (!tokenContent.anonymousAction) return res.status(401).type('text/plain').send('Invalid token')
-
-        // 3rd level of anti-spam protection, simple rate limiting based on ip
-        if (!rateLimiting.consume(req, 'postApplicationKey', tokenContent.id ?? tokenContent.iat)) {
-          console.warn('Rate limit error for application key', requestIp.getClientIp(req), req.originalUrl)
-          return res.status(429).type('text/plain').send(req.__('errors.exceedAnonymousRateLimiting'))
-        }
-      }
-
-      // apply some permissions based on app configuration
-      // some dataset might need to be readable, some other writable only for createLine, etc
-      const datasetIndex = matchingApplication.configuration?.datasets?.findIndex(d => d && (d.href === datasetHref || d.id === dataset.id))
-      if (datasetIndex === undefined || datasetIndex === -1) {
-        debug('dataset is not referenced in app configuration')
-        return next()
-      }
-      const matchingApplicationDataset = matchingApplication.configuration?.datasets?.[datasetIndex]
-      if (!matchingApplicationDataset) return next()
-      debug('matchingApplicationDataset', matchingApplicationDataset)
-      const datasetFilters = matchingApplication.baseApp?.datasetsFilters?.[datasetIndex]
-      debug('matching baseApp.datasetFilters', datasetFilters)
-      if (datasetFilters?.properties) {
-        for (const key of Object.keys(datasetFilters.properties)) {
-          if (datasetFilters.properties[key].default && !(key in dataset)) matchingApplicationDataset[key] = datasetFilters.properties[key].default
-          if (datasetFilters.properties[key].const) matchingApplicationDataset[key] = datasetFilters.properties[key].const
-        }
-      }
-
-      const bypassPermissions = matchingApplicationDataset.applicationKeyPermissions || { classes: ['read'] }
-      setReqBypassPermissions(req, bypassPermissions)
-      debug('apply bypass permissions', bypassPermissions)
-      if (!reqUser(req)) {
-        debug('set pseudo user')
-        setReqUser(
-          req,
-          { id: applicationKey.id, name: applicationKey.title, email: '', organizations: [] },
-          undefined, undefined, undefined,
-          { isApplicationKey: true }
-        )
-      }
-    }
+  setReqBypassPermissions(req, bypassPermissions)
+  debug('apply bypass permissions', bypassPermissions)
+  if (!reqUser(req)) {
+    debug('set pseudo user')
+    setReqUser(
+      req,
+      { id: applicationKey.id, name: applicationKey.title, email: '', organizations: [] },
+      undefined, undefined, undefined,
+      { isApplicationKey: true }
+    )
   }
   next()
 }

--- a/tests/features/auth/api-keys.api.spec.ts
+++ b/tests/features/auth/api-keys.api.spec.ts
@@ -364,6 +364,40 @@ test.describe('API keys', () => {
     assert.equal(res.status, 200)
   })
 
+  // realtime-* operations gate websocket subscriptions (see canSubscribe in api/src/app.js) and
+  // live in the readAdvanced class, so a default key (classes: ['read']) must NOT grant them: an
+  // application has to opt in through applicationKeyPermissions to follow a dataset live
+  test('Grant realtime permissions through an application key only when configured', async () => {
+    const ax = testUser1
+
+    // a default key does not grant the realtime-* operations
+    const datasetDefault = await sendDataset('datasets/dataset1.csv', ax)
+    const appDefault = (await ax.post('/api/v1/applications', { url: mockAppUrl('monapp1') })).data.id
+    await ax.put('/api/v1/applications/' + appDefault + '/config', {
+      datasets: [{ href: `${config.publicUrl}/api/v1/datasets/${datasetDefault.id}` }]
+    })
+    const keyDefault = (await ax.post(`/api/v1/applications/${appDefault}/keys`, [{ title: 'Access key' }])).data[0].id
+    let res = await anonymous.get(`/api/v1/datasets/${datasetDefault.id}`, { headers: { referrer: config.publicUrl + `/app/${appDefault}/?key=${keyDefault}` } })
+    assert.equal(res.status, 200)
+    assert.ok(res.data.userPermissions.includes('readLines'))
+    assert.ok(!res.data.userPermissions.includes('realtime-journal'))
+    assert.ok(!res.data.userPermissions.includes('realtime-task-progress'))
+
+    // opting in through applicationKeyPermissions makes the realtime channels subscribable
+    const datasetRealtime = await sendDataset('datasets/dataset1.csv', ax)
+    const appRealtime = (await ax.post('/api/v1/applications', { url: mockAppUrl('monapp1') })).data.id
+    await ax.put('/api/v1/applications/' + appRealtime + '/config', {
+      datasets: [{
+        href: `${config.publicUrl}/api/v1/datasets/${datasetRealtime.id}`,
+        applicationKeyPermissions: { operations: ['readDescription', 'realtime-journal', 'realtime-task-progress'] }
+      }]
+    })
+    const keyRealtime = (await ax.post(`/api/v1/applications/${appRealtime}/keys`, [{ title: 'Access key' }])).data[0].id
+    res = await anonymous.get(`/api/v1/datasets/${datasetRealtime.id}`, { headers: { referrer: config.publicUrl + `/app/${appRealtime}/?key=${keyRealtime}` } })
+    assert.equal(res.status, 200)
+    assert.deepEqual([...res.data.userPermissions].sort(), ['readDescription', 'realtime-journal', 'realtime-task-progress'].sort())
+  })
+
   test('Use an application key to access child applications and previews (used for dashboards)', async () => {
     const ax = testUser1
     const dataset = await sendDataset('datasets/dataset1.csv', ax)


### PR DESCRIPTION
An unauthenticated client — typically a visualization opened through a protected-link application key — could read a dataset over HTTP but could not subscribe to its realtime websocket channels (`datasets/:id/journal`, `datasets/:id/task-progress`). The `canSubscribe` handler only knew session and api-key auth, and the application-key path was HTTP/`Referer`-only middleware — and browsers send no `Referer` on a websocket handshake.

**What changed:**
- Extract the application-key matching out of the HTTP middleware into a pure `resolveApplicationKeyBypass(applicationKeyId, dataset, appId?)` core in `application-key.ts` — mongodb lookups only, no `req` dependency. `appId` set ⇒ the calling-application branch (dashboards via `countParentApplicationOfApp`); `appId` undefined ⇒ the dataset embed-page branch. The HTTP middleware now parses the `Referer` then delegates to this core, behaviour unchanged.
- `canSubscribe` (`app.js`) resolves the bypass from `message.applicationKey`/`appId` and passes it to `permissions.can(..., bypass)` for the `datasets/:id/{journal,task-progress}` channels.
- Test: a default key (`classes: ['read']`) does not grant the realtime operations; an application opts in by listing them in its dataset `applicationKeyPermissions.operations`.

**Why:** a protected-link visualization needs to follow its dataset live (processing progress, journal events) for an unconnected user. The key cannot ride the `Referer` over a websocket, so it travels in the subscribe message instead.

**Heads-up:**
- Realtime stays opt-in: `realtime-journal`/`realtime-task-progress` are in the `readAdvanced` class, so a default application key does not grant them — by design.
- Server-only change; it needs no `@data-fair/lib-vue` bump. The browser side that sends `message.applicationKey` (base-app, and optionally the data-fair embed page) lands separately, once `@data-fair/lib-vue` ships `subscribe(channel, cb, params)` (data-fair/lib#43).
- The live websocket handshake is not covered e2e here: the dev server runs with `NODE_ENV=development`, where `canSubscribe` short-circuits to `true` (pre-existing TODO). The permission half is covered over HTTP via `userPermissions`.
