### PR TITLE
fix(datasets): send spreadsheet normalizeOptions as JSON on dataset creation

### DIFF
--- a/ui/src/pages/new-dataset.vue
+++ b/ui/src/pages/new-dataset.vue
@@ -703,8 +703,8 @@ async function createFileDataset () {
     formData.append('dataset_encoding', fileEncoding.value)
   }
 
-  for (const [key, val] of Object.entries(normalizeOptions.value)) {
-    if (val !== undefined) formData.append(key, String(val))
+  if (Object.keys(normalizeOptions.value).length) {
+    formData.append('dataset_normalizeOptions', JSON.stringify(normalizeOptions.value))
   }
 
   const body: Record<string, any> = {}


### PR DESCRIPTION
The dataset creation form appended `spreadsheetHeaderLine` / `spreadsheetWorksheetIndex` / `spreadsheetStartCol` as loose top-level form fields, but the upload handler only reads them from a single `dataset_normalizeOptions` JSON field. The options were silently dropped, so header row / worksheet / start column settings set in the UI never reached the backend — the file was always parsed with header auto-detection instead.

**Why:** surfaced while debugging a user's xlsx import failing on a file whose header row has to be set manually (row 1 is a merged section-title row, real headers are on row 3). Auto-detection only skips genuinely empty leading rows, so it picked row 1 as the header and broke CSV sniffing on that file's embedded quote characters.
