### PR TITLE
fix(datasets): gate editable table bulk selection on bulkLines permission

### DIFF
--- a/ui/src/components/dataset/table/dataset-table-header-actions.vue
+++ b/ui/src/components/dataset/table/dataset-table-header-actions.vue
@@ -3,7 +3,7 @@
     :elevation="selectedResults.length >= 2 ? 4 : 0"
     density="compact"
   >
-    <template v-if="results.length >= 2">
+    <template v-if="canBulkLines && results.length >= 2">
       <v-btn
         v-if="selectedResults.length"
         :title="t('unselectAllLines')"
@@ -27,7 +27,7 @@
     </template>
     <template v-if="selectedResults.length >=2">
       <v-btn
-        v-if="canDeleteLine"
+        v-if="canBulkLines"
         :size="dense ? 'md' : 'large'"
         color="warning"
         variant="text"
@@ -37,7 +37,7 @@
         @click="deletingResults = [...selectedResults]; deleteSelectedResultsDialog = true;"
       />
       <v-btn
-        v-if="canUpdateLine && selectedResults.length >= 2"
+        v-if="canBulkLines"
         :icon="mdiPencil"
         :size="dense ? 'md' : 'large'"
         variant="text"
@@ -278,8 +278,6 @@ if (!jsonSchemaFetch.initialized.value) jsonSchemaFetch.refresh()
 
 const deleteSelectedResultsDialog = ref(false)
 
-const canDeleteLine = can('deleteLine')
-const canUpdateLine = can('updateLine')
 const canCreateLine = can('createLine')
 const canBulkLines = can('bulkLines')
 

--- a/ui/src/components/dataset/table/dataset-table-header-actions.vue
+++ b/ui/src/components/dataset/table/dataset-table-header-actions.vue
@@ -7,10 +7,10 @@
       <v-btn
         v-if="selectedResults.length"
         :title="t('unselectAllLines')"
-        :color="selectedResults.length === results.length ? 'primary' : 'grey'"
+        color="primary"
         :size="dense ? 'md' : 'large'"
         variant="text"
-        :icon="mdiCheckboxMarked"
+        :icon="selectedResults.length === results.length ? mdiCheckboxMarked : mdiMinusBox"
         :disabled="saving"
         @click="selectedResults = []"
       />
@@ -253,7 +253,7 @@
 import type { VForm } from 'vuetify/components'
 import type { RestActionsSummary } from '#api/types'
 import type { ExtendedResult } from '~/composables/dataset/lines'
-import { mdiCheckboxBlankOutline, mdiCheckboxMarked, mdiPencil, mdiTrashCanOutline, mdiPlusCircle, mdiUpload } from '@mdi/js'
+import { mdiCheckboxBlankOutline, mdiCheckboxMarked, mdiMinusBox, mdiPencil, mdiTrashCanOutline, mdiPlusCircle, mdiUpload } from '@mdi/js'
 import useDatasetEdition from './use-dataset-edition'
 
 defineProps({

--- a/ui/src/components/dataset/table/dataset-table-result-actions.vue
+++ b/ui/src/components/dataset/table/dataset-table-result-actions.vue
@@ -1,24 +1,26 @@
 <template>
   <v-btn-group density="compact">
-    <v-btn
-      v-if="selectedResults.some(r => r._id === result._id)"
-      :title="t('unselectLine')"
-      color="primary"
-      :size="dense ? 'md' : 'large'"
-      variant="text"
-      :icon="mdiCheckboxMarked"
-      :disabled="saving"
-      @click="selectedResults = selectedResults.filter(r => r !== result)"
-    />
-    <v-btn
-      v-else
-      :size="dense ? 'md' : 'large'"
-      variant="text"
-      :title="t('selectLine')"
-      :icon="mdiCheckboxBlankOutline"
-      :disabled="saving"
-      @click="selectedResults.push(result)"
-    />
+    <template v-if="canBulkLines">
+      <v-btn
+        v-if="selectedResults.some(r => r._id === result._id)"
+        :title="t('unselectLine')"
+        color="primary"
+        :size="dense ? 'md' : 'large'"
+        variant="text"
+        :icon="mdiCheckboxMarked"
+        :disabled="saving"
+        @click="selectedResults = selectedResults.filter(r => r !== result)"
+      />
+      <v-btn
+        v-else
+        :size="dense ? 'md' : 'large'"
+        variant="text"
+        :title="t('selectLine')"
+        :icon="mdiCheckboxBlankOutline"
+        :disabled="saving"
+        @click="selectedResults.push(result)"
+      />
+    </template>
     <v-btn
       v-if="canDeleteLine"
       :size="dense ? 'md' : 'large'"
@@ -74,4 +76,5 @@ const { saving } = useDatasetEdition()
 
 const canDeleteLine = can('deleteLine')
 const canUpdateLine = can('updateLine')
+const canBulkLines = can('bulkLines')
 </script>

--- a/ui/src/components/dataset/table/use-headers.ts
+++ b/ui/src/components/dataset/table/use-headers.ts
@@ -69,10 +69,6 @@ export const useHeaders = (
       if (dataset.value?.bbox && !noInteraction) {
         headers.unshift({ title: '', key: '_map_preview' })
       }
-      // the _actions column hosts the selection checkboxes, whose only purpose is to drive
-      // the multi-line bulk operations (_bulk_lines) — so it is gated on the bulkLines permission,
-      // like the file upload dialog. can() returns a ComputedRef, hence the explicit .value:
-      // this is a plain .ts module with no template auto-unwrapping.
       if (selectable || (edit && can('bulkLines').value)) {
         headers.unshift({ title: '', key: '_actions', sticky: true })
       } else if (fixed.value) {

--- a/ui/src/components/dataset/table/use-headers.ts
+++ b/ui/src/components/dataset/table/use-headers.ts
@@ -69,7 +69,11 @@ export const useHeaders = (
       if (dataset.value?.bbox && !noInteraction) {
         headers.unshift({ title: '', key: '_map_preview' })
       }
-      if (selectable || (edit && can('bulkLines').value)) {
+      // the _actions column hosts the per-row edit/delete buttons and the add-line button (single-line
+      // write permissions) as well as the bulk selection checkboxes (bulkLines). Show it as soon as the
+      // user holds any of these permissions; each button inside is then gated on its own permission.
+      const canEditLines = edit && (can('bulkLines').value || can('createLine').value || can('updateLine').value || can('deleteLine').value)
+      if (selectable || canEditLines) {
         headers.unshift({ title: '', key: '_actions', sticky: true })
       } else if (fixed.value) {
         const fixedHeader = headers.find(h => h.key === fixed.value)

--- a/ui/src/components/dataset/table/use-headers.ts
+++ b/ui/src/components/dataset/table/use-headers.ts
@@ -69,7 +69,11 @@ export const useHeaders = (
       if (dataset.value?.bbox && !noInteraction) {
         headers.unshift({ title: '', key: '_map_preview' })
       }
-      if (selectable || (edit && (can('updateLine') || can('deleteLine') || selectable))) {
+      // the _actions column hosts the selection checkboxes, whose only purpose is to drive
+      // the multi-line bulk operations (_bulk_lines) — so it is gated on the bulkLines permission,
+      // like the file upload dialog. can() returns a ComputedRef, hence the explicit .value:
+      // this is a plain .ts module with no template auto-unwrapping.
+      if (selectable || (edit && can('bulkLines').value)) {
         headers.unshift({ title: '', key: '_actions', sticky: true })
       } else if (fixed.value) {
         const fixedHeader = headers.find(h => h.key === fixed.value)


### PR DESCRIPTION
Gate the editable dataset table's bulk-selection UI on the `bulkLines` permission instead of the per-line `updateLine`/`deleteLine` permissions.

**What changed:**
- The per-row and select-all selection checkboxes now appear only when the user holds `bulkLines`, matching the permission the bulk edit/delete operations actually require server-side.
- The bulk edit and bulk delete header buttons are gated on `bulkLines` (previously `updateLine` / `deleteLine`).
- The select-all header button shows an indeterminate icon (and stays primary blue) when the selection is partial rather than complete.
- The `_actions` column is shown as soon as the user holds any relevant permission (`bulkLines`, `createLine`, `updateLine`, or `deleteLine`); each button inside is then gated on its own permission.

**Why:** the selection checkboxes and bulk actions were tied to single-line write permissions, so users could be shown a bulk-select UI they had no permission to actually execute (and vice versa). `bulkLines` is the permission enforced on the `_bulk_lines` API route.

**Heads-up:** this is a permission-visibility change — users who previously saw the bulk-select/edit/delete controls via `updateLine`/`deleteLine` but lack `bulkLines` will no longer see them. Confirm `bulkLines` is granted wherever bulk selection is expected.
