### PR TITLE
fix(shutdown): drain delay before graceful stop to avoid 502s on rollout

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,3 +1,4 @@
+import { setTimeout as delay } from 'node:timers/promises'
 import config from '#config'
 import * as app from './src/app.js'
 import { internalError } from '@data-fair/lib-node/observer.js'
@@ -14,8 +15,12 @@ app.run().then(app => {
   process.exit(-1)
 })
 
-process.on('SIGTERM', function onSigterm () {
-  console.info('Received SIGTERM signal, shutdown gracefully...')
+const shutdownDrainDelay = 5000 // ms
+
+process.on('SIGTERM', async function onSigterm () {
+  const drainDelay = config.mode.includes('server') ? shutdownDrainDelay : 0
+  console.info(`Received SIGTERM signal, draining for ${drainDelay}ms before graceful shutdown...`)
+  await delay(drainDelay)
   app.stop().then(() => {
     console.log('shutting down now')
     process.exit()

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -240,7 +240,8 @@ export const run = async () => {
 
     server = (await import('http')).createServer(app)
     const { createHttpTerminator } = await import('http-terminator')
-    httpTerminator = createHttpTerminator({ server })
+    // wait up for in-flight requests to finish on shutdown before forcibly closing sockets
+    httpTerminator = createHttpTerminator({ server, gracefulTerminationTimeout: 5000 })
     // cf https://connectreport.com/blog/tuning-http-keep-alive-in-node-js/
     // timeout is often 60s on the reverse proxy, better to a have a longer one here
     // so that interruption is managed downstream instead of here


### PR DESCRIPTION
Rolling updates of the `data-fair` server produce brief 502s (a few seconds), most often on
non-idempotent requests (POST/PUT), sometimes on GETs too. Pod removal is eventually consistent:
on termination, the SIGTERM and the removal from Service endpoints race each other, and it takes a
moment for reverse proxies (ingress endpoints, and the 2-layer L2 nginx that resolves the
headless-service DNS with `valid=5s`) to stop routing to the pod. The app already does a graceful
shutdown via `http-terminator`, but it stops accepting new connections **immediately** on SIGTERM —
so during that propagation window the proxy keeps sending requests to a pod whose HTTP server is
already closed → connection refused/reset → 502. The legacy ingress only retries idempotent requests
(`error timeout`), so POSTs surface directly, and `proxy-buffering off` limits GET retries once
streaming has started.

**What changed:**
- `api/index.ts`: on SIGTERM in `server` mode, wait a 5s drain delay before calling `app.stop()`,
  so the proxies drop this pod from their pool first. Worker-only pods sit behind no proxy and stop
  immediately (`drainDelay = 0`).
- `api/src/app.js`: give `http-terminator` a `gracefulTerminationTimeout` of 5s so in-flight
  requests can finish before sockets are forcibly closed.

**Why:** keeping the server up for a short drain window lets the eventually-consistent endpoint
removal propagate to the proxies before the pod actually closes — that is what removes the 502s.
Values are hardcoded on purpose (no new config keys).

**Heads-up:**
- Shutdown budget: ~5s drain + ≤5s terminator + mongo/es close ≈ 12s, well under the default 30s
  `terminationGracePeriodSeconds`, so no SIGKILL and no infra change required.
- 5s is comfortable for the current ingress; for the 2-layer L2 path (`resolve valid=5s`) it is
  borderline — bump to ~7-8s if rare 502s remain there.
- Verified statically only: ESLint clean on both files, type ratchet 532/532. The runtime drain on
  SIGTERM is not exercised here (needs the full stack). To test locally: `npm run dev-api`, then
  `pkill -TERM -f 'api/index'`, and confirm the logs show `draining for 5000ms...` followed ~5s
  later by `shutting down now`, while a curl loop against `/data-fair/api/v1/datasets` keeps
  returning 200 during the drain.
