### PR TITLE
feat(datasets): add a fullscreen button to the paginated dataset table

### DIFF
--- a/ui/src/components/dataset/table/dataset-table-card.vue
+++ b/ui/src/components/dataset/table/dataset-table-card.vue
@@ -128,7 +128,7 @@
 <script setup lang="ts">
 import { type DatasetFilter } from '~/composables/dataset/filters'
 import { type ExtendedResult, type ExtendedResultValue } from '~/composables/dataset/lines'
-import { type TableHeaderWithProperty } from './use-headers'
+import { type TableHeaderWithProperty, type TableSort } from './use-headers'
 import { findEqFilter } from '~/composables/dataset/filters'
 import { mdiSortAscending, mdiSortDescending, mdiMenuDown, mdiMagnifyPlus } from '@mdi/js'
 
@@ -142,7 +142,7 @@ const { headers } = defineProps({
   hovered: { type: Object as () => ExtendedResultValue, default: null }
 })
 
-const sort = defineModel<{ direction: 1 | -1, key: string }>('sort')
+const sort = defineModel<TableSort>('sort')
 
 const emit = defineEmits<{
   hide: [header: TableHeaderWithProperty],

--- a/ui/src/components/dataset/table/dataset-table.vue
+++ b/ui/src/components/dataset/table/dataset-table.vue
@@ -75,6 +75,14 @@
         :selected-cols="cols"
         :total="total"
       />
+      <v-btn
+        v-if="fullscreenTo"
+        :title="t('fullscreen')"
+        :icon="mdiOpenInNew"
+        :to="fullscreenTo"
+        color="primary"
+        size="large"
+      />
     </v-btn-group>
   </v-toolbar>
   <v-toolbar
@@ -441,6 +449,7 @@
     helpFilterPrompt: Aide-moi à filtrer ces données
     checkDataQualityPrompt: Vérifier la qualité de ces données
     helpEditDataPrompt: Aide-moi à saisir des données
+    fullscreen: Afficher en plein écran
   en:
     cancel: Cancel
     delete: Delete
@@ -451,14 +460,16 @@
     deleteLine: Delete a line
     deleteLineWarning: Warning, the data from this line will be lost permanently
     helpEditDataPrompt: Help me enter data
+    fullscreen: Show fullscreen
 </i18n>
 
 <script setup lang="ts">
+import type { RouteLocationRaw } from 'vue-router'
 import type { VVirtualScroll, VForm } from 'vuetify/components'
-import { mdiSortDescending, mdiSortAscending, mdiMenuDown, mdiClose, mdiChevronLeft, mdiChevronRight } from '@mdi/js'
+import { mdiSortDescending, mdiSortAscending, mdiMenuDown, mdiClose, mdiChevronLeft, mdiChevronRight, mdiOpenInNew } from '@mdi/js'
 import useLines, { type ExtendedResultValue, type ExtendedResult } from '../../../composables/dataset/lines'
 import { dateTimeZoneLabel } from '../../../composables/dataset/format-date-logic'
-import useHeaders, { TableHeaderWithProperty, type TableHeader, type SyntheticColumn } from './use-headers'
+import useHeaders, { TableHeaderWithProperty, type TableHeader, type SyntheticColumn, type TableSort } from './use-headers'
 import { provideDatasetEdition } from './use-dataset-edition'
 import { useDisplay } from 'vuetify'
 import { DatasetLine, type SchemaProperty } from '#api/types'
@@ -470,7 +481,7 @@ const asyncDatasetMap = defineAsyncComponent(() => import('~/components/dataset/
 const asyncDatasetTableHeaderActions = defineAsyncComponent(() => import('~/components/dataset/table/dataset-table-header-actions.vue'))
 const asyncDatasetEditLineForm = defineAsyncComponent(() => import('~/components/dataset/form/dataset-edit-line-form.vue'))
 
-const { height, noInteraction, edit, selectable, pagination, searchOnly, syntheticColumns, headerKeys } = defineProps({
+const { height, noInteraction, edit, selectable, pagination, searchOnly, syntheticColumns, headerKeys, fullscreenTo } = defineProps({
   height: { type: Number, default: 800 },
   noInteraction: { type: Boolean, default: false },
   edit: { type: Boolean, default: false },
@@ -479,6 +490,7 @@ const { height, noInteraction, edit, selectable, pagination, searchOnly, synthet
   searchOnly: { type: Boolean, default: false },
   syntheticColumns: { type: Array as () => SyntheticColumn[], default: () => [] },
   headerKeys: { type: Boolean, default: false },
+  fullscreenTo: { type: Object as () => RouteLocationRaw, default: undefined },
 })
 
 const displayMode = defineModel<string>('display', { default: 'table' })
@@ -506,8 +518,8 @@ const pageSize = computed(() => {
   return Math.ceil(((height / lineHeight.value) + 4) / 20) * 20
 })
 
-const sort = computed<{ key: string, direction: 1 | -1 } | undefined>({
-  get () {
+const sort = computed<TableSort | undefined>({
+  get (): TableSort | undefined {
     if (!sortStr.value) return undefined
     if (sortStr.value.startsWith('-')) return { direction: -1, key: sortStr.value.slice(1) }
     return { direction: 1, key: sortStr.value }

--- a/ui/src/components/dataset/table/use-headers.ts
+++ b/ui/src/components/dataset/table/use-headers.ts
@@ -28,6 +28,7 @@ export type TableHeader = {
 }
 
 export type TableHeaderWithProperty = Omit<TableHeader, 'property'> & Required<Pick<TableHeader, 'property'>>
+export type TableSort = { key: string, direction: 1 | -1 }
 
 // transform a schema key into a string usable in a CSS selector (id/class/activator) ;
 // keys can contain dots but also slashes, accents, spaces, etc. that would break querySelector

--- a/ui/src/pages/dataset/[id]/index.vue
+++ b/ui/src/pages/dataset/[id]/index.vue
@@ -183,6 +183,7 @@
           <dataset-table
             :height="windowHeight - 300"
             :pagination="true"
+            :fullscreen-to="{ path: `/dataset/${route.params.id}/table`, query: route.query }"
           />
         </v-tabs-window-item>
 


### PR DESCRIPTION
The exploration tab on `/dataset/:id` mounts the table in pagination mode at a constrained height, and nothing linked it to the full page view that already exists at `/dataset/:id/table` — you had to know the URL.

- new opt-in `fullscreenTo` prop on `dataset-table` renders a link at the end of the toolbar button group (display / columns / download); the page passes the target route, so the component keeps knowing nothing about back-office routing and the embed pages are untouched
- the route carries the current query, so active filters survive the jump: `useFilters` already writes them to the URL as `<key>_<operator>=<value>`, so `route.query` *is* the filters. `q` / columns / sort / display are component-local state and deliberately reset — syncing those to the URL would mean reworking `/dataset/:id`, which carries other tabs
- drive-by: `TableSort` extracted into `use-headers` and the `sort` getter return type annotated — the `1 | -1` literals were widened to `number`, breaking the `WritableComputedOptions` overload resolution (an IDE-visible error; the repo's vue-tsc does not flag it)

**Why:** on a wide dataset, filtering in the exploration tab leaves too little room to actually read the result.

**Heads-up:** `dataset-table` is shared with `/embed/dataset/:id/table`, a hot path — the button is opt-in and sits under the existing `v-if="!noInteraction"` toolbar, and the embed rendering is unchanged. The `TableSort` rename also touches `dataset-table-card` (card display mode). No test covers the filter transport yet.
