### PR TITLE
fix(datasets): avoid bulk-edit crash with an attachment column

### DIFF
--- a/ui/src/components/dataset/form/dataset-edit-multiple-lines.vue
+++ b/ui/src/components/dataset/form/dataset-edit-multiple-lines.vue
@@ -116,9 +116,12 @@ const editSchema = computed(() => {
       }
     }
     if (schema.properties[key]['x-refersTo'] === 'http://schema.org/DigitalDocument' && schema.properties[key].layout?.comp !== 'text-field') {
+      // attachment columns cannot be edited in a bulk patch, drop them from the form and the patch
       delete schema.properties[key]
+      return
     }
     if (schema.properties[key]['x-extension']) {
+      // extension results are computed, they must not be part of a bulk patch
       delete schema.properties[key]
     }
   })


### PR DESCRIPTION
In the "edit multiple lines" dialog, an attachment column (`x-refersTo`
`http://schema.org/DigitalDocument`) was deleted from the schema and the
following condition then read `x-extension` on the now-undefined
property, throwing a `TypeError` that broke the whole dialog.

Add an early `return` after dropping the attachment column so the
extension check no longer dereferences a deleted property.

**Why:** any editable dataset with an attachment column crashed as soon
as rows were selected and "edit multiple" was opened.

**Heads-up:** the `delete` is intentional — attachment and extension
columns must stay out of the bulk patch (vjsf `removeAdditional` strips
them), unlike the single-line form which only hides them with
`comp: 'none'`.
