### PR TITLE
fix(files-storage): respond to HEAD requests without streaming the body

### DIFF
--- a/api/src/files-storage/utils.ts
+++ b/api/src/files-storage/utils.ts
@@ -35,6 +35,14 @@ export const downloadFileFromStorage = async (filePath: string, req: Request, re
     res.set('Content-Disposition', cd)
   }
 
+  // HEAD must return GET's headers (Content-Length, Last-Modified) with no body — streaming the
+  // throttled body would hang until the file fully drains, timing out crawlers (e.g. hydra).
+  if (req.method === 'HEAD') {
+    body.destroy()
+    res.end()
+    return
+  }
+
   try {
     // @ts-ignore
     if (res.throttle) await pipeline(body, res.throttle('static'), res)

--- a/tests/features/datasets/file-download.api.spec.ts
+++ b/tests/features/datasets/file-download.api.spec.ts
@@ -1,0 +1,28 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { axiosAuth, clean, checkPendingTasks } from '../../support/axios.ts'
+import { sendDataset } from '../../support/workers.ts'
+
+const testUser1 = await axiosAuth('test_user1@test.com')
+
+test.describe('datasets - file download', () => {
+  test.beforeEach(async () => {
+    await clean()
+  })
+
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === 'passed') await checkPendingTasks()
+  })
+
+  // A HEAD on /raw must return GET's headers (Content-Length, Last-Modified) with no body, so
+  // crawlers like data.gouv.fr's hydra (HEAD + 5s timeout) can read the date without hanging on
+  // the throttled body stream.
+  test('HEAD /raw returns headers without a body', async () => {
+    const dataset = await sendDataset('datasets/dataset1.csv', testUser1)
+    const res = await testUser1.head(`/api/v1/datasets/${dataset.id}/raw`)
+    assert.equal(res.status, 200)
+    assert.ok(Number(res.headers['content-length']) > 0)
+    assert.ok(res.headers['last-modified'])
+    assert.ok(!res.data)
+  })
+})


### PR DESCRIPTION
`downloadFileFromStorage` now short-circuits `HEAD` requests: it sends the same headers a `GET` would (`Content-Length`, `Last-Modified`, `Content-Type`, …), destroys the source stream, and ends the response with no body.

**Why:** crawlers such as data.gouv.fr's hydra issue a `HEAD` with a short (~5s) timeout to read the file's date. Previously the handler streamed the throttled body even for `HEAD`, so the request hung until the file fully drained and the crawler timed out. Because the fix lives in the shared helper, it applies to every file-download route (`/raw`, `/convert`, `/full`, `/data-files`, attachments, diagnostics, captures).

**Heads-up:** the superadmin REST-export branch of `/raw` streams its CSV via `pump` before reaching this helper, so a `HEAD` there still streams the body — out of scope for this crawler fix, but worth knowing.
