### PR TITLE
fix(datasets): quote the thumbnail qs filter to accept urls with commas

### DIFF
--- a/api/src/datasets/routes/misc.ts
+++ b/api/src/datasets/routes/misc.ts
@@ -154,7 +154,7 @@ export const registerMiscRoutes = (router: Router) => {
     } else {
       const imageField = dataset.schema.find((f: any) => f['x-refersTo'] === 'http://schema.org/image')
       const count = await esUtils.count(dataset, {
-        qs: `${esUtils.escapeFilter(imageField.key)}:${esUtils.escapeFilter(url)}`
+        qs: `${esUtils.escapeFilter(imageField.key)}:"${esUtils.escapeFilter(url)}"`
       })
       if (!count) return res.status(404).send('thumbnail does not match a URL from this dataset')
       await getThumbnail(req, res, url, null, dataset.thumbnails)

--- a/tests/features/datasets/upload/datasets-features.api.spec.ts
+++ b/tests/features/datasets/upload/datasets-features.api.spec.ts
@@ -31,7 +31,8 @@ test.describe('datasets - features', () => {
     res = await ax.post('/api/v1/datasets/thumbnails1/_bulk_lines', [
       { imageUrl: `${mockUrl}/image.png`, desc: '1 image' },
       { imageUrl: `${mockUrl}/avatar.jpg`, desc: '2 avatar' },
-      { imageUrl: `${mockUrl}/wikipedia.gif`, desc: '3 wikipedia animated' }
+      { imageUrl: `${mockUrl}/wikipedia.gif`, desc: '3 wikipedia animated' },
+      { imageUrl: `${mockUrl}/iiif/full/!300,300/0/default.jpg`, desc: '4 iiif comma' }
     ])
     await waitForFinalize(ax, 'thumbnails1')
 
@@ -39,12 +40,14 @@ test.describe('datasets - features', () => {
     await setupMockRoute({ path: '/image.png', status: 200, body: '', contentType: 'image/png' })
     await setupMockRoute({ path: '/avatar.jpg', status: 200, bodyBase64: fs.readFileSync('./tests/resources/avatar.jpeg').toString('base64'), contentType: 'image/jpeg' })
     await setupMockRoute({ path: '/wikipedia.gif', status: 200, bodyBase64: fs.readFileSync('./tests/resources/wikipedia.gif').toString('base64'), contentType: 'image/gif' })
+    await setupMockRoute({ path: '/iiif/full/!300,300/0/default.jpg', status: 200, bodyBase64: fs.readFileSync('./tests/resources/avatar.jpeg').toString('base64'), contentType: 'image/jpeg' })
 
     res = await ax.get('/api/v1/datasets/thumbnails1/lines', { params: { thumbnail: true, select: 'desc', sort: 'desc' } })
-    assert.equal(res.data.results.length, 3)
+    assert.equal(res.data.results.length, 4)
     assert.equal(res.data.results[0].desc, '1 image')
     assert.equal(res.data.results[1].desc, '2 avatar')
     assert.equal(res.data.results[2].desc, '3 wikipedia animated')
+    assert.equal(res.data.results[3].desc, '4 iiif comma')
     assert.ok(res.data.results[0]._thumbnail.endsWith('width=300&height=200'))
 
     // Empty image should redirect
@@ -59,6 +62,10 @@ test.describe('datasets - features', () => {
     assert.equal(thumbresGif.headers['content-type'], 'image/webp')
     assert.equal(thumbresGif.headers['x-thumbnails-cache-status'], 'MISS')
     assert.equal(thumbresGif.headers['cache-control'], 'must-revalidate, private, max-age=0')
+
+    const thumbresIiif = await ax.get(res.data.results[3]._thumbnail)
+    assert.equal(thumbresIiif.headers['content-type'], 'image/png')
+    assert.equal(thumbresIiif.headers['x-thumbnails-cache-status'], 'MISS')
 
     await clearMockRoutes()
   })


### PR DESCRIPTION
`/datasets/:id/thumbnail/:thumbnailId` returned a 400 for image urls containing a comma, typical of IIIF size specs (`.../full/!300,300/0/default.jpg`). The route checks that the decoded url belongs to the dataset with an ES count whose `qs` filter was built unquoted (`field:escapeFilter(url)`). `escapeFilter` correctly escapes Lucene special characters, but the comma is not one of them — the failure comes from the qs validation parser (`lucene-query-parser`), whose unquoted-term grammar contains `+-/` inside a character class: an accidental ASCII range that excludes `,`. Elasticsearch itself accepts such terms fine.

- the filter value is now quoted (`field:"escapeFilter(url)"`), the same pattern already used by the master-data exact-match filters; a quoted term accepts any character and keeps the exact match on the keyword field. Unquoted values containing a space were also silently mis-matching (`field:foo bar` parses as two clauses)
- regression test: a line with an IIIF-style image url whose thumbnail must return 200 (verified failing with the exact production error before the fix)

**Why quote rather than fix the parser:** an audit of every other qs construction (API and UI) found no other exposed spot — master-data already quotes, and the typed filters (`_eq`, `_in`…) bypass Lucene parsing entirely. Swapping the abandoned `lucene-query-parser` for a correct grammar would fix the root cause for client-built queries too, but it changes validation behavior for every user-supplied `qs` — worth its own change if apps report the same 400.
