### PR TITLE
perf(datasets): incremental /lines body assembly + deeper accept backlog to stop probe-kill stalls

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -250,7 +250,11 @@ export const run = async () => {
     server.requestTimeout = (15 * 60 * 1000)
 
     if (!config.listenWhenReady) {
-      server.listen(config.port)
+      // deep accept backlog: a single thread does both accept() and request work, so any event-loop hitch
+      // pauses accepting and connections queue in the kernel. The default 511 overflowed in production
+      // (TcpExt ListenOverflows) under connection bursts, dropping SYNs incl. the liveness probe's.
+      // Requires net.core.somaxconn >= 4096 on the node (checked: 4096), the kernel clamps silently otherwise.
+      server.listen({ port: config.port, backlog: 4096 })
       await eventPromise(server, 'listening')
     }
   }
@@ -331,7 +335,8 @@ export const run = async () => {
     app.set('ui-ready', true)
 
     if (config.listenWhenReady) {
-      server.listen(config.port)
+      // see the early listen above for the backlog rationale
+      server.listen({ port: config.port, backlog: 4096 })
       await eventPromise(server, 'listening')
     }
   }

--- a/api/src/datasets/routes/lines-body.ts
+++ b/api/src/datasets/routes/lines-body.ts
@@ -1,6 +1,7 @@
 // Pure, config-free payload/link builders for the /lines pipeline — extracted from lines-pipeline.ts so
 // the byte-level output contract can be unit-tested without loading the app config, and so read.ts's
 // hard-format branch shares the SAME next-link construction (one pagination contract, not two).
+import { createHash } from 'node:crypto'
 import LinkHeader from 'http-link-header'
 
 // Inputs needed to build the `next` pagination link (all optional — omitted in unit tests that don't
@@ -31,20 +32,78 @@ export const linkHeaderValue = (href: string): string => {
   return link.toString()
 }
 
-// Head object serialized then spliced with the pre-serialized rows: byte-identical to JSON.stringify of
-// the equivalent object (same key order, JSON.stringify per value) → identical ETag.
-export const buildJsonBody = (head: Record<string, any>, rows: string[]): string => {
-  const headStr = JSON.stringify(head)
-  return (headStr === '{}' ? '{' : headStr.slice(0, -1) + ',') + '"results":[' + rows.join(',') + ']}'
+// Accumulates the body of a /lines response (json/csv/geojson) as pre-encoded Buffer batches instead of
+// one monolithic string, so no single synchronous pass over the whole body ever blocks the event loop
+// (a large export used to block for seconds in join + Express's etag sha1 + utf8 encode inside res.send).
+// push() is fed the exact body substrings (separators included) and encodes them to a Buffer every
+// ~flushChars characters — amortized inside consumeHits' every-500-rows yield, so it needs no yields of
+// its own. finish() takes the envelope prefix/suffix (the prefix — total/next — is only known after the
+// last hit, but must be hashed first) and does the only remaining full-body passes: a sha1 walk yielding
+// every hashYieldBytes, and one Buffer.concat (pure memcpy). The returned etag is byte-identical to what
+// Express generates in res.send (the `etag` package's weak form) — the caller sets it as a header so
+// Express skips its own full-body hash.
+export class BodyAccumulator {
+  private parts: Buffer[] = []
+  private pending: string[] = []
+  private pendingChars = 0
+  private readonly flushChars: number
+  private readonly hashYieldBytes: number
+
+  constructor (opts?: { flushChars?: number, hashYieldBytes?: number }) {
+    this.flushChars = opts?.flushChars ?? 64 * 1024
+    this.hashYieldBytes = opts?.hashYieldBytes ?? 2 * 1024 * 1024
+  }
+
+  push (chunk: string): void {
+    this.pending.push(chunk)
+    this.pendingChars += chunk.length
+    if (this.pendingChars >= this.flushChars) this.flush()
+  }
+
+  private flush (): void {
+    if (!this.pendingChars) return
+    this.parts.push(Buffer.from(this.pending.join('')))
+    this.pending = []
+    this.pendingChars = 0
+  }
+
+  async finish (prefix: string, suffix: string): Promise<{ buffer: Buffer, etag: string }> {
+    this.flush()
+    const parts = [Buffer.from(prefix), ...this.parts, Buffer.from(suffix)]
+    const hash = createHash('sha1')
+    let length = 0
+    let sinceYield = 0
+    for (const part of parts) {
+      hash.update(part)
+      length += part.length
+      sinceYield += part.length
+      if (sinceYield >= this.hashYieldBytes) {
+        sinceYield = 0
+        await new Promise(resolve => setImmediate(resolve))
+      }
+    }
+    // the `etag` package's weak format: W/"<byte length in hex>-<base64 sha1 truncated to 27 chars>"
+    const etag = `W/"${length.toString(16)}-${hash.digest('base64').substring(0, 27)}"`
+    return { buffer: Buffer.concat(parts), etag }
+  }
 }
 
-// FeatureCollection body, key order type → total? → features → bbox? (matches the buffered
-// `res.send(result2geojson(esResponse) + bbox)` output).
-export const buildGeojsonBody = (total: number | undefined | null, features: string[], bbox: any): string => {
-  let body = '{"type":"FeatureCollection"'
-  if (total != null) body += ',"total":' + total
-  body += ',"features":[' + features.join(',') + ']'
-  if (bbox !== undefined) body += ',"bbox":' + JSON.stringify(bbox)
-  body += '}'
-  return body
+// Head object serialized then spliced ahead of the rows: byte-identical to JSON.stringify of the
+// equivalent object (same key order, JSON.stringify per value) → identical ETag. The prefix/suffix pair
+// is what the accumulator path uses; buildJsonBody derives from it so the two paths cannot drift.
+export const jsonBodyPrefix = (head: Record<string, any>): string => {
+  const headStr = JSON.stringify(head)
+  return (headStr === '{}' ? '{' : headStr.slice(0, -1) + ',') + '"results":['
 }
+export const jsonBodySuffix = ']}'
+export const buildJsonBody = (head: Record<string, any>, rows: string[]): string =>
+  jsonBodyPrefix(head) + rows.join(',') + jsonBodySuffix
+
+// FeatureCollection body, key order type → total? → features → bbox? (matches the buffered
+// `res.send(result2geojson(esResponse) + bbox)` output). Same prefix/suffix sharing as the json envelope.
+export const geojsonBodyPrefix = (total: number | undefined | null): string =>
+  '{"type":"FeatureCollection"' + (total != null ? ',"total":' + total : '') + ',"features":['
+export const geojsonBodySuffix = (bbox: any): string =>
+  ']' + (bbox !== undefined ? ',"bbox":' + JSON.stringify(bbox) : '') + '}'
+export const buildGeojsonBody = (total: number | undefined | null, features: string[], bbox: any): string =>
+  geojsonBodyPrefix(total) + features.join(',') + geojsonBodySuffix(bbox)

--- a/api/src/datasets/routes/lines-body.ts
+++ b/api/src/datasets/routes/lines-body.ts
@@ -35,23 +35,28 @@ export const linkHeaderValue = (href: string): string => {
 // Accumulates the body of a /lines response (json/csv/geojson) as pre-encoded Buffer batches instead of
 // one monolithic string, so no single synchronous pass over the whole body ever blocks the event loop
 // (a large export used to block for seconds in join + Express's etag sha1 + utf8 encode inside res.send).
-// push() is fed the exact body substrings (separators included) and encodes them to a Buffer every
-// ~flushChars characters — amortized inside consumeHits' every-500-rows yield, so it needs no yields of
-// its own. finish() takes the envelope prefix/suffix (the prefix — total/next — is only known after the
-// last hit, but must be hashed first) and does the only remaining full-body passes: a sha1 walk yielding
-// every hashYieldBytes, and one Buffer.concat (pure memcpy). The returned etag is byte-identical to what
-// Express generates in res.send (the `etag` package's weak form) — the caller sets it as a header so
-// Express skips its own full-body hash.
+// push() is fed the exact body substrings (separators included); every ~flushChars characters they are
+// encoded to a Buffer AND fed to the sha1 — amortized inside consumeHits' every-500-rows yield, so the
+// accumulator needs no yields of its own. finish() takes the envelope prefix/suffix (the prefix —
+// total/next — is only known after the last hit) and only hashes those two + one Buffer.concat (pure
+// memcpy) — synchronous and O(envelope), not O(body).
+//
+// The etag is an OPAQUE deterministic content fingerprint, not Express's body hash: the hash input order
+// is rows → suffix → prefix (sha1 is sequential and the prefix arrives last), which is fine because an
+// etag only needs same-body ⇒ same-etag (across pods, restarts and flush batching — the prefix/rows split
+// is a deterministic function of the body) and any-change ⇒ different-etag (rows, suffix AND prefix are
+// all hashed — identical rows with a different envelope `total` must not 304). Same weak format as the
+// `etag` package (W/"<hex byte length>-<base64 sha1, 27 chars>"); the value differs, so deploying a
+// scheme change costs each cached client one revalidation miss — harmless.
 export class BodyAccumulator {
   private parts: Buffer[] = []
   private pending: string[] = []
   private pendingChars = 0
   private readonly flushChars: number
-  private readonly hashYieldBytes: number
+  private readonly hash = createHash('sha1')
 
-  constructor (opts?: { flushChars?: number, hashYieldBytes?: number }) {
+  constructor (opts?: { flushChars?: number }) {
     this.flushChars = opts?.flushChars ?? 64 * 1024
-    this.hashYieldBytes = opts?.hashYieldBytes ?? 2 * 1024 * 1024
   }
 
   push (chunk: string): void {
@@ -62,29 +67,22 @@ export class BodyAccumulator {
 
   private flush (): void {
     if (!this.pendingChars) return
-    this.parts.push(Buffer.from(this.pending.join('')))
+    const part = Buffer.from(this.pending.join(''))
+    this.hash.update(part)
+    this.parts.push(part)
     this.pending = []
     this.pendingChars = 0
   }
 
-  async finish (prefix: string, suffix: string): Promise<{ buffer: Buffer, etag: string }> {
+  finish (prefix: string, suffix: string): { buffer: Buffer, etag: string } {
     this.flush()
-    const parts = [Buffer.from(prefix), ...this.parts, Buffer.from(suffix)]
-    const hash = createHash('sha1')
-    let length = 0
-    let sinceYield = 0
-    for (const part of parts) {
-      hash.update(part)
-      length += part.length
-      sinceYield += part.length
-      if (sinceYield >= this.hashYieldBytes) {
-        sinceYield = 0
-        await new Promise(resolve => setImmediate(resolve))
-      }
-    }
-    // the `etag` package's weak format: W/"<byte length in hex>-<base64 sha1 truncated to 27 chars>"
-    const etag = `W/"${length.toString(16)}-${hash.digest('base64').substring(0, 27)}"`
-    return { buffer: Buffer.concat(parts), etag }
+    const prefixBuf = Buffer.from(prefix)
+    const suffixBuf = Buffer.from(suffix)
+    this.hash.update(suffixBuf)
+    this.hash.update(prefixBuf)
+    const buffer = Buffer.concat([prefixBuf, ...this.parts, suffixBuf])
+    const etag = `W/"${buffer.length.toString(16)}-${this.hash.digest('base64').substring(0, 27)}"`
+    return { buffer, etag }
   }
 }
 

--- a/api/src/datasets/routes/lines-pipeline.ts
+++ b/api/src/datasets/routes/lines-pipeline.ts
@@ -6,10 +6,15 @@
 //
 // Memory strategy: stream the SOURCE (bounded raw input via the splitter) and serialize each row
 // immediately, discarding the transformed objects — only the serialized bytes accumulate (flat
-// allocations, never the full parsed/transformed object graph that drove old-gen GC). The whole body is
-// then `res.send`. Because we assemble before sending, the last hit is known, so the response keeps its
-// full HTTP semantics: the `Link` header + body `next` pagination, a strong Express ETag / Content-Length,
-// and `304` on `If-None-Match`. A transform error throws before anything is sent → a clean HTTP status.
+// allocations, never the full parsed/transformed object graph that drove old-gen GC). Rows accumulate in a
+// BodyAccumulator (lines-body.ts): encoded to Buffers per ~64KB batch inside consumeHits' every-500-rows
+// yield, hashed in a yielded post-pass, so no synchronous pass over the WHOLE body ever blocks the event
+// loop (the previous single join + Express's full-body etag sha1 + utf8 encode inside res.send blocked for
+// seconds on large exports — an accept-queue-overflow / liveness-probe aggravator). The final
+// `res.send(buffer)` is one Buffer.concat memcpy. Because we assemble before sending, the last hit is
+// known, so the response keeps its full HTTP semantics: the `Link` header + body `next` pagination, the
+// same (weak, W/-prefixed — Express's default) ETag / Content-Length, and `304` on `If-None-Match`.
+// A transform error throws before anything is sent → a clean HTTP status.
 //
 // The output MUST be byte-identical to the pre-refactor buffered `readLines`:
 //   - JSON envelope: `{ hint?, total, next?, totalCollapse?, results:[…] }` (the exact key order Express's
@@ -27,9 +32,21 @@ import { attachQueryHint } from '../../misc/utils/query-advice.ts'
 import { reqDataset } from '../../misc/utils/req-context.ts'
 import { reqPublicBaseUrl } from '../../misc/utils/public-base-url.ts'
 import type { LinesSource } from './lines-source.ts'
-import { type NextContext, nextLinkHref, linkHeaderValue, buildJsonBody, buildGeojsonBody } from './lines-body.ts'
+import { type NextContext, nextLinkHref, linkHeaderValue, BodyAccumulator, jsonBodyPrefix, jsonBodySuffix, geojsonBodyPrefix, geojsonBodySuffix } from './lines-body.ts'
 
 export type { NextContext }
+
+// Send a pre-assembled body whose ETag was computed incrementally by the BodyAccumulator. Reproduces the
+// two things Express's res.send(string) did that res.send(Buffer) does not: append `; charset=utf-8` to
+// the content-type (set earlier via res.type) and set the ETag — pre-setting it makes Express skip its own
+// synchronous full-body sha1 while keeping `req.fresh` → 304 handling intact (it runs inside res.send,
+// after the ETag header check).
+const sendPrepared = (res: any, buffer: Buffer, etag: string): void => {
+  const type = res.get('Content-Type')
+  if (type && !type.includes('charset')) res.set('Content-Type', type + '; charset=utf-8')
+  res.set('ETag', etag)
+  res.status(200).send(buffer)
+}
 
 // Sets the `Link: <…>; rel=next` header on `res` when the page is full (both json and csv rely on it —
 // json additionally echoes the href in the body). Pure construction lives in lines-body.ts. Returns the
@@ -96,10 +113,12 @@ export async function streamJson (req: any, res: any, source: LinesSource, ctx: 
   const resultCtx = esUtils.prepareResultContext(dataset, query)
   resultCtx.rewriteAttachmentUrl = ctx.rewriteAttachmentUrl
 
-  // Serialize each row on the fly; keep only the row strings (no transformed-object graph retained).
-  const rows: string[] = []
+  // Serialize each row on the fly; keep only the encoded bytes (no transformed-object graph retained).
+  const acc = new BodyAccumulator()
+  let sep = ''
   const { count, lastHit } = await consumeHits(source, hit => {
-    rows.push(JSON.stringify(esUtils.prepareResultItem(hit, dataset, query, flatten, ctx.publicBaseUrl, resultCtx)))
+    acc.push(sep + JSON.stringify(esUtils.prepareResultItem(hit, dataset, query, flatten, ctx.publicBaseUrl, resultCtx)))
+    sep = ','
   })
   const tail = await safeTail(source)
 
@@ -117,7 +136,8 @@ export async function streamJson (req: any, res: any, source: LinesSource, ctx: 
   if (nextHref) head.next = nextHref
   if (query.collapse && tail?.aggregations?.totalCollapse) head.totalCollapse = tail.aggregations.totalCollapse.value
 
-  res.type('json').status(200).send(buildJsonBody(head, rows))
+  const { buffer, etag } = await acc.finish(jsonBodyPrefix(head), jsonBodySuffix)
+  sendPrepared(res.type('json'), buffer, etag)
 }
 
 export interface StreamCsvContext extends NextContext {
@@ -136,17 +156,19 @@ export async function streamCsv (req: any, res: any, source: LinesSource, ctx: S
   // Same compiled per-row serializer as the buffered export (results2csv / the old csvStreams Transform,
   // whose first push was `prologue + row(item)`): byte-identical output with no stream machinery — a
   // serializer throw propagates synchronously, before anything is sent, and there is no drain/error
-  // plumbing to get wrong. Only the row strings accumulate (no transformed-object graph retained).
+  // plumbing to get wrong. Only the encoded bytes accumulate (no transformed-object graph retained).
   // Assemble + res.send at the end so csv keeps its Link-header pagination (its only pagination signal)
   // + ETag / Content-Length. An empty result set still yields the header row (the prologue).
   const { prologue, row } = outputs.compileForRequest(dataset, query)
-  const parts: string[] = [prologue]
+  const acc = new BodyAccumulator()
+  acc.push(prologue)
   const { count, lastHit } = await consumeHits(source, hit => {
-    parts.push(row(esUtils.prepareResultItem(hit, dataset, query, flatten, publicBaseUrl, resultCtx)))
+    acc.push(row(esUtils.prepareResultItem(hit, dataset, query, flatten, publicBaseUrl, resultCtx)))
   })
 
   setNextLink(res, ctx, count, lastHit)
-  res.type('csv').status(200).send(parts.join(''))
+  const { buffer, etag } = await acc.finish('', '')
+  sendPrepared(res.type('csv'), buffer, etag)
 }
 
 export interface StreamGeojsonContext extends NextContext {
@@ -163,7 +185,8 @@ export async function streamGeojson (req: any, res: any, source: LinesSource, ct
   const flatten = getFlatten(dataset, true) // geojson preserves arrays (matches read.ts getFlatten(dataset, true))
   const publicBaseUrl = reqPublicBaseUrl(req)
 
-  const features: string[] = []
+  const acc = new BodyAccumulator()
+  let sep = ''
   const { count, lastHit } = await consumeHits(source, hit => {
     const feature = hit2feature(hit, flatten)
     // like json/csv: a searchStream source holds the raw stored _attachment_url → rewrite here (buffered
@@ -171,7 +194,8 @@ export async function streamGeojson (req: any, res: any, source: LinesSource, ct
     if (ctx.rewriteAttachmentUrl && feature.properties._attachment_url) {
       feature.properties._attachment_url = rewriteAttachmentUrl(feature.properties._attachment_url, dataset, publicBaseUrl)
     }
-    features.push(JSON.stringify(feature))
+    acc.push(sep + JSON.stringify(feature))
+    sep = ','
   })
   const tail = await safeTail(source) // drain the stream to completion; total lives in the envelope
   // ctx.bbox may be a promise (read.ts starts the bboxAgg round trip and lets it overlap the hit
@@ -180,5 +204,6 @@ export async function streamGeojson (req: any, res: any, source: LinesSource, ct
 
   setNextLink(res, ctx, count, lastHit)
   const total = tail?.hits?.total?.value
-  res.status(200).send(buildGeojsonBody(total, features, bbox))
+  const { buffer, etag } = await acc.finish(geojsonBodyPrefix(total), geojsonBodySuffix(bbox))
+  sendPrepared(res, buffer, etag)
 }

--- a/api/src/datasets/routes/lines-pipeline.ts
+++ b/api/src/datasets/routes/lines-pipeline.ts
@@ -7,14 +7,14 @@
 // Memory strategy: stream the SOURCE (bounded raw input via the splitter) and serialize each row
 // immediately, discarding the transformed objects — only the serialized bytes accumulate (flat
 // allocations, never the full parsed/transformed object graph that drove old-gen GC). Rows accumulate in a
-// BodyAccumulator (lines-body.ts): encoded to Buffers per ~64KB batch inside consumeHits' every-500-rows
-// yield, hashed in a yielded post-pass, so no synchronous pass over the WHOLE body ever blocks the event
-// loop (the previous single join + Express's full-body etag sha1 + utf8 encode inside res.send blocked for
+// BodyAccumulator (lines-body.ts): encoded to Buffers AND sha1-hashed per ~64KB batch inside consumeHits'
+// every-500-rows yield, so no synchronous pass over the WHOLE body ever blocks the event loop (the
+// previous single join + Express's full-body etag sha1 + utf8 encode inside res.send blocked for
 // seconds on large exports — an accept-queue-overflow / liveness-probe aggravator). The final
 // `res.send(buffer)` is one Buffer.concat memcpy. Because we assemble before sending, the last hit is
-// known, so the response keeps its full HTTP semantics: the `Link` header + body `next` pagination, the
-// same (weak, W/-prefixed — Express's default) ETag / Content-Length, and `304` on `If-None-Match`.
-// A transform error throws before anything is sent → a clean HTTP status.
+// known, so the response keeps its full HTTP semantics: the `Link` header + body `next` pagination, a
+// weak content-derived ETag (opaque fingerprint, see BodyAccumulator) / Content-Length, and `304` on
+// `If-None-Match`. A transform error throws before anything is sent → a clean HTTP status.
 //
 // The output MUST be byte-identical to the pre-refactor buffered `readLines`:
 //   - JSON envelope: `{ hint?, total, next?, totalCollapse?, results:[…] }` (the exact key order Express's
@@ -124,7 +124,7 @@ export async function streamJson (req: any, res: any, source: LinesSource, ctx: 
 
   // Head object in the exact key order the buffered result had: { hint, total, next?, totalCollapse? }.
   // Serialize it, strip the closing brace, and splice `,"results":[…]}` so the bytes equal JSON.stringify
-  // of the equivalent object (→ identical ETag). `next` also goes into the Link header.
+  // of the equivalent object. `next` also goes into the Link header.
   const head: Record<string, any> = {}
   const hint = (attachQueryHint(req, ctx.esSearchDurationMs, {}) as Record<string, any>).hint
   if (hint) head.hint = hint
@@ -136,7 +136,7 @@ export async function streamJson (req: any, res: any, source: LinesSource, ctx: 
   if (nextHref) head.next = nextHref
   if (query.collapse && tail?.aggregations?.totalCollapse) head.totalCollapse = tail.aggregations.totalCollapse.value
 
-  const { buffer, etag } = await acc.finish(jsonBodyPrefix(head), jsonBodySuffix)
+  const { buffer, etag } = acc.finish(jsonBodyPrefix(head), jsonBodySuffix)
   sendPrepared(res.type('json'), buffer, etag)
 }
 
@@ -167,7 +167,7 @@ export async function streamCsv (req: any, res: any, source: LinesSource, ctx: S
   })
 
   setNextLink(res, ctx, count, lastHit)
-  const { buffer, etag } = await acc.finish('', '')
+  const { buffer, etag } = acc.finish('', '')
   sendPrepared(res.type('csv'), buffer, etag)
 }
 
@@ -204,6 +204,6 @@ export async function streamGeojson (req: any, res: any, source: LinesSource, ct
 
   setNextLink(res, ctx, count, lastHit)
   const total = tail?.hits?.total?.value
-  const { buffer, etag } = await acc.finish(geojsonBodyPrefix(total), geojsonBodySuffix(bbox))
+  const { buffer, etag } = acc.finish(geojsonBodyPrefix(total), geojsonBodySuffix(bbox))
   sendPrepared(res, buffer, etag)
 }

--- a/api/src/datasets/routes/read.ts
+++ b/api/src/datasets/routes/read.ts
@@ -192,7 +192,7 @@ const readLines: RequestHandler = async (req, res) => {
   // request (ineligible) stays on the buffered search that yields a concrete esResponse consumed directly by
   // the geo/wkt/tile branches below.
   //
-  // TODO (shelved optimization): `res.send` already gives every /lines response a strong ETag + `304`. To
+  // TODO (shelved optimization): every /lines response already has a (weak, Express-default) ETag + `304`. To
   // also skip the ES query on a cache hit, compute a synthetic validator from what fully determines the body
   // (dataset.finalizedAt + normalized query + shaping params: select/html/thumbnail/truncate/arrays/format),
   // set it as the ETag, and short-circuit `If-None-Match` at the top of readLines — a 304 *before* the query,

--- a/tests/features/datasets/body-accumulator.unit.spec.ts
+++ b/tests/features/datasets/body-accumulator.unit.spec.ts
@@ -1,0 +1,52 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import etag from 'etag'
+import { BodyAccumulator, buildJsonBody } from '../../../api/src/datasets/routes/lines-body.ts'
+
+// The accumulator replaces the single monolithic join + Express-internal sha1 + utf8-encode of /lines
+// bodies with per-batch encoding and a yielded hash pass. Its contract: the final buffer is BYTE-IDENTICAL
+// to the string the old path sent, and the self-computed ETag is byte-identical to what Express would have
+// generated (weak etag of the body). The `etag` npm package (what Express uses) is the oracle.
+test.describe('BodyAccumulator (pure)', () => {
+  const expectEqualToString = async (acc: BodyAccumulator, prefix: string, suffix: string, expected: string) => {
+    const { buffer, etag: tag } = await acc.finish(prefix, suffix)
+    assert.equal(buffer.toString(), expected)
+    assert.equal(tag, etag(expected, { weak: true }))
+  }
+
+  test('bytes and etag match the buildJsonBody string and the etag package', async () => {
+    const head = { total: 2, next: 'http://x/lines?after=1' }
+    const rows = [JSON.stringify({ a: 'plain' }), JSON.stringify({ a: 'accented é 💥' })]
+    const acc = new BodyAccumulator()
+    rows.forEach((row, i) => acc.push(i === 0 ? row : ',' + row))
+    const headStr = JSON.stringify(head)
+    await expectEqualToString(acc, headStr.slice(0, -1) + ',"results":[', ']}', buildJsonBody(head, rows))
+  })
+
+  test('internal flushing at a tiny threshold does not change bytes or etag', async () => {
+    const acc = new BodyAccumulator({ flushChars: 4 })
+    const rows: string[] = []
+    for (let i = 0; i < 100; i++) {
+      const row = JSON.stringify({ i, s: 'é💥'.repeat(i % 7) })
+      rows.push(row)
+      acc.push(i === 0 ? row : ',' + row)
+    }
+    await expectEqualToString(acc, '{"results":[', ']}', buildJsonBody({}, rows))
+  })
+
+  test('empty body (no pushes) still yields the exact envelope and etag', async () => {
+    await expectEqualToString(new BodyAccumulator(), '{"results":[', ']}', '{"results":[]}')
+  })
+
+  test('hash pass yields between slices without altering the result', async () => {
+    // hashYieldBytes far below the body size forces many yield points in finish()
+    const acc = new BodyAccumulator({ flushChars: 32, hashYieldBytes: 64 })
+    const rows: string[] = []
+    for (let i = 0; i < 500; i++) {
+      const row = JSON.stringify({ i, pad: 'x'.repeat(20) })
+      rows.push(row)
+      acc.push(i === 0 ? row : ',' + row)
+    }
+    await expectEqualToString(acc, '{"results":[', ']}', buildJsonBody({}, rows))
+  })
+})

--- a/tests/features/datasets/body-accumulator.unit.spec.ts
+++ b/tests/features/datasets/body-accumulator.unit.spec.ts
@@ -1,52 +1,60 @@
 import { test } from '@playwright/test'
 import assert from 'node:assert/strict'
-import etag from 'etag'
 import { BodyAccumulator, buildJsonBody } from '../../../api/src/datasets/routes/lines-body.ts'
 
 // The accumulator replaces the single monolithic join + Express-internal sha1 + utf8-encode of /lines
-// bodies with per-batch encoding and a yielded hash pass. Its contract: the final buffer is BYTE-IDENTICAL
-// to the string the old path sent, and the self-computed ETag is byte-identical to what Express would have
-// generated (weak etag of the body). The `etag` npm package (what Express uses) is the oracle.
+// bodies with per-batch encoding and hashing inside the consume loop's yields. Its contract:
+//   - the final buffer is BYTE-IDENTICAL to the string the old path sent;
+//   - the ETag is an OPAQUE deterministic content fingerprint (weak format) — NOT Express's body hash.
+//     Same body ⇒ same etag (across pods/restarts/batching), any body change (rows OR envelope,
+//     e.g. a different `total` with identical rows) ⇒ different etag.
+//   - finish() is synchronous: hashing happened at flush time, only the concat remains.
 test.describe('BodyAccumulator (pure)', () => {
-  const expectEqualToString = async (acc: BodyAccumulator, prefix: string, suffix: string, expected: string) => {
-    const { buffer, etag: tag } = await acc.finish(prefix, suffix)
-    assert.equal(buffer.toString(), expected)
-    assert.equal(tag, etag(expected, { weak: true }))
+  const build = (rows: string[], prefix: string, suffix: string, flushChars?: number) => {
+    const acc = new BodyAccumulator(flushChars ? { flushChars } : undefined)
+    rows.forEach((row, i) => acc.push(i === 0 ? row : ',' + row))
+    return acc.finish(prefix, suffix)
   }
 
-  test('bytes and etag match the buildJsonBody string and the etag package', async () => {
+  const rows = [JSON.stringify({ a: 'plain' }), JSON.stringify({ a: 'accented é 💥' })]
+
+  test('bytes match the buildJsonBody string, finish is synchronous', () => {
     const head = { total: 2, next: 'http://x/lines?after=1' }
-    const rows = [JSON.stringify({ a: 'plain' }), JSON.stringify({ a: 'accented é 💥' })]
-    const acc = new BodyAccumulator()
-    rows.forEach((row, i) => acc.push(i === 0 ? row : ',' + row))
     const headStr = JSON.stringify(head)
-    await expectEqualToString(acc, headStr.slice(0, -1) + ',"results":[', ']}', buildJsonBody(head, rows))
+    const result = build(rows, headStr.slice(0, -1) + ',"results":[', ']}')
+    assert.ok(!(result instanceof Promise))
+    assert.equal(result.buffer.toString(), buildJsonBody(head, rows))
   })
 
-  test('internal flushing at a tiny threshold does not change bytes or etag', async () => {
-    const acc = new BodyAccumulator({ flushChars: 4 })
-    const rows: string[] = []
-    for (let i = 0; i < 100; i++) {
-      const row = JSON.stringify({ i, s: 'é💥'.repeat(i % 7) })
-      rows.push(row)
-      acc.push(i === 0 ? row : ',' + row)
-    }
-    await expectEqualToString(acc, '{"results":[', ']}', buildJsonBody({}, rows))
+  test('etag: weak format with the exact body byte length in hex', () => {
+    const { buffer, etag } = build(rows, '{"results":[', ']}')
+    const match = etag.match(/^W\/"([0-9a-f]+)-[A-Za-z0-9+/]{27}"$/)
+    assert.ok(match, `unexpected etag format: ${etag}`)
+    assert.equal(parseInt(match![1], 16), buffer.length)
   })
 
-  test('empty body (no pushes) still yields the exact envelope and etag', async () => {
-    await expectEqualToString(new BodyAccumulator(), '{"results":[', ']}', '{"results":[]}')
+  test('etag is deterministic and insensitive to flush batching', () => {
+    const reference = build(rows, '{"results":[', ']}')
+    assert.equal(build(rows, '{"results":[', ']}').etag, reference.etag)
+    // a tiny flush threshold changes the internal Buffer boundaries, never the etag or the bytes
+    const tiny = build(rows, '{"results":[', ']}', 4)
+    assert.equal(tiny.etag, reference.etag)
+    assert.equal(tiny.buffer.toString(), reference.buffer.toString())
   })
 
-  test('hash pass yields between slices without altering the result', async () => {
-    // hashYieldBytes far below the body size forces many yield points in finish()
-    const acc = new BodyAccumulator({ flushChars: 32, hashYieldBytes: 64 })
-    const rows: string[] = []
-    for (let i = 0; i < 500; i++) {
-      const row = JSON.stringify({ i, pad: 'x'.repeat(20) })
-      rows.push(row)
-      acc.push(i === 0 ? row : ',' + row)
-    }
-    await expectEqualToString(acc, '{"results":[', ']}', buildJsonBody({}, rows))
+  test('etag changes when any part of the body changes, envelope included', () => {
+    const reference = build(rows, '{"results":[', ']}').etag
+    // different rows
+    assert.notEqual(build([rows[0]], '{"results":[', ']}').etag, reference)
+    // identical rows, different envelope head (e.g. total changed while the page did not)
+    assert.notEqual(build(rows, '{"total":3,"results":[', ']}').etag, reference)
+    // identical rows, different suffix
+    assert.notEqual(build(rows, '{"results":[', ']},').etag, reference)
+  })
+
+  test('empty body (no pushes) still yields the exact envelope and a valid etag', () => {
+    const { buffer, etag } = build([], '{"results":[', ']}')
+    assert.equal(buffer.toString(), '{"results":[]}')
+    assert.match(etag, /^W\/"e-[A-Za-z0-9+/]{27}"$/) // 14 bytes = 0xe
   })
 })

--- a/tests/features/datasets/lines-pipeline.unit.spec.ts
+++ b/tests/features/datasets/lines-pipeline.unit.spec.ts
@@ -2,6 +2,7 @@ import { test } from '@playwright/test'
 import assert from 'node:assert/strict'
 import { PassThrough } from 'node:stream'
 import path from 'node:path'
+import etag from 'etag'
 
 // The api result/csv modules import `#config` at module load (config.ts validates on import). The unit
 // harness doesn't set NODE_CONFIG_DIR, so point node-config at the real api/config dir — same pattern
@@ -49,13 +50,17 @@ const load = async () => ({
 })
 
 // A real Writable (streamCsv uses transform.pipe(res)) with the express Response chaining helpers
-// bolted on. Collects everything written and resolves `_done` with the concatenated bytes on end.
+// bolted on, including a header map — sendPrepared reads back Content-Type (to append the charset the
+// way res.send(string) did) and sets the ETag, so parity tests can assert both against the oracle.
+// Collects everything written and resolves `_done` with the concatenated bytes on end.
 const fakeRes = () => {
   const res: any = new PassThrough()
-  res.type = function () { return this }
+  res._headers = {}
+  res.type = function (t: string) { this._headers['content-type'] = 'application/' + t; return this }
   res.status = function () { return this }
-  res.setHeader = function () { return this }
-  res.set = function () { return this }
+  res.setHeader = function (k: string, v: string) { this._headers[k.toLowerCase()] = v; return this }
+  res.set = function (k: string, v: string) { this._headers[k.toLowerCase()] = v; return this }
+  res.get = function (k: string) { return this._headers[k.toLowerCase()] }
   res.send = function (body: any) { this.end(body); return this }
   const chunks: Buffer[] = []
   res.on('data', (c: Buffer) => chunks.push(Buffer.from(c)))
@@ -75,7 +80,13 @@ test.describe('lines-pipeline parity', () => {
 
     const res = fakeRes()
     await streamJson(req, res, bufferedSource(esResponse()), { publicBaseUrl, esSearchDurationMs: 0 })
-    const streamed = JSON.parse((await res._done).toString())
+    const rawBody = await res._done
+    const streamed = JSON.parse(rawBody.toString())
+
+    // the incrementally computed ETag must equal what Express's res.send(string) would have generated,
+    // and the charset res.send(string) appended must be reproduced
+    assert.equal(res.get('ETag'), etag(rawBody.toString(), { weak: true }))
+    assert.equal(res.get('Content-Type'), 'application/json; charset=utf-8')
 
     // reference built the CURRENT (buffered) way
     const esResp = esResponse()
@@ -110,6 +121,8 @@ test.describe('lines-pipeline parity', () => {
     const refCsv = await outputs.results2csv(req, referenceRows)
 
     assert.equal(bytes.toString(), refCsv)
+    assert.equal(res.get('ETag'), etag(bytes.toString(), { weak: true }))
+    assert.equal(res.get('Content-Type'), 'application/csv; charset=utf-8')
   })
 })
 

--- a/tests/features/datasets/lines-pipeline.unit.spec.ts
+++ b/tests/features/datasets/lines-pipeline.unit.spec.ts
@@ -2,7 +2,6 @@ import { test } from '@playwright/test'
 import assert from 'node:assert/strict'
 import { PassThrough } from 'node:stream'
 import path from 'node:path'
-import etag from 'etag'
 
 // The api result/csv modules import `#config` at module load (config.ts validates on import). The unit
 // harness doesn't set NODE_CONFIG_DIR, so point node-config at the real api/config dir — same pattern
@@ -83,9 +82,12 @@ test.describe('lines-pipeline parity', () => {
     const rawBody = await res._done
     const streamed = JSON.parse(rawBody.toString())
 
-    // the incrementally computed ETag must equal what Express's res.send(string) would have generated,
-    // and the charset res.send(string) appended must be reproduced
-    assert.equal(res.get('ETag'), etag(rawBody.toString(), { weak: true }))
+    // the incrementally computed ETag: weak format carrying the exact body byte length (the hash part
+    // is an opaque content fingerprint — see BodyAccumulator — asserted by its own unit spec), and the
+    // charset that res.send(string) used to append must be reproduced
+    const jsonEtag = res.get('ETag').match(/^W\/"([0-9a-f]+)-[A-Za-z0-9+/]{27}"$/)
+    assert.ok(jsonEtag, `unexpected etag format: ${res.get('ETag')}`)
+    assert.equal(parseInt(jsonEtag[1], 16), rawBody.length)
     assert.equal(res.get('Content-Type'), 'application/json; charset=utf-8')
 
     // reference built the CURRENT (buffered) way
@@ -121,7 +123,9 @@ test.describe('lines-pipeline parity', () => {
     const refCsv = await outputs.results2csv(req, referenceRows)
 
     assert.equal(bytes.toString(), refCsv)
-    assert.equal(res.get('ETag'), etag(bytes.toString(), { weak: true }))
+    const csvEtag = res.get('ETag').match(/^W\/"([0-9a-f]+)-[A-Za-z0-9+/]{27}"$/)
+    assert.ok(csvEtag, `unexpected etag format: ${res.get('ETag')}`)
+    assert.equal(parseInt(csvEtag[1], 16), bytes.length)
     assert.equal(res.get('Content-Type'), 'application/csv; charset=utf-8')
   })
 })

--- a/tests/features/infra/lines-stream-parity.unit.spec.ts
+++ b/tests/features/infra/lines-stream-parity.unit.spec.ts
@@ -82,13 +82,16 @@ const gen = (seed: number) => {
 // A Node Readable that emits the buffer in fixed-size chunks (drives the splitter across boundaries).
 const chunked = (buf: Buffer, size: number) => Readable.from((function * () { for (let i = 0; i < buf.length; i += size) yield buf.subarray(i, i + size) })())
 
-// A real Writable with the express Response chaining helpers bolted on (mirrors lines-pipeline.unit.spec).
+// A real Writable with the express Response chaining helpers bolted on, including a header map —
+// sendPrepared reads back Content-Type and sets the ETag (mirrors lines-pipeline.unit.spec).
 const fakeRes = () => {
   const res: any = new PassThrough()
-  res.type = function () { return this }
+  res._headers = {}
+  res.type = function (t: string) { this._headers['content-type'] = 'application/' + t; return this }
   res.status = function () { return this }
-  res.setHeader = function () { return this }
-  res.set = function () { return this }
+  res.setHeader = function (k: string, v: string) { this._headers[k.toLowerCase()] = v; return this }
+  res.set = function (k: string, v: string) { this._headers[k.toLowerCase()] = v; return this }
+  res.get = function (k: string) { return this._headers[k.toLowerCase()] }
   res.send = function (body: any) { this.end(body); return this }
   const chunks: Buffer[] = []
   res.on('data', (c: Buffer) => chunks.push(Buffer.from(c)))


### PR DESCRIPTION
Production pods were killed by the liveness probe during connection bursts: the kernel accept queue (default backlog 511) overflowed (`TcpExt ListenOverflows` = 3527 in ~90 min on one pod), dropping SYNs including the probe's, and large `/lines` exports widened the window by blocking the event loop for seconds (accept() shares the single thread).

- `/lines` json/csv/geojson bodies are now assembled by a `BodyAccumulator`: rows encoded to Buffers and sha1-hashed per ~64KB batch inside the consume loop's existing yields, replacing three synchronous full-body passes (join + Express's etag sha1 + utf8 encode in `res.send`). The only remaining whole-body synchronous op is one `Buffer.concat` memcpy. No size threshold — one code path for all responses.
- The ETag is now an opaque deterministic content fingerprint (same weak format, hash order rows→suffix→prefix, envelope included). Bytes, charset, `Link` header, body `next`, `Content-Length`, 304 handling and bandwidth throttling are unchanged and test-asserted.
- HTTP accept backlog raised 511 → 4096 at both `listen` sites (nodes have `somaxconn=4096`).

**Why:** stop the recurring probe-kill restarts without blocking abusive IPs — make the server robust to bursts instead (companion infra changes: relaxed probe, per-IP `limit-connections` at the ingress).

**Heads-up:** ETag *values* change on deploy, so every cached client revalidation misses once (full refetch, then normal 304s resume). Mixed old/new pods during the rolling deploy briefly amplify this.
