### PR TITLE
refactor(api): reuse the shared @data-fair/lib-node axios instance

### DIFF
--- a/api/src/misc/utils/axios.ts
+++ b/api/src/misc/utils/axios.ts
@@ -1,27 +1,7 @@
-// prepare an axios instance with improved error management
+// reuse the shared axios instance from @data-fair/lib-node but keep our own http agents
+// so the configurable socket limits and the non-keepalive https agent are preserved
 
-import axios from 'axios'
+import { axiosBuilder } from '@data-fair/lib-node/axios.js'
 import { httpAgent, httpsAgent } from './http-agents.ts'
 
-const axiosInstance = axios.create({
-  httpAgent,
-  httpsAgent
-})
-
-axiosInstance.interceptors.response.use(response => response, error => {
-  if (!error.response) return Promise.reject(error)
-  delete error.response.request
-  delete error.response.headers
-  error.response.config = { method: error.response.config.method, url: error.response.config.url, data: error.response.config.data }
-  if (error.response.config.data && error.response.config.data._writableState) delete error.response.config.data
-  if (error.response.data && error.response.data._readableState) delete error.response.data
-  let messageText = error.response.statusText
-  if (error.response.data) {
-    messageText = typeof error.response.data === 'string' ? error.response.data : JSON.stringify(error.response.data)
-  }
-  error.response.message = `${error.response.status} - ${messageText}`
-
-  return Promise.reject(error.response)
-})
-
-export default axiosInstance
+export default axiosBuilder({ httpAgent, httpsAgent })

--- a/api/src/misc/utils/http-agents.ts
+++ b/api/src/misc/utils/http-agents.ts
@@ -1,12 +1,12 @@
 import config from '#config'
 import CacheableLookup from 'cacheable-lookup'
-import AgentKeepAlive from 'agentkeepalive'
+import { HttpAgent } from 'agentkeepalive'
 import https from 'https'
 
 // HTTP agent performance, cf https://github.com/nodejitsu/node-http-proxy/issues/1058
 // use agent keepalive only for http (meaning probably internal to the infrastructure)
 // if by mistake we also use https (reentrant) it is better not to saturate the reverse proxy with opened sockets
-export const httpAgent = new AgentKeepAlive(config.agentkeepaliveOptions)
+export const httpAgent = new HttpAgent(config.agentkeepaliveOptions)
 
 export const httpsAgent = new https.Agent({})
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1669,9 +1669,9 @@
       }
     },
     "node_modules/@data-fair/lib-node": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@data-fair/lib-node/-/lib-node-2.13.1.tgz",
-      "integrity": "sha512-X5/aZWWjyK/coLvreNYMlCekcRiuFJhFtRRx6mZFQmMf8Nb2ZCXm++Bg6a4wcBJGEPjonfurGhqA1tPOnBR4+g==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@data-fair/lib-node/-/lib-node-2.13.3.tgz",
+      "integrity": "sha512-djpe8B1Ri2TOVWehAXfIdNzHdZEVa/z7Bw9LOiDm6/S8UifPQGepKZCIhNVeKj4AwQ4e706dsyB+wGUOy3ehAw==",
       "license": "MIT",
       "dependencies": {
         "@data-fair/lib-common-types": "^1.8.4",


### PR DESCRIPTION
`api/src/misc/utils/axios.ts` maintained its own `axios.create(...)` plus a hand-rolled response-error interceptor. `@data-fair/lib-node` now ships an equivalent `axiosBuilder`, so the local copy was a duplicated interceptor drifting from the shared one. Consolidate onto the library and keep only what is data-fair-specific: our http agents.

- `axios.ts` drops the local instance and interceptor and returns `axiosBuilder({ httpAgent, httpsAgent })` from `@data-fair/lib-node/axios.js`, passing our own agents so the configurable socket limits and the non-keepalive https agent are preserved.
- `http-agents.ts` switches to the named `HttpAgent` export of `agentkeepalive` (same instance, matches lib-node usage).
- Bumps `@data-fair/lib-node` to 2.13.3 (lock only — the `^` ranges already allowed it).

**Why:** removes a duplicated error interceptor that has to be kept in sync by hand; the shared builder also `destroy()`s a streamed error body before dropping it (avoids a socket leak) and attaches a request-context stack trace to rejected errors.

**Heads-up:** on a failed request the rejected value is now lib-node's `AxiosRequestError` (an `Error` with the response fields assigned onto it) rather than the bare `error.response` — consumers reading `err.status` / `err.data` / `err.message` are unaffected. `error.response.headers` is no longer stripped from the rejected object (harmless extra data).
