### PR TITLE
fix(datasets): compute uploaded file md5 in-stream to avoid 500 on file update with S3 storage

### DIFF
--- a/api/src/datasets/service.ts
+++ b/api/src/datasets/service.ts
@@ -24,7 +24,6 @@ import { getDatasetCacheKey } from './operations.ts'
 import * as virtualDatasetsUtils from './utils/virtual.ts'
 import i18n from 'i18n'
 import filesStorage from '#files-storage'
-import md5File from 'md5-file'
 import type { Db } from 'mongodb'
 import type { Client } from '@elastic/elasticsearch'
 import type { SessionState, SessionStateAuthenticated } from '@data-fair/lib-express'
@@ -308,7 +307,7 @@ export const createDataset = async (db: Db, es: Client, locale: string, sessionS
 
   if (datasetFile) {
     dataset.title = dataset.title || titleFromFileName(datasetFile.originalname)
-    const md5 = await md5File(datasetFile.path)
+    const md5 = datasetFile.md5
     const filePatch: any = {
       status: 'created',
       dataUpdatedBy: dataset.updatedBy,

--- a/api/src/datasets/utils/patch.ts
+++ b/api/src/datasets/utils/patch.ts
@@ -4,7 +4,6 @@ import equal from 'deep-equal'
 import moment from 'moment'
 import { httpError } from '@data-fair/lib-utils/http-errors.js'
 import mime from 'mime-types'
-import md5File from 'md5-file'
 import config from '#config'
 import * as geo from './geo.ts'
 import * as datasetUtils from './index.ts'
@@ -56,9 +55,10 @@ export const preparePatch = async (app: any, patch: any, dataset: any, sessionSt
 
   if (datasetFile) {
     if (!dataset.file && !dataset.loaded) throw httpError(400, 'this dataset is not file based')
-    // compute md5 of the updated file, matching the create path (service.ts) so originalFile.md5
-    // stays current across file replacements (it was previously only computed on create)
-    const md5 = await md5File(datasetFile.path)
+    // md5 of the updated file (keeps originalFile.md5 current across file replacements) is computed
+    // in-flight while the upload streams to storage (see upload.ts _handleFile) — the update path
+    // streams straight to storage with no local copy, so a local md5File read would ENOENT on S3.
+    const md5 = datasetFile.md5
     patch.loaded = {
       dataset: {
         md5,

--- a/api/src/datasets/utils/upload.ts
+++ b/api/src/datasets/utils/upload.ts
@@ -13,6 +13,16 @@ import debugLib from 'debug'
 import filesStorage from '#files-storage'
 import tmp from 'tmp-promise'
 import { pipeline } from 'node:stream/promises'
+import { Transform } from 'node:stream'
+import { createHash } from 'node:crypto'
+
+// a pass-through stream that md5-hashes the bytes flowing through it, so the file's md5 is computed
+// in a single pass during upload — no local temp copy (S3 streams straight through) and no re-read.
+const md5Tee = () => {
+  const hash = createHash('md5')
+  const stream = new Transform({ transform (chunk, _enc, cb) { hash.update(chunk); cb(null, chunk) } })
+  return { stream, digest: () => hash.digest('hex') }
+}
 
 const fallbackMimeTypes = {
   dbf: 'application/dbase',
@@ -31,29 +41,34 @@ const storage = {
     try {
       const filename = file.fieldname === 'attachments' ? 'attachments.zip' : file.originalname
       const dataset = reqDatasetOptional(req)
+      const tee = md5Tee()
       if (dataset) {
         const destination = datasetUtils.loadingDir({ ...dataset, draftReason: req.query.draft === 'true' || reqDraftOptional(req) })
         const finalPath = path.join(destination, filename)
-        await filesStorage.writeStream(file.stream, finalPath)
+        // forward a source read error to the tee so the storage upload rejects instead of hanging
+        file.stream.on('error', (err: any) => tee.stream.destroy(err))
+        await filesStorage.writeStream(file.stream.pipe(tee.stream), finalPath)
         const stats = await filesStorage.fileStats(finalPath)
         cb(null, {
           destination,
           filename,
           path: finalPath,
-          size: stats.size
+          size: stats.size,
+          md5: tee.digest()
         })
       } else {
         const destination = await tmp.tmpName({ tmpdir: tmpDir })
         const finalPath = path.join(destination, filename)
         await fs.ensureFile(finalPath)
-        await pipeline(file.stream, fs.createWriteStream(finalPath))
+        await pipeline(file.stream, tee.stream, fs.createWriteStream(finalPath))
         await fsyncFile(finalPath)
         const stats = await fs.stat(finalPath)
         cb(null, {
           destination,
           filename,
           path: finalPath,
-          size: stats.size
+          size: stats.size,
+          md5: tee.digest()
         })
       }
     } catch (err) {


### PR DESCRIPTION
Updating an existing dataset with a new file returned a 500 (`ENOENT ... /loading/<file>.csv`) on S3 deployments, while creation worked fine. Since the WORM anchoring change (#481), `preparePatch` computed the file md5 with `md5File(datasetFile.path)`, reading the **local filesystem** — but on the update path the upload streams the file straight into the storage backend (loading dir), so on S3 there is no local copy and the read fails. Creation escaped it only because its file lands in a local tmp dir first. The fs-backed test suite never caught it: with `filesStorage: 'fs'` the local read always succeeds.

- `upload.ts` `_handleFile` now hashes the bytes **in-flight** through a pass-through Transform (`md5Tee`) as they stream to storage, on both the storage and local-tmp branches, and exposes `file.md5`.
- `service.ts` (create) and `patch.ts` (update) read `datasetFile.md5` instead of re-reading the file — the create path no longer does a second local pass either.

**Why:** single pass, constant memory — no local copy and no re-download — which matters for multi-GB datasets; and it removes the local-filesystem assumption that only held for the fs backend.

**Heads-up:** the md5 is now computed during upload for every uploaded dataset/attachment file (cheap, one pass); `originalFile.md5` (consumed by the integrity feature) is unchanged in value. There is no S3-under-API test harness, so this is verified via the fs suite (no regression on the create/update file paths) plus the integrity tests (md5 correctness, which do exercise S3).
