### PR TITLE
fix(datasets): redirect to original image when thumbnail fetch fails instead of 502

### DIFF
--- a/api/src/misc/utils/thumbnails.ts
+++ b/api/src/misc/utils/thumbnails.ts
@@ -81,7 +81,8 @@ const getCacheEntry = async (db: any, url: string, filePath: string | null, shar
         } else {
           console.warn(`failed to fetch image for thumbnail "${url}"`, err)
           if (err.status === 404) throw httpError(404, `image not found ${url}`)
-          throw httpError(502, `failed to fetch image ${url}`)
+          // no cache entry to serve as stale content, let getThumbnail redirect to the original image
+          return { entry: null, status: 'FALLBACK' }
         }
       }
     }
@@ -148,11 +149,11 @@ export const getThumbnail = async (req: Request, res: Response, url: string, fil
   const { entry, status } = await getCacheEntry(db, url, filePath, sharpOptions)
 
   const ifModifiedSince = req.get('if-modified-since')
-  if (ifModifiedSince && entry.lastModified === ifModifiedSince) {
+  if (entry && ifModifiedSince && entry.lastModified === ifModifiedSince) {
     debug('if-modified-since matches local date, return 304')
     return res.status(304).send()
   }
-  if (entry.lastModified) res.setHeader('Last-Modified', entry.lastModified)
+  if (entry?.lastModified) res.setHeader('Last-Modified', entry.lastModified)
   res.setHeader('X-Thumbnails-Cache-Status', status)
   if (reqPublicOperation(req)) {
     // force buffering (necessary for caching) of this response in the reverse proxy
@@ -161,8 +162,10 @@ export const getThumbnail = async (req: Request, res: Response, url: string, fil
   } else {
     setNoCache(req, res)
   }
-  if (entry.sharpError) {
-    // res.status(400).type('text/plain').send(entry.sharpError)
+  if (!entry || entry.sharpError) {
+    // either the image could not be fetched (and there is no stale cache entry to fall back on)
+    // or it could not be processed by sharp, in both cases degrade gracefully by redirecting
+    // to the original image instead of failing
     res.redirect(url)
   } else {
     res.setHeader('content-type', entry.mimetype || 'image/png')

--- a/tests/features/datasets/upload/datasets-features.api.spec.ts
+++ b/tests/features/datasets/upload/datasets-features.api.spec.ts
@@ -63,6 +63,36 @@ test.describe('datasets - features', () => {
     await clearMockRoutes()
   })
 
+  test('should redirect to the original image when fetching it fails without a previous cache entry', async () => {
+    const ax = testUser1
+    await ax.post('/api/v1/datasets/thumbnails-fallback', {
+      isRest: true,
+      title: 'thumbnails-fallback',
+      schema: [{ key: 'imageUrl', type: 'string', 'x-refersTo': 'http://schema.org/image' }]
+    })
+    await ax.post('/api/v1/datasets/thumbnails-fallback/_bulk_lines', [
+      { imageUrl: `${mockUrl}/rate-limited.jpg` },
+      { imageUrl: `${mockUrl}/missing.jpg` }
+    ])
+    await waitForFinalize(ax, 'thumbnails-fallback')
+
+    // the image host answers 429 (e.g. wikimedia rate-limiting our server IP)
+    await setupMockRoute({ path: '/rate-limited.jpg', status: 429, body: 'too many requests', contentType: 'text/plain' })
+    await setupMockRoute({ path: '/missing.jpg', status: 404, body: 'not found', contentType: 'text/plain' })
+
+    const res = await ax.get('/api/v1/datasets/thumbnails-fallback/lines', { params: { thumbnail: true, sort: 'imageUrl' } })
+    // no previous cache entry to serve as stale content -> redirect to the original image instead of failing
+    await assert.rejects(ax.get(res.data.results[1]._thumbnail, { maxRedirects: 0 }), (err: any) => {
+      assert.equal(err.status, 302)
+      assert.equal(err.headers.location, `${mockUrl}/rate-limited.jpg`)
+      return true
+    })
+    // a missing image is still a 404, not a redirect
+    await assert.rejects(ax.get(res.data.results[0]._thumbnail, { maxRedirects: 0 }), (err: any) => err.status === 404)
+
+    await clearMockRoutes()
+  })
+
   test('should create thumbnail for the image metadata of a dataset', async () => {
     const ax = testUser1
     await setupMockRoute({ path: '/dataset-image.jpg', status: 200, bodyBase64: fs.readFileSync('./tests/resources/avatar.jpeg').toString('base64'), contentType: 'image/jpeg' })


### PR DESCRIPTION
Rendering the table view of a dataset with an image column triggers one `/thumbnail/<hex(url)>` request per row, and on the first display of a given image at a given size the API has no cache entry yet and must fetch the source. Hosts like Wikimedia rate-limit our server IP (`429 - Your bot is making too many requests`), and any such failure on a cold cache surfaced as a 502 and a broken image, with no way out since error responses are never cached.

- `getCacheEntry` no longer throws a 502 when the fetch fails without a previous cache entry: it returns a null entry (`X-Thumbnails-Cache-Status: FALLBACK`) and `getThumbnail` redirects (302) to the original image URL — the same graceful degradation as the existing `sharpError` fallback, sharing its cache-headers logic.
- A 404 from the image host is still returned as a 404: it is deterministic, the browser would just get the same 404.
- Existing behaviors are untouched: stale cache entry served on fetch failure, 304 revalidation, file-based (attachment) thumbnails.

**Why:** the browser can often succeed where the server failed — 429 and 403 are usually keyed on IP or User-Agent — and at worst it receives the same error, which renders exactly like the 502 did for an `<img>` tag. A full-size image (or an identical broken state) beats a guaranteed broken cell.

**Heads-up:** API clients that previously observed a 502 now get a 302. On public datasets the redirect inherits `Cache-Control: public, max-age=300`, so the reverse proxy may keep serving the fallback for up to 5 minutes after the source recovers — accepted, it also avoids hammering a host that is already rate-limiting us. Images whose host keeps blocking our server now load full-resolution in the UI until it unblocks; a background prewarm with slow retries honouring `Retry-After` was discussed and deferred.
