### PR TITLE
fix(rate-limiting): plug PromiseReaction leak in throttled sends

### DIFF
--- a/api/src/misc/utils/rate-limiting.ts
+++ b/api/src/misc/utils/rate-limiting.ts
@@ -1,12 +1,13 @@
 import config from '#config'
-import { Transform } from 'node:stream'
-import { RateLimiter, TokenBucket } from 'limiter' // cf https://github.com/jhurliman/node-rate-limiter/issues/80#issuecomment-1649261071
+import { Transform, PassThrough } from 'node:stream'
+import { RateLimiter } from 'limiter' // cf https://github.com/jhurliman/node-rate-limiter/issues/80#issuecomment-1649261071
 import requestIp from 'request-ip'
 import debug from 'debug'
 import promClient from 'prom-client'
 import { type Request, type Response } from 'express'
 import { reqUser, reqSession, type SessionState } from '@data-fair/lib-express'
 import { ComputeBucket } from './compute-budget.ts'
+import { removeTokensOrAborted, tokenBucketFor, type TokenBucketWrapper } from './throttle-wait.ts'
 import { queryAdvice } from './query-advice.ts'
 import { reqEsAbortContextOptional } from '../../datasets/es/abort.ts'
 
@@ -48,12 +49,6 @@ const computeBudgetExceededCounter = new promClient.Counter({
 })
 
 const tokenBuckets: Record<string, TokenBucketWrapper> = {}
-
-type TokenBucketWrapper = {
-  lastUsed?: number,
-  bucketSize: number,
-  bucket: TokenBucket
-}
 
 // simple cleanup of the limiters every 20 minutes
 setInterval(() => {
@@ -127,38 +122,31 @@ export const debitComputeBudget = (req: Request, limitType: string, ms: number):
 }
 
 const burstFactor = 4
-export const getTokenBucket = (req, limitType, bandwidthType) => {
+// Returns undefined when the tier has no bandwidth limit (0 or absent config) → callers skip throttling.
+export const getTokenBucket = (req, limitType, bandwidthType): TokenBucketWrapper | undefined => {
   const user = rateLimitUser(req)
   const throttlingId = user ? user.id : requestIp.getClientIp(req)
-  const bucketSize = config.defaultLimits.apiRate[limitType].bandwidth[bandwidthType] * burstFactor
+  const key = throttlingId + bandwidthType
   // init lastUsed at creation so the 20-min sweep can detect this entry as idle later — every call
   // to res.throttle() creates a bucket via this path but lastUsed is only set inside the Throttle
   // _transform; a stream that never receives bytes (empty body, immediate error before any chunk)
   // would leave lastUsed=undefined and the sweep would skip it forever.
-  const tokenBucket: TokenBucketWrapper = tokenBuckets[throttlingId + bandwidthType] = tokenBuckets[throttlingId + bandwidthType] || {
-    bucketSize,
-    lastUsed: Date.now(),
-    bucket: new TokenBucket({
-      bucketSize,
-      tokensPerInterval: config.defaultLimits.apiRate[limitType].bandwidth[bandwidthType],
-      interval: 1000
-    })
-  }
+  const tokenBucket = tokenBuckets[key] ?? tokenBucketFor(config.defaultLimits.apiRate[limitType].bandwidth[bandwidthType], burstFactor)
+  if (tokenBucket) tokenBuckets[key] = tokenBucket // only cache real buckets (never undefined — the sweep dereferences entries)
   return tokenBucket
 }
 
 class Throttle extends Transform {
   tokenBucket: TokenBucketWrapper
-  // resolves to `true` once the Throttle is closed (normal end or destroy/abort). Used to race against
-  // `removeTokens`: without this the slice currently waiting for tokens would be retained for up to one
-  // refill window (bucketSize / bandwidth seconds) after the request was aborted, multiplied by every
-  // stalled stream from the same client. Underscore-prefixed to avoid clashing with Readable.closed.
-  private _closedPromise: Promise<true>
+  // aborted once the Throttle is closed (normal end or destroy/abort). removeTokensOrAborted races the
+  // token wait against it so a slice waiting for tokens is dropped promptly when the request is torn down,
+  // rather than retained for up to one refill window (bucketSize / bandwidth seconds) per stalled stream.
+  private _abort = new AbortController()
 
   constructor (tokenBucket: TokenBucketWrapper) {
     super()
     this.tokenBucket = tokenBucket
-    this._closedPromise = new Promise<true>(resolve => this.once('close', () => resolve(true)))
+    this.once('close', () => this._abort.abort())
   }
 
   async transformPromise (chunk: Buffer, encoding: string) {
@@ -167,11 +155,7 @@ class Throttle extends Transform {
     while (chunk.length > pos) {
       if (this.destroyed) return
       const slice = chunk.subarray(pos, pos + this.tokenBucket.bucketSize)
-      const stop = await Promise.race([
-        this.tokenBucket.bucket.removeTokens(slice.length).then(() => false as const),
-        this._closedPromise
-      ])
-      if (stop) return // stream torn down mid-wait — drop the slice, let it be GC'd
+      if (!await removeTokensOrAborted(this.tokenBucket.bucket, slice.length, this._abort.signal)) return
       this.push(slice)
       pos += slice.length
     }
@@ -186,16 +170,13 @@ const throttledEnd = async (res: Response, buffer: Buffer, tokenBucket: TokenBuc
   // mirror the Throttle abort race for the wrapped res.end path — if the client disconnects while we're
   // waiting on tokens, stop awaiting and drop the rest of `buffer` instead of holding it for the full
   // refill window
-  const closed = new Promise<true>(resolve => res.once('close', () => resolve(true)))
+  const abort = new AbortController()
+  res.once('close', () => abort.abort())
   let pos = 0
   while (buffer.length > pos) {
     if (res.writableEnded || res.destroyed) return
     const slice = buffer.subarray(pos, pos + tokenBucket.bucketSize)
-    const stop = await Promise.race([
-      tokenBucket.bucket.removeTokens(slice.length).then(() => false as const),
-      closed
-    ])
-    if (stop) return
+    if (!await removeTokensOrAborted(tokenBucket.bucket, slice.length, abort.signal)) return
     res.write(slice)
     pos += slice.length
   }
@@ -234,7 +215,9 @@ const buildMiddleware = (_limitType) => async (req, res, next) => {
   }
 
   res.throttle = (bandwidthType) => {
-    const throttle = new Throttle(getTokenBucket(req, limitType, bandwidthType))
+    const tokenBucket = getTokenBucket(req, limitType, bandwidthType)
+    if (!tokenBucket) return new PassThrough() // no bandwidth limit for this tier → pass through unthrottled
+    const throttle = new Throttle(tokenBucket)
     throttle.on('error', () => {
       // nothing, throttle might finish in error if the HTTP request was interrupted or somethin like that
       // we don't care about ERR_STREAM_PREMATURE_CLOSE errors, etc
@@ -251,6 +234,7 @@ const buildMiddleware = (_limitType) => async (req, res, next) => {
     res.end = function (buffer) {
       if (!buffer) return res._originalEnd()
       const tokenBucket = getTokenBucket(req, limitType, bandwidthType)
+      if (!tokenBucket) return res._originalEnd(buffer) // no bandwidth limit → send unthrottled
       tokenBucket.lastUsed = Date.now()
       throttledEnd(res, buffer, tokenBucket)
         .catch(err => console.warn('failed to send throttled response', err))

--- a/api/src/misc/utils/throttle-wait.ts
+++ b/api/src/misc/utils/throttle-wait.ts
@@ -1,0 +1,46 @@
+import { TokenBucket } from 'limiter'
+
+// Config-free so it can be unit-tested without a config directory (see rate-limiting.unit.spec.ts), same
+// as its sibling compute-budget.ts. Consumed by the bandwidth throttle in rate-limiting.ts.
+
+export type TokenBucketWrapper = {
+  lastUsed?: number,
+  bucketSize: number,
+  bucket: TokenBucket
+}
+
+// Build the token bucket for a `bandwidth` limit (bytes/s), sized `bandwidth * burstFactor`. Returns
+// `undefined` when `bandwidth` is 0 or absent (`apiRate[type].bandwidth[bandwidthType]` is optional — e.g.
+// remoteService has no `static`): that means "no bandwidth limit", so callers skip throttling entirely.
+// This is the short-circuit that keeps a 0 limit from ever reaching the throttle loop, where a bucketSize
+// of 0 would slice into empty chunks and spin forever (and an undefined one would stall on NaN).
+export const tokenBucketFor = (bandwidth: number | undefined, burstFactor: number): TokenBucketWrapper | undefined => {
+  if (!bandwidth) return undefined
+  const bucketSize = bandwidth * burstFactor
+  return { bucketSize, lastUsed: Date.now(), bucket: new TokenBucket({ bucketSize, tokensPerInterval: bandwidth, interval: 1000 }) }
+}
+
+// Wait until `bucket` grants `count` tokens, resolving `false` early if `signal` fires first (the stream /
+// response was torn down mid-wait — drop the slice instead of retaining it for up to one refill window).
+// It attaches ONE 'abort' listener and removes it on settle, so a loop calling this per body slice keeps
+// at most one live listener on the long-lived close signal. This replaces the previous
+// `await Promise.race([bucket.removeTokens(n), closedPromise])`: the race's losing-side reaction on the
+// long-lived `closedPromise` was never released until that promise settled, so a throttled send that
+// stalled (a client whose per-IP token bucket was saturated) accumulated one retained PromiseReaction
+// per slice, unbounded — the production heap leak (millions of retained Promises pinning ServerResponse /
+// Socket / Buffer until the pod OOM/GC-spiralled). Returns true when granted, false when aborted first.
+export const removeTokensOrAborted = (
+  bucket: { removeTokens: (count: number) => Promise<unknown> },
+  count: number,
+  signal: AbortSignal
+): Promise<boolean> => {
+  if (signal.aborted) return Promise.resolve(false)
+  return new Promise<boolean>((resolve) => {
+    const onAbort = () => resolve(false)
+    signal.addEventListener('abort', onAbort, { once: true })
+    bucket.removeTokens(count).then(
+      () => { signal.removeEventListener('abort', onAbort); resolve(true) },
+      () => { signal.removeEventListener('abort', onAbort); resolve(false) }
+    )
+  })
+}

--- a/tests/features/infra/rate-limiting.unit.spec.ts
+++ b/tests/features/infra/rate-limiting.unit.spec.ts
@@ -1,0 +1,73 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { removeTokensOrAborted, tokenBucketFor } from '../../../api/src/misc/utils/throttle-wait.ts'
+
+// removeTokensOrAborted waits for the token bucket to grant `count` tokens, but bails out early if the
+// response/stream is torn down (its AbortSignal fires). It must attach at most ONE 'abort' listener per
+// call and remove it on settle — a loop calling it per body slice must NOT accumulate listeners/reactions
+// on the long-lived close signal (that accumulation was the production heap leak: millions of retained
+// PromiseReactions from `Promise.race([removeTokens, closedPromise])` in a per-slice loop).
+
+// bucket doubles (structural: only removeTokens is used)
+const grantingBucket = () => ({ removeTokens: async (_n: number) => 0 })
+const neverBucket = () => ({ removeTokens: (_n: number) => new Promise<number>(() => {}) })
+
+// AbortSignal double that exposes its live-listener count so we can assert non-accumulation
+function countingSignal () {
+  const listeners = new Set<() => void>()
+  let aborted = false
+  return {
+    get aborted () { return aborted },
+    addEventListener (_type: string, fn: () => void) { listeners.add(fn) },
+    removeEventListener (_type: string, fn: () => void) { listeners.delete(fn) },
+    get liveListeners () { return listeners.size },
+    abort () { aborted = true; for (const fn of [...listeners]) { listeners.delete(fn); fn() } }
+  }
+}
+
+test.describe('removeTokensOrAborted', () => {
+  test('resolves true when the bucket grants the tokens', async () => {
+    const sig = countingSignal()
+    assert.equal(await removeTokensOrAborted(grantingBucket() as any, 5, sig as any), true)
+  })
+
+  test('resolves false promptly when aborted before the tokens are granted', async () => {
+    const sig = countingSignal()
+    const p = removeTokensOrAborted(neverBucket() as any, 5, sig as any)
+    sig.abort()
+    assert.equal(await p, false)
+  })
+
+  test('resolves false immediately when the signal is already aborted', async () => {
+    const sig = countingSignal()
+    sig.abort()
+    assert.equal(await removeTokensOrAborted(neverBucket() as any, 5, sig as any), false)
+  })
+
+  test('does not accumulate listeners on the shared signal across many grants (leak guard)', async () => {
+    const sig = countingSignal()
+    for (let i = 0; i < 500; i++) {
+      await removeTokensOrAborted(grantingBucket() as any, 1, sig as any)
+      assert.ok(sig.liveListeners <= 1, `iteration ${i}: ${sig.liveListeners} live listeners`)
+    }
+    assert.equal(sig.liveListeners, 0, 'no listener residue after the loop')
+  })
+})
+
+test.describe('tokenBucketFor', () => {
+  // a 0 or absent bandwidth limit means "no throttling" — the short-circuit that keeps a degenerate bucket
+  // (bucketSize 0 → empty slices → infinite loop; undefined → NaN stall) from ever reaching the throttle loop
+  test('returns undefined for a 0 bandwidth limit (throttling disabled)', () => {
+    assert.equal(tokenBucketFor(0, 4), undefined)
+  })
+
+  test('returns undefined for an absent (undefined) bandwidth limit', () => {
+    assert.equal(tokenBucketFor(undefined, 4), undefined)
+  })
+
+  test('builds a bucket sized bandwidth * burstFactor for a real limit', () => {
+    const tb = tokenBucketFor(100000, 4)
+    assert.ok(tb)
+    assert.equal(tb.bucketSize, 400000)
+  })
+})


### PR DESCRIPTION
Production API pods leaked memory for a few hours until a GC death spiral failed the liveness probe and restarted them. A retained heap snapshot of a degraded pod showed 4.8M Promise nodes held via `system/PromiseReaction` chains, pinning ~2150 stuck responses and 1.4 GB of ArrayBuffers.

**Root cause:** both throttle loops (`Throttle.transformPromise`, `throttledEnd`) awaited `Promise.race([bucket.removeTokens(slice), closedPromise])` per body slice. The race's losing-side reaction on the long-lived close promise was never released, so a send stalled on a saturated per-IP token bucket accumulated one retained PromiseReaction per slice, unbounded. Introduced by #374; surfaced at scale when #474 routed the high-volume `/lines` bodies through `res.send` → `throttledEnd` under an anonymous scraping flood.

**Fix:**
- New config-free `throttle-wait.ts`: `removeTokensOrAborted(bucket, count, signal)` attaches ONE `'abort'` listener and removes it on settle — at most one live listener on the close signal, while keeping #374's prompt-abort-on-disconnect.
- 0/absent bandwidth config (the schema makes `bandwidth.dynamic/static` optional; `remoteService` has no `static`) now short-circuits to unthrottled: `tokenBucketFor` returns `undefined`, `res.throttle` returns a `PassThrough`, `res.throttleEnd` sends directly. Previously `bucketSize=0` sliced empty subarrays and spun the event loop forever.

**Heads-up:**
- Bandwidth `0` now means *unlimited* instead of the previous de-facto infinite hang.
- A `removeTokens` rejection is now treated as an abort (stop sending) instead of a stream error — unreachable in practice since slices are capped at `bucketSize`.

Unit tests cover grant/abort paths, a leak guard (live listeners ≤ 1 across 500 grants), and the disabled-bandwidth short-circuit. Final confirmation is observational: after deploy, the old-space floor should stay flat over hours (was ~600 MB at 1.7 h uptime).
