### PR TITLE
fix(encoding): treat ASCII detection as UTF-8 to avoid mangling multi-byte tails

### DIFF
--- a/api/src/misc/utils/decode-stream.ts
+++ b/api/src/misc/utils/decode-stream.ts
@@ -1,9 +1,9 @@
 // inspired by https://github.com/danielgindi/node-autodetect-decoder-stream/blob/master/index.js
 
 import iconv, { type DecoderStream } from 'iconv-lite'
-import chardet from 'chardet'
 import { Transform, type TransformCallback } from 'stream'
 import outOfCharacter from 'out-of-character'
+import { detectEncoding } from './detect-encoding.ts'
 
 const sampleSize = 32768 // 32kb
 
@@ -23,7 +23,7 @@ class DecodeStream extends Transform {
     if (!this.decoder) {
       if (chunk) this._buffer = Buffer.concat([this._buffer!, chunk])
       if (this._buffer!.length > sampleSize || flush) {
-        const encoding = chardet.detect(this._buffer!) ?? 'UTF-8'
+        const encoding = detectEncoding(this._buffer!)
         this.decoder = iconv.getDecoder(encoding, iconvOpts)
         chunk = this._buffer!
         delete this._buffer

--- a/api/src/misc/utils/detect-encoding.ts
+++ b/api/src/misc/utils/detect-encoding.ts
@@ -1,0 +1,20 @@
+import chardet from 'chardet'
+
+// chardet only ever sees a sample taken from the start of the file (a 1MB
+// fileSample when storing, a 32kb stream buffer when decoding). A file that is
+// pure 7-bit ASCII within that sample but turns multi-byte deeper down is
+// detected as "ASCII" — common for GeoJSON, where ASCII-only geometry
+// coordinates dominate the head and accented text properties appear later. The
+// stored/streamed "ASCII" codec then mangles every non-ASCII byte past the
+// sample window (e.g. "à" 0xC3 0xA0 → "��").
+//
+// ASCII is a strict subset of UTF-8, so promoting an ASCII detection to UTF-8
+// decodes genuine ASCII byte-identically while correctly handling the
+// multi-byte tail. UTF-8 is also the natural fallback when detection fails.
+export const detectEncoding = (buffer: Buffer): string => {
+  const detected = chardet.detect(buffer)
+  if (!detected || detected === 'ASCII') return 'UTF-8'
+  return detected
+}
+
+export default detectEncoding

--- a/api/src/workers/files-manager/store-file.ts
+++ b/api/src/workers/files-manager/store-file.ts
@@ -3,7 +3,7 @@ import * as datasetUtils from '../../datasets/utils/index.ts'
 import { updateStorage } from '../../datasets/utils/storage.ts'
 import * as datasetsService from '../../datasets/service.ts'
 import { replaceAllAttachments } from '../../datasets/utils/attachments.ts'
-import chardet from 'chardet'
+import { detectEncoding } from '../../misc/utils/detect-encoding.ts'
 import JSONStream from 'JSONStream'
 import { Transform } from 'node:stream'
 import split2 from 'split2'
@@ -91,8 +91,7 @@ export default async function (dataset: DatasetInternal) {
     } else {
       const fileSample = await filesStorage.fileSample(loadedFilePath)
       debug(`Attempt to detect encoding from ${fileSample.length} first bytes of file ${loadedFilePath}`)
-      const encoding = chardet.detect(fileSample)
-      if (encoding) datasetFile.encoding = encoding
+      datasetFile.encoding = detectEncoding(fileSample)
       debug(`Detected encoding ${datasetFile.encoding} for file ${loadedFilePath}`)
     }
 

--- a/tests/features/datasets/detect-encoding.unit.spec.ts
+++ b/tests/features/datasets/detect-encoding.unit.spec.ts
@@ -1,0 +1,55 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { Readable } from 'node:stream'
+import { detectEncoding } from '../../../api/src/misc/utils/detect-encoding.ts'
+import DecodeStream from '../../../api/src/misc/utils/decode-stream.ts'
+
+test.describe('detectEncoding', () => {
+  test('promotes a pure-ASCII buffer to UTF-8 (superset)', () => {
+    // genuine ASCII decodes byte-identically as UTF-8, so this never regresses
+    assert.equal(detectEncoding(Buffer.from('{"type":"FeatureCollection"}', 'ascii')), 'UTF-8')
+  })
+
+  test('promotes a large ASCII-only sample to UTF-8', () => {
+    // reproduces the PED_circuit geojson root cause: detection only ever sees a
+    // sample from the head of the file (1MB when storing, 32kb when decoding).
+    // When that whole sample is 7-bit ASCII — because the first accented byte
+    // ("à" = 0xC3 0xA0) only appears deeper in the file — chardet returns
+    // "ASCII", and the ASCII codec would later turn "à" into two replacement
+    // chars. Promoting to UTF-8 decodes the multi-byte tail correctly.
+    const asciiSample = Buffer.from('x'.repeat(1024 * 1024), 'ascii')
+    assert.equal(detectEncoding(asciiSample), 'UTF-8')
+  })
+
+  test('keeps a genuine non-ASCII detection (UTF-8 with accents up front)', () => {
+    const buf = Buffer.from('nom,adresse\nÉglise,Château de Versailles\n'.repeat(50), 'utf8')
+    assert.equal(detectEncoding(buf), 'UTF-8')
+  })
+
+  test('falls back to UTF-8 on an empty buffer', () => {
+    assert.equal(detectEncoding(Buffer.alloc(0)), 'UTF-8')
+  })
+})
+
+test.describe('DecodeStream', () => {
+  const decode = async (inputChunks: Buffer[]): Promise<string> => {
+    const ds = new DecodeStream()
+    const chunks: Buffer[] = []
+    Readable.from(inputChunks).pipe(ds)
+    for await (const c of ds) chunks.push(c as Buffer)
+    return Buffer.concat(chunks).toString('utf8')
+  }
+
+  test('decodes accented UTF-8 arriving after an ASCII-detected sample', async () => {
+    // exactly the PED_circuit-1.geojson shape: the first chunk exceeds the 32kb
+    // sample window and is pure ASCII, so encoding detection fires on it (and,
+    // before the fix, latched onto ASCII). The accented "à"/"é" only arrive in
+    // a later chunk — where the ASCII codec would have decoded them to
+    // replacement chars.
+    const head = Buffer.from('x'.repeat(40000), 'ascii') // > sampleSize, triggers detection
+    const tail = Buffer.from(" l'Atlantique à la Côte Française", 'utf8')
+    const out = await decode([head, tail])
+    assert.ok(out.endsWith('à la Côte Française'), `unexpected tail: ${JSON.stringify(out.slice(-40))}`)
+    assert.ok(!out.includes('�'), 'output must not contain replacement chars')
+  })
+})


### PR DESCRIPTION
Encoding detection only ever sees a sample from the head of the file (1MB when storing `dataset.file.encoding`, 32kb when stream-decoding). A file that is pure 7-bit ASCII within that sample but turns multi-byte deeper down — common for GeoJSON, where ASCII-only geometry coordinates dominate the head and accented properties appear later — is detected as `ASCII`, and the ASCII codec then mangles every non-ASCII byte past the sample window (e.g. `à` `0xC3 0xA0` → `��`).
Fix: promote an `ASCII` detection to `UTF-8`. ASCII is a strict subset of UTF-8, so genuine ASCII decodes byte-identically while the multi-byte tail decodes correctly. Extracted into a shared `detectEncoding` helper used by both the store-file detection and `DecodeStream`.

**Why:** a real GeoJSON upload (`PED_circuit-1.geojson`, first accented byte at offset ~1.39MB, past both sample windows) was ingested with corrupted accented text.

**Heads-up:**
- Behavioral change in shared code: any file previously detected as `ASCII` is now labelled `UTF-8`. Decoding is identical for genuine ASCII; downstream `analyze-csv.ts` now takes the UTF-8 `toString()` fast path instead of `iconv.decode(…, 'ASCII')`.
- Existing datasets already stored with `encoding: "ASCII"` won't self-heal — they need a re-process to pick up the corrected value. No migration is included (intentionally).
