### PR TITLE
perf(datasets): reduce CPU and memory churn in the indexing and extension workers

### DIFF
--- a/api/config/custom-environment-variables.cjs
+++ b/api/config/custom-environment-variables.cjs
@@ -350,6 +350,10 @@ module.exports = {
     __name: 'EXTENSION_UPDATE_DELAY',
     __format: 'json'
   },
+  extensionsBatchSize: {
+    __name: 'EXTENSIONS_BATCH_SIZE',
+    __format: 'json'
+  },
   compatODS: {
     __name: 'COMPAT_ODS',
     __format: 'json'

--- a/api/config/default.cjs
+++ b/api/config/default.cjs
@@ -330,6 +330,10 @@ module.exports = {
   assertImmutable: false,
   remoteAttachmentCacheDuration: 1000 * 5,
   extensionUpdateDelay: 600,
+  // lines per request to a remote service (and per extensions-cache bulk read/write) when
+  // applying extensions. Large enough that the per-batch fixed costs (HTTP request, cache
+  // round-trips) stay marginal, small enough to bound the lines held in memory per batch.
+  extensionsBatchSize: 250,
   compatODS: false,
   apiKeysMaxDuration: 2 * 365, // in days
   apiKeysExpirationCron: '0 3 * * *', // daily at 3 AM, scan apiKeys expireAt and notify J-3 / J

--- a/api/config/type/schema.json
+++ b/api/config/type/schema.json
@@ -49,6 +49,7 @@
     "assertImmutable",
     "remoteAttachmentCacheDuration",
     "extensionUpdateDelay",
+    "extensionsBatchSize",
     "apiKeysMaxDuration",
     "apiKeysExpirationCron"
   ],
@@ -474,6 +475,9 @@
       "type": "number"
     },
     "extensionUpdateDelay": {
+      "type": "number"
+    },
+    "extensionsBatchSize": {
       "type": "number"
     },
     "compatODS": {

--- a/api/src/datasets/es/index-stream.ts
+++ b/api/src/datasets/es/index-stream.ts
@@ -16,6 +16,10 @@ interface IndexStreamOptions {
   refresh?: boolean | string
   updateMode?: boolean
   attachments?: boolean
+  // re-emit indexed lines on the readable side. Only the REST path consumes them
+  // (markIndexedStream); file datasets pipe into a no-op sink, so skipping the
+  // re-emit avoids a full per-line object copy.
+  reemit?: boolean
 }
 
 // remove some properties that must not be indexed
@@ -49,6 +53,7 @@ class IndexStream extends Transform {
     super({ objectMode: true })
     this.options = options
     this.options.refresh = this.options.refresh || false
+    this.options.reemit = this.options.reemit ?? true
     this.applyCalculations = extensionsUtils.prepareCalculations(options.dataset)
     this.body = []
     this.items = []
@@ -136,10 +141,12 @@ class IndexStream extends Transform {
       if (this.options.attachments) bulkOpts.pipeline = 'attachment'
       const res: any = await es.client.bulk(bulkOpts)
       debug('Bulk sent OK')
-      for (let i = 0; i < res.items.length; i++) {
-        const item = res.items[i]
-        const _id = (item.index && item.index._id) || (item.update && item.update._id) || (item.delete && item.delete._id)
-        this.push({ _id, ...this.items[i] })
+      if (this.options.reemit) {
+        for (let i = 0; i < res.items.length; i++) {
+          const item = res.items[i]
+          const _id = (item.index && item.index._id) || (item.update && item.update._id) || (item.delete && item.delete._id)
+          this.push({ _id, ...this.items[i] })
+        }
       }
       if (res.errors) {
         for (let i = 0; i < res.items.length; i++) {

--- a/api/src/datasets/es/index-stream.ts
+++ b/api/src/datasets/es/index-stream.ts
@@ -31,7 +31,15 @@ const maxErroredItems = 3
 
 class IndexStream extends Transform {
   options: IndexStreamOptions
-  body: any[]
+  // pre-serialized ndjson lines for the ES bulk request. Serializing here (instead of
+  // letting the ES client serialize the objects) means each line is stringified exactly
+  // once: the string is used both for the maxBulkChars accounting and for the request
+  // (the transport's ndserialize passes strings through untouched).
+  body: string[]
+  // the line objects of the current batch, one entry per bulk operation, kept for
+  // error reporting and (REST only) re-emitting on the readable side
+  items: any[]
+  applyCalculations: (item: any) => Promise<string | null>
   bulkChars: number
   i: number
   nbErroredItems: number
@@ -41,7 +49,9 @@ class IndexStream extends Transform {
     super({ objectMode: true })
     this.options = options
     this.options.refresh = this.options.refresh || false
+    this.applyCalculations = extensionsUtils.prepareCalculations(options.dataset)
     this.body = []
+    this.items = []
     this.bulkChars = 0
     this.i = 0
     this.nbErroredItems = 0
@@ -51,28 +61,29 @@ class IndexStream extends Transform {
   async transformPromise (item: any, encoding?: BufferEncoding) {
     let warning
     if (this.options.updateMode) {
-      warning = await extensionsUtils.applyCalculations(this.options.dataset, item.doc)
+      warning = await this.applyCalculations(item.doc)
       const keys = Object.keys(item.doc)
       if (keys.length === 0 || (keys.length === 1 && keys[0] === '_i')) return
-      this.body.push({ update: { _index: this.options.indexName, _id: item.id, retry_on_conflict: 3 } })
-      cleanItem(item.doc)
-      this.body.push({ doc: cleanItem(item.doc) })
-      this.bulkChars += JSON.stringify(item.doc).length
+      this.body.push(JSON.stringify({ update: { _index: this.options.indexName, _id: item.id, retry_on_conflict: 3 } }))
+      const docStr = JSON.stringify({ doc: cleanItem(item.doc) })
+      this.body.push(docStr)
+      this.items.push(item.doc)
+      this.bulkChars += docStr.length
     } else if (item._deleted) {
-      const params = { delete: { _index: this.options.indexName, _id: item._id } }
-      // kinda lame, but pushing the delete query twice keeps parity of the body size that we use in reporting results
-      this.body.push(params)
-      this.body.push(item)
+      this.body.push(JSON.stringify({ delete: { _index: this.options.indexName, _id: item._id } }))
+      this.items.push(item)
     } else {
       cleanItem(item)
       const params: any = { index: { _index: this.options.indexName } }
       // nanoid will prevent risks of collision even when assembling in virtual datasets
       params.index._id = item._id || nanoid()
       delete item._id
-      this.body.push(params)
-      warning = await extensionsUtils.applyCalculations(this.options.dataset, item)
-      this.body.push(item)
-      this.bulkChars += JSON.stringify(item).length
+      warning = await this.applyCalculations(item)
+      this.body.push(JSON.stringify(params))
+      const itemStr = JSON.stringify(item)
+      this.body.push(itemStr)
+      this.items.push(item)
+      this.bulkChars += itemStr.length
     }
     if (warning) {
       this.nbErroredItems += 1
@@ -82,7 +93,7 @@ class IndexStream extends Transform {
     this.i += 1
 
     if (
-      this.body.length / 2 >= config.elasticsearch.maxBulkLines ||
+      this.items.length >= config.elasticsearch.maxBulkLines ||
         this.bulkChars >= config.elasticsearch.maxBulkChars
     ) {
       await this.sendBulk()
@@ -113,13 +124,10 @@ class IndexStream extends Transform {
   }
 
   async sendBulk () {
-    if (this.body.length === 0) return
-    debug(`Send ${this.body.length} lines to bulk indexing`)
-    const bodyClone: any[] = this.body.slice()
+    if (this.items.length === 0) return
+    debug(`Send ${this.items.length} lines to bulk indexing`)
     const bulkOpts: any = {
-      // ES does not want the doc along with a delete instruction,
-      // but we put it in body anyway for our outgoing/reporting logic
-      body: this.body.filter(line => !line._deleted),
+      body: this.body,
       timeout: '4m',
       refresh: this.options.refresh
     }
@@ -131,15 +139,14 @@ class IndexStream extends Transform {
       for (let i = 0; i < res.items.length; i++) {
         const item = res.items[i]
         const _id = (item.index && item.index._id) || (item.update && item.update._id) || (item.delete && item.delete._id)
-        const line = this.options.updateMode ? bodyClone[(i * 2) + 1].doc : bodyClone[(i * 2) + 1]
-        this.push({ _id, ...line })
+        this.push({ _id, ...this.items[i] })
       }
       if (res.errors) {
         for (let i = 0; i < res.items.length; i++) {
           const item = {
-            _i: (this.options.updateMode ? bodyClone[(i * 2) + 1].doc : bodyClone[(i * 2) + 1])._i,
+            _i: this.items[i]._i,
             error: (res.items[i].index && res.items[i].index.error) || (res.items[i].update && res.items[i].update.error),
-            input: this.body[(i * 2) + 1]
+            input: this.items[i]
           }
           if (!item.error) continue
 
@@ -153,6 +160,7 @@ class IndexStream extends Transform {
         }
       }
       this.body = []
+      this.items = []
       this.bulkChars = 0
     } catch (err) {
       internalError('es-bulk-index', err)

--- a/api/src/datasets/utils/data-streams.ts
+++ b/api/src/datasets/utils/data-streams.ts
@@ -387,7 +387,7 @@ export const sampleValues = async (dataset: Dataset, ignoreKeys?: string[], onDe
         finished = false
         const value = typeof chunk[key] !== 'string' ? '' + chunk[key] : chunk[key]
         // prevent too costly sniffing by truncating long strings
-        sampleValues[key].add(value.length > 300 ? value.slice(300) : value)
+        sampleValues[key].add(value.length > 300 ? value.slice(0, 300) : value)
       }
       currentLine += 1
 

--- a/api/src/datasets/utils/extensions.ts
+++ b/api/src/datasets/utils/extensions.ts
@@ -499,13 +499,13 @@ async function prepareInputMapping (action: any, dataset: Dataset, extensionKey:
     )
     return field && [field.key, input.name, field]
   }).filter(Boolean)
+  // resolved once per extension run, not once per line
+  const calculate = fieldMappings.some((mapping: any) => mapping[2]['x-calculated']) ? prepareCalculations(dataset) : null
   return async (item: any) => {
     const mappedItem: any = {}
     const flatItem = flatten<any, any>(item) // in case the input comes from another extension
 
-    if (fieldMappings.find((mapping: any) => mapping[2]['x-calculated'])) {
-      await applyCalculations(dataset, flatItem)
-    }
+    if (calculate) await calculate(flatItem)
 
     for (const mapping of fieldMappings) {
       const val = flatItem[mapping[0]]
@@ -636,62 +636,77 @@ export const checkExtensions = async (schema: any[], extensions: any[] = []) => 
   return null
 }
 
-export const applyCalculations = async (dataset: Dataset, item: any) => {
-  let warning = null
-  const flatItem = flatten<any, any>(item, { safe: true })
-
-  // Add base64 content of attachments
+// Prepare a per-line calculated-fields function for a dataset. Everything that only
+// depends on the dataset (schema scans, geo concept detection, separator fields) is
+// resolved once here instead of once per line — this runs for every line of every
+// indexed dataset. The flattened copy of the line is only built when a consumer
+// (attachment or geo calculation) actually needs it.
+export const prepareCalculations = (dataset: Dataset) => {
   const attachmentField = dataset.schema?.find(f => f['x-refersTo'] === 'http://schema.org/DigitalDocument')
-  if (attachmentField && flatItem[attachmentField.key]) {
-    const attachmentValue = flatItem[attachmentField.key]
-    const isURL = !!parseURL(attachmentValue).host
-    if (!isURL) {
-      item._attachment_url = `${config.publicUrl}/api/v1/datasets/${dataset.id}/attachments/${attachmentValue}`
-      const filePath = attachmentPath(dataset, attachmentValue)
-      if (await filesStorage.pathExists(filePath)) {
-        const stats = await filesStorage.fileStats(filePath)
+  const hasGeopoint = geoUtils.schemaHasGeopoint(dataset.schema)
+  const hasGeometry = geoUtils.schemaHasGeometry(dataset.schema)
+  const separatorFields = (dataset.schema ?? []).filter(f => f.separator)
+  const needsFlatten = !!attachmentField || hasGeopoint || hasGeometry
 
-        if (!attachmentField['x-capabilities'] || attachmentField['x-capabilities'].indexAttachment !== false) {
-          // -1 is the "unlimited" sentinel used across config.defaultLimits (see storage.ts)
-          if (config.defaultLimits.attachmentIndexed !== -1 && stats.size > config.defaultLimits.attachmentIndexed) {
-            warning = 'Pièce jointe trop volumineuse pour être analysée'
-          } else {
-            const buf = await arrayBuffer((await filesStorage.readStream(filePath)).body)
-            item._file_raw = Buffer.from(buf).toString('base64')
+  return async (item: any): Promise<string | null> => {
+    let warning: string | null = null
+    const flatItem = needsFlatten ? flatten<any, any>(item, { safe: true }) : null
+
+    // Add base64 content of attachments
+    if (attachmentField && flatItem?.[attachmentField.key]) {
+      const attachmentValue = flatItem[attachmentField.key]
+      const isURL = !!parseURL(attachmentValue).host
+      if (!isURL) {
+        item._attachment_url = `${config.publicUrl}/api/v1/datasets/${dataset.id}/attachments/${attachmentValue}`
+        const filePath = attachmentPath(dataset, attachmentValue)
+        if (await filesStorage.pathExists(filePath)) {
+          const stats = await filesStorage.fileStats(filePath)
+
+          if (!attachmentField['x-capabilities'] || attachmentField['x-capabilities'].indexAttachment !== false) {
+            // -1 is the "unlimited" sentinel used across config.defaultLimits (see storage.ts)
+            if (config.defaultLimits.attachmentIndexed !== -1 && stats.size > config.defaultLimits.attachmentIndexed) {
+              warning = 'Pièce jointe trop volumineuse pour être analysée'
+            } else {
+              const buf = await arrayBuffer((await filesStorage.readStream(filePath)).body)
+              item._file_raw = Buffer.from(buf).toString('base64')
+            }
           }
         }
       }
     }
-  }
 
-  // calculate geopoint and geometry fields depending on concepts
-  if (geoUtils.schemaHasGeopoint(dataset.schema)) {
-    try {
-      Object.assign(item, geoUtils.latlon2fields(dataset, flatItem))
-    } catch (err: any) {
-      console.log('failure to parse geopoints', dataset.id, err, flatItem)
-      warning = 'Coordonnée géographique non valide - ' + err.message
+    // calculate geopoint and geometry fields depending on concepts
+    if (hasGeopoint) {
+      try {
+        Object.assign(item, geoUtils.latlon2fields(dataset, flatItem!))
+      } catch (err: any) {
+        console.log('failure to parse geopoints', dataset.id, err, flatItem)
+        warning = 'Coordonnée géographique non valide - ' + err.message
+      }
+    } else if (hasGeometry) {
+      try {
+        Object.assign(item, await geoUtils.geometry2fields(dataset, flatItem!))
+      } catch (err: any) {
+        console.log('failure to parse geometry', dataset.id, err, flatItem)
+        warning = 'Géométrie non valide - ' + err.message
+      }
     }
-  } else if (geoUtils.schemaHasGeometry(dataset.schema)) {
-    try {
-      Object.assign(item, await geoUtils.geometry2fields(dataset, flatItem))
-    } catch (err: any) {
-      console.log('failure to parse geometry', dataset.id, err, flatItem)
-      warning = 'Géométrie non valide - ' + err.message
-    }
-  }
 
-  // Pseudo-random number for the _rand sampling sort. Intentionally NOT seeded from the line id:
-  // _rand is stored at index time, and pagination tie-breaks on the unique _i, so nothing needs it
-  // to be reproducible (a full reindex just reshuffles the random order). This replaces random-seed,
-  // whose per-line ARC4 key scheduling was ~69% of the indexing-thread CPU.
-  item._rand = Math.floor(Math.random() * 1000000)
+    // Pseudo-random number for the _rand sampling sort. Intentionally NOT seeded from the line id:
+    // _rand is stored at index time, and pagination tie-breaks on the unique _i, so nothing needs it
+    // to be reproducible (a full reindex just reshuffles the random order). This replaces random-seed,
+    // whose per-line ARC4 key scheduling was ~69% of the indexing-thread CPU.
+    item._rand = Math.floor(Math.random() * 1000000)
 
-  // split the fields that have a separator in their schema
-  for (const field of dataset.schema ?? []) {
-    if (field.separator && typeof item[field.key] === 'string') {
-      item[field.key] = item[field.key].split((field.separator as string).trim()).map((part: string) => part.trim())
+    // split the fields that have a separator in their schema
+    for (const field of separatorFields) {
+      if (typeof item[field.key] === 'string') {
+        item[field.key] = item[field.key].split((field.separator as string).trim()).map((part: string) => part.trim())
+      }
     }
+    return warning
   }
-  return warning
 }
+
+// compatibility wrapper for per-line callers; prefer prepareCalculations(dataset) reused across lines
+export const applyCalculations = async (dataset: Dataset, item: any) => prepareCalculations(dataset)(item)

--- a/api/src/datasets/utils/extensions.ts
+++ b/api/src/datasets/utils/extensions.ts
@@ -522,12 +522,20 @@ async function prepareInputMapping (action: any, dataset: Dataset, extensionKey:
   const calculate = fieldMappings.some((mapping: any) => mapping[2]['x-calculated']) ? prepareCalculations(dataset) : null
   return async (item: any) => {
     const mappedItem: any = {}
-    const flatItem = flatten<any, any>(item) // in case the input comes from another extension
+    // flatten the row lazily: it is only needed when an input value is nested (comes
+    // from another extension's result object) or computed by a calculated field — for
+    // plain scalar columns (the common case) reading the own property directly avoids
+    // a full copy of the row per line
+    let flatItem: any = null
+    const getFlatItem = () => { flatItem = flatItem ?? flatten<any, any>(item); return flatItem }
 
-    if (calculate) await calculate(flatItem)
+    if (calculate) await calculate(getFlatItem())
 
     for (const mapping of fieldMappings) {
-      const val = flatItem[mapping[0]]
+      let val = (flatItem ?? item)[mapping[0]]
+      // missing keys and object/array values defer to the flattened view, where they
+      // resolve exactly as before (nested value or dropped)
+      if (val === undefined || (typeof val === 'object' && val !== null)) val = getFlatItem()[mapping[0]]
       if (val !== undefined && val !== '') mappedItem[mapping[1]] = val
     }
     return mappedItem

--- a/api/src/datasets/utils/extensions.ts
+++ b/api/src/datasets/utils/extensions.ts
@@ -707,6 +707,3 @@ export const prepareCalculations = (dataset: Dataset) => {
     return warning
   }
 }
-
-// compatibility wrapper for per-line callers; prefer prepareCalculations(dataset) reused across lines
-export const applyCalculations = async (dataset: Dataset, item: any) => prepareCalculations(dataset)(item)

--- a/api/src/datasets/utils/extensions.ts
+++ b/api/src/datasets/utils/extensions.ts
@@ -279,7 +279,7 @@ class ExtensionsStream extends Transform {
   async transformPromise (item: any) {
     this.i += 1
     this.buffer.push(item)
-    if (this.i % 1000 === 0) await this.sendBuffer()
+    if (this.buffer.length >= config.extensionsBatchSize) await this.sendBuffer()
   }
 
   _transform (item: any, encoding: BufferEncoding, cb: (err?: Error) => void) {

--- a/api/src/datasets/utils/extensions.ts
+++ b/api/src/datasets/utils/extensions.ts
@@ -25,7 +25,7 @@ import * as fieldsSniffer from './fields-sniffer.ts'
 import intoStream from 'into-stream'
 import { getFlatten } from './flatten.ts'
 import type { Dataset, DatasetLine } from '#types'
-import type { Document, Filter, WithId } from 'mongodb'
+import type { AnyBulkWriteOperation, Document, Filter, WithId } from 'mongodb'
 import { isRestDataset } from '#types/dataset/index.ts'
 import filesStorage from '#files-storage'
 import { arrayBuffer } from 'stream/consumers'
@@ -349,7 +349,7 @@ class ExtensionsStream extends Transform {
         if (extension.select && extension.select.length) {
           opts.params.select = extension.select.join(',')
         }
-        const inputs = []
+        const inputs: any[] = []
         for (const i in this.buffer) {
           const input = await extension.inputMapping(this.buffer[i])
           input[extension.idInput.name] = i
@@ -360,22 +360,34 @@ class ExtensionsStream extends Transform {
         debug('is extension local ?', localMasterData, extension.remoteService.server, `${config.publicUrl}/api/v1/datasets/`)
 
         // TODO: no need to use a cache in the special case of a locale master-data dataset ?
-        const inputCacheKeys = inputs.map(input => stringify([input, extension.select || []]))
+        // stringify cannot return undefined here (the input is always an array)
+        const inputCacheKeys = inputs.map(input => stringify([input, extension.select || []])!)
         const extensionCacheKey = extension.remoteService + '/' + extension.action
-        // first get previous results from cache
+        // first get previous results from cache, in bulk: one $in query on the
+        // {extensionKey, input} index and one lastUsed bump, instead of one
+        // findOneAndUpdate round-trip per line
+        const cachedOutputs = new Map<string, any>()
+        if (!localMasterData) {
+          const usableCacheKeys = inputCacheKeys.filter((_, i) => Object.keys(inputs[i]).length > 1)
+          if (usableCacheKeys.length) {
+            const cursor = mongo.db.collection('extensions-cache')
+              .find({ extensionKey: extensionCacheKey, input: { $in: usableCacheKeys } })
+            for await (const cachedValue of cursor) {
+              cachedOutputs.set(cachedValue.input, cachedValue.output)
+            }
+            if (cachedOutputs.size) {
+              await mongo.db.collection('extensions-cache')
+                .updateMany({ extensionKey: extensionCacheKey, input: { $in: [...cachedOutputs.keys()] } }, { $set: { lastUsed: new Date() } })
+            }
+          }
+        }
         for (let i = 0; i < inputs.length; i++) {
           if (Object.keys(inputs[i]).length === 1) continue
-          let cachedValue
-          if (!localMasterData) {
-            // TODO: read cached values in a bulk read ?
-            cachedValue = await mongo.db.collection('extensions-cache')
-              .findOneAndUpdate({ extensionKey: extensionCacheKey, input: inputCacheKeys[i] }, { $set: { lastUsed: new Date() } })
-          }
-
-          if (cachedValue) {
-            const hasChanges = applyExtensionResult(extension.extensionKey, overwrittenKeys, this.buffer[i], cachedValue.output, this.onlyEmitChanges, separatorOutput)
+          if (cachedOutputs.has(inputCacheKeys[i])) {
+            const output = cachedOutputs.get(inputCacheKeys[i])
+            const hasChanges = applyExtensionResult(extension.extensionKey, overwrittenKeys, this.buffer[i], output, this.onlyEmitChanges, separatorOutput)
             if (hasChanges) changesIndexes.add(i)
-            await reportLineError(i, cachedValue.output)
+            await reportLineError(i, output)
           } else opts.data += JSON.stringify(inputs[i]) + '\n'
         }
         if (!opts.data) continue
@@ -401,6 +413,7 @@ class ExtensionsStream extends Transform {
         if (typeof data === 'object') data = JSON.stringify(data) // axios parses the object when there is only one
         const results = data.split('\n').filter((line: string) => !!line).map(JSON.parse)
 
+        const cacheWriteOps: AnyBulkWriteOperation[] = []
         for (const result of results) {
           const selectFields = extension.select || []
           const selectedResult = Object.keys(result)
@@ -409,19 +422,25 @@ class ExtensionsStream extends Transform {
 
           const i = result[extension.idInput.name]
           if (!localMasterData) {
-            // TODO: do this in bulk ?
-            await mongo.db.collection('extensions-cache')
-              .replaceOne(
-                { extensionKey: extensionCacheKey, input: inputCacheKeys[i] },
-                { extensionKey: extensionCacheKey, input: inputCacheKeys[i], lastUsed: new Date(), output: selectedResult },
-                { upsert: true }
-              )
+            cacheWriteOps.push({
+              replaceOne: {
+                filter: { extensionKey: extensionCacheKey, input: inputCacheKeys[i] },
+                replacement: { extensionKey: extensionCacheKey, input: inputCacheKeys[i], lastUsed: new Date(), output: selectedResult },
+                upsert: true
+              }
+            })
           }
 
           const hasChanges = applyExtensionResult(extension.extensionKey, overwrittenKeys, this.buffer[i], selectedResult, this.onlyEmitChanges, separatorOutput)
           if (hasChanges) changesIndexes.add(i)
 
           await reportLineError(i, selectedResult)
+        }
+        // single round-trip for all cache writes of the batch. Ordered, so duplicate
+        // inputs within a batch upsert-then-replace sequentially like the per-line
+        // writes did (the {extensionKey, input} index is not unique)
+        if (cacheWriteOps.length) {
+          await mongo.db.collection('extensions-cache').bulkWrite(cacheWriteOps)
         }
       } else if (extension.evaluate && extension.property) {
         for (const i in this.buffer) {

--- a/api/src/datasets/utils/rest.ts
+++ b/api/src/datasets/utils/rest.ts
@@ -39,7 +39,7 @@ import type { NextFunction, Response, RequestHandler } from 'express'
 import { reqSessionAuthenticated, reqUserAuthenticated, type Account, type SessionStateAuthenticated } from '@data-fair/lib-express'
 import { type ValidateFunction } from 'ajv'
 import { type RequestWithRestDataset } from '#types/dataset/index.ts'
-import type { Collection, Filter, UpdateFilter } from 'mongodb'
+import type { AnyBulkWriteOperation, Collection, Filter, UpdateFilter } from 'mongodb'
 import iterHits from '../es/iter-hits.ts'
 import { pipeline } from 'node:stream/promises'
 import { isInFilesStorage } from '../../files-storage/utils.ts'
@@ -1385,6 +1385,14 @@ export const writeExtendedStreams = (dataset: RestDataset, extensions: RestDatas
     if (extension.type === 'exprEval') patchedKeys.push(extension.property.key)
   }
   const c = collection(dataset)
+  // batched write-back: one bulkWrite per batch instead of one updateOne round-trip per line
+  let bulkOps: AnyBulkWriteOperation<DatasetLine>[] = []
+  const flush = async () => {
+    if (!bulkOps.length) return
+    const ops = bulkOps
+    bulkOps = []
+    await c.bulkWrite(ops, { ordered: false })
+  }
   return [new Writable({
     objectMode: true,
     async write (item, encoding, cb) {
@@ -1394,7 +1402,16 @@ export const writeExtendedStreams = (dataset: RestDataset, extensions: RestDatas
           if (key in item && patch.$set) patch.$set[key] = item[key]
           else if (patch.$unset) patch.$unset[key] = item[key]
         }
-        await c.updateOne({ _id: item._id }, patch)
+        bulkOps.push({ updateOne: { filter: { _id: item._id }, update: patch } })
+        if (bulkOps.length >= config.mongo.maxBulkOps) await flush()
+        cb()
+      } catch (err: any) {
+        cb(err)
+      }
+    },
+    async final (cb) {
+      try {
+        await flush()
         cb()
       } catch (err: any) {
         cb(err)

--- a/api/src/workers/batch-processor/index-lines.ts
+++ b/api/src/workers/batch-processor/index-lines.ts
@@ -88,7 +88,9 @@ export default async function (dataset: DatasetInternal) {
     debug(`Initialize new dataset index ${indexName}`)
   }
 
-  const indexStream = getIndexStream({ indexName, dataset, attachments: !!attachmentsProperty })
+  // only the REST path consumes the re-emitted lines (markIndexedStream); for file
+  // datasets the sink is a no-op, so skip the per-line copy on the readable side
+  const indexStream = getIndexStream({ indexName, dataset, attachments: !!attachmentsProperty, reemit: isRestDataset(dataset) })
 
   if (!dataset.extensions || dataset.extensions.filter(e => e.active).length === 0) {
     if (dataset.file && await filesStorage.pathExists(datasetUtils.fullFilePath(dataset))) {

--- a/tests/features/datasets/extensions/extensions-core.api.spec.ts
+++ b/tests/features/datasets/extensions/extensions-core.api.spec.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import fs from 'fs-extra'
 import FormData from 'form-data'
 import { axiosAuth, clean, checkPendingTasks } from '../../../support/axios.ts'
-import { waitForFinalize, sendDataset, waitForDatasetError, setupMockRoute, clearMockRoutes } from '../../../support/workers.ts'
+import { waitForFinalize, sendDataset, waitForDatasetError, setupMockRoute, clearMockRoutes, getMockReceivedRequests } from '../../../support/workers.ts'
 
 const testUser1 = await axiosAuth('test_user1@test.com')
 const testSuperadmin = await axiosAuth('test_superadmin@test.com', undefined, true)
@@ -142,6 +142,52 @@ test.describe('Extensions (core)', () => {
     assert.equal(res.status, 200)
     assert.ok(res.data.find((file: any) => file.key === 'original'))
     assert.ok(!res.data.find((file: any) => file.key === 'full'))
+  })
+
+  test('Extend dataset across multiple extension batches', async () => {
+    const ax = testUser1
+    await setupCoordsMock(10)
+
+    // 600 lines with distinct addresses > extensionsBatchSize (250) so the extension
+    // runs in 3 batches (250 + 250 + 100), exercising the batched cache reads/writes
+    const nbLines = 600
+    let content = 'label,adr\n'
+    for (let i = 0; i < nbLines; i++) content += `line${i},${i} rue de la paix paris\n`
+    let form = new FormData()
+    form.append('file', content, 'dataset-batches.csv')
+    let res = await ax.post('/api/v1/datasets', form, { headers: { 'Content-Length': form.getLengthSync(), ...form.getHeaders() } })
+    let dataset = await waitForFinalize(ax, res.data.id)
+
+    dataset.schema.find((field: any) => field.key === 'adr')['x-refersTo'] = 'http://schema.org/address'
+    res = await ax.patch(`/api/v1/datasets/${dataset.id}`, {
+      schema: dataset.schema,
+      extensions: [{ active: true, type: 'remoteService', remoteService: 'geocoder-koumoul', action: 'postCoords' }]
+    })
+    assert.equal(res.status, 200)
+    dataset = await waitForFinalize(ax, dataset.id)
+    const extensionKey = dataset.extensions[0].propertyPrefix
+
+    // every line of every batch was extended
+    res = await ax.get(`/api/v1/datasets/${dataset.id}/lines`, { params: { size: 1000, select: '*' } })
+    assert.equal(res.data.total, nbLines)
+    assert.equal(res.data.results.filter((l: any) => l[extensionKey + '.lat'] === 10).length, nbLines)
+
+    // one request to the remote service per batch of extensionsBatchSize (250)
+    const requests1 = (await getMockReceivedRequests()).filter(r => r.path === '/geocoder/coords')
+    assert.equal(requests1.length, Math.ceil(nbLines / 250))
+
+    // re-upload the same content: all results must be replayed from extensions-cache
+    // without any new request to the remote service
+    form = new FormData()
+    form.append('file', content, 'dataset-batches.csv')
+    res = await ax.post(`/api/v1/datasets/${dataset.id}`, form, { headers: { 'Content-Length': form.getLengthSync(), ...form.getHeaders() } })
+    assert.equal(res.status, 200)
+    await waitForFinalize(ax, dataset.id)
+    res = await ax.get(`/api/v1/datasets/${dataset.id}/lines`, { params: { size: 1000, select: '*' } })
+    assert.equal(res.data.total, nbLines)
+    assert.equal(res.data.results.filter((l: any) => l[extensionKey + '.lat'] === 10).length, nbLines)
+    const requests2 = (await getMockReceivedRequests()).filter(r => r.path === '/geocoder/coords')
+    assert.equal(requests2.length, requests1.length)
   })
 
   test('Extend dataset that was previouly converted', async () => {


### PR DESCRIPTION
Reduce CPU and memory churn in the dataset workers:

- serialize each line exactly once when bulk indexing, and stop re-emitting indexed lines for file datasets (the sink is a no-op there)
- prepare per-dataset calculations (schema scans, geo detection, separator fields) once instead of per line, and flatten rows lazily
- read and write the extensions cache in bulk (one `$in` query + one `bulkWrite` per batch instead of per-line round-trips), and batch the REST extension write-back into a single unordered `bulkWrite`
- make the extension batch size configurable (`EXTENSIONS_BATCH_SIZE`, default 250 instead of the hardcoded 1000) to bound the lines held in memory per batch
- fix the analysis sampling truncation that kept the tail of long values instead of their first 300 chars

**Why:** worker pods spend significant CPU on per-line redundant work (double serialization, per-line schema scans, per-line Mongo round-trips) and hold full 1000-line batches in memory during extensions.

**Heads-up:**
- extension runs now issue ~4× more (smaller) HTTP requests to remote services; tune with `EXTENSIONS_BATCH_SIZE` if a service rate-limits by request count
- type sniffing on columns with values > 300 chars may detect differently on re-analysis (that's the truncation fix)
