### PR TITLE
fix(rate-limiting): stop endParts throw and send-slot leak on abort

### DIFF
--- a/api/src/misc/utils/rate-limiting.ts
+++ b/api/src/misc/utils/rate-limiting.ts
@@ -250,14 +250,32 @@ const buildMiddleware = (_limitType) => async (req, res, next) => {
     res.endParts = (parts: Buffer[]) => {
       if (endPartsCalled) return // mirror the wrapped res.end's reentrancy protection
       endPartsCalled = true
+      // the client may have disconnected while the body was being assembled: drop the parts. pipeline()
+      // into an already-closed res throws ERR_STREAM_UNABLE_TO_PIPE SYNCHRONOUSLY (bypassing `done`) and
+      // would leak the send slot acquired by res.throttle (the Throttle is never wired into the pipeline,
+      // so the 'close' that releases the slot never fires) — leaked slots saturate the client's bucket
+      // until the queue-full guard tears down every one of its responses
+      if (res.destroyed || res.closed || res.writableEnded) return
       const source = Readable.from((function * () { while (parts.length) yield parts.shift()! })())
       const done = (err: NodeJS.ErrnoException | null) => {
         // teardowns are expected, not actionable: client aborts surface as premature-close, and a
         // queue-full res.destroy() (inside res.throttle) is already counted + debug-logged there
         if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE' && !res.destroyed) console.warn('failed to send response parts', err)
       }
-      if (ignoreRateLimiting) pipeline(source, res, done)
-      else pipeline(source, res.throttle(bandwidthType), res, done)
+      if (ignoreRateLimiting) {
+        pipeline(source, res, done)
+        return
+      }
+      const throttle = res.throttle(bandwidthType)
+      try {
+        pipeline(source, throttle, res, done)
+      } catch (err) {
+        // pipeline() can still throw synchronously instead of reporting through `done` (e.g. the
+        // queue-full teardown inside res.throttle returns an already-destroyed stream): destroy the
+        // throttle so its send slot is released, and route the error like the async failures
+        throttle.destroy()
+        done(err as NodeJS.ErrnoException)
+      }
     }
 
     if (ignoreRateLimiting) return // res.end stays original; endParts above skips the throttle

--- a/docs/architecture/read-lines-efficiency.md
+++ b/docs/architecture/read-lines-efficiency.md
@@ -43,6 +43,17 @@ bandwidth throttling. The old 2×-body concat transient is gone **and memory dec
 instead of pinning ~1× body for the duration of a slow-client throttled download (the prod heap
 profile's "transient assemble-then-send body/Buffer" spike, ~1.2 GB external).
 
+One teardown subtlety (a post-release prod incident): the client can disconnect while the body is still
+being *assembled*, so `res` may already be destroyed when `res.endParts` runs — and on node ≥ 24
+`pipeline()` into a closed stream throws `ERR_STREAM_UNABLE_TO_PIPE` *synchronously*, bypassing its
+callback. Unhandled, that both surfaced as internal errors and permanently leaked the send slot
+`res.throttle()` had just acquired (the Throttle is never wired, so the `'close'` that releases the slot
+never fires) — after `maxPendingSends` aborted requests the client's bucket was saturated and the
+queue-full guard tore down every later response. `res.endParts` therefore drops the parts up front when
+`res` is already destroyed/closed/ended, and wraps the `pipeline()` call to destroy the throttle (freeing
+the slot) on any residual synchronous throw (e.g. the queue-full teardown returns an already-destroyed
+stream). Pinned by `rate-limiting-end-parts.unit.spec.ts`, which drives the real middleware.
+
 Peak drops to ~1× the payload at assembly time (bounded per request by `maxPageSize`), decaying during
 the send. Going lower would require true output streaming, i.e. giving up the response contract — the
 deliberate trade is to stop at ~1×.

--- a/tests/features/infra/rate-limiting-end-parts.unit.spec.ts
+++ b/tests/features/infra/rate-limiting-end-parts.unit.spec.ts
@@ -1,0 +1,93 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import { PassThrough } from 'node:stream'
+import { maxPendingSends } from '../../../api/src/misc/utils/throttle-wait.ts'
+
+// The real res.endParts installed by res.throttleEnd (rate-limiting.ts), driven through the actual
+// middleware. Pins the production incident of 2026-07: a client disconnecting while the /lines body was
+// still being assembled left `res` destroyed by the time sendPreparedParts called res.endParts — on
+// node >= 24 pipeline() then throws ERR_STREAM_UNABLE_TO_PIPE SYNCHRONOUSLY (bypassing its callback),
+// so 1. the error escaped to the global handler (the internal-error spike) and 2. the send slot
+// acquired by res.throttle leaked forever (the Throttle is never wired, its 'close' never fires) —
+// after maxPendingSends aborted requests, EVERY later response of that client (per-IP bucket for
+// anonymous) was torn down by the queue-full guard.
+
+// rate-limiting.ts imports `#config` at module load: point node-config at the real api/config dir and
+// load via dynamic import, same pattern as lines-pipeline.unit.spec.ts
+process.env.NODE_CONFIG_DIR ??= path.resolve(import.meta.dirname, '../../../api/config')
+
+const load = async () => ({
+  ...await import('../../../api/src/misc/utils/rate-limiting.ts'),
+  session: (await import('@data-fair/lib-express/index.js')).session
+})
+
+// minimal express-like request: enough for the session middleware (headers/cookies) and the rate
+// limiter (client ip via x-forwarded-for, req.get for the ignore-rate-limiting header)
+const fakeReq = () => {
+  const headers: Record<string, string> = { 'x-forwarded-for': '9.9.9.9' }
+  return {
+    headers,
+    method: 'GET',
+    query: {},
+    socket: { remoteAddress: '9.9.9.9' },
+    get (name: string) { return headers[name.toLowerCase()] },
+    __: (key: string) => key // only used by the 429 paths — present so an unexpected 429 fails legibly
+  } as any
+}
+
+// a real Writable so destroy/close/pipeline semantics are the genuine stream ones
+const fakeRes = () => {
+  const res: any = new PassThrough()
+  res.status = function () { return this }
+  res.type = function () { return this }
+  res.send = function (body: any) { this.end(body); return this }
+  return res
+}
+
+// run the session middleware (anonymous, no cookies — resolves without JWKS) then the rate-limiting
+// middleware, then install the throttled end helpers like a /lines route does
+const preparedRes = async (mod: Awaited<ReturnType<typeof load>>) => {
+  const req = fakeReq()
+  const res = fakeRes()
+  await mod.session.middleware()(req, res, () => {})
+  await mod.middleware(req, res, () => {})
+  res.throttleEnd()
+  return res
+}
+
+test.describe('res.endParts on a torn-down response', () => {
+  test('does not throw when the client disconnected during body assembly', async () => {
+    const mod = await load()
+    mod.clear()
+    const res = await preparedRes(mod)
+    res.destroy() // client disconnects while the body is still being assembled
+    // before the fix: pipeline() throws ERR_STREAM_UNABLE_TO_PIPE synchronously
+    res.endParts([Buffer.from('part1'), Buffer.from('part2')])
+  })
+
+  test('does not leak send slots (queue-full starvation guard)', async () => {
+    const mod = await load()
+    mod.clear()
+    // one more aborted send than the cap: if each one leaks its slot, the client's bucket is
+    // permanently saturated and every later response is torn down by the queue-full guard
+    for (let i = 0; i <= maxPendingSends; i++) {
+      // stay under the request-count limit (100/s in the dev config this spec runs with): pause one
+      // refill window partway through the loop — this test is about the bandwidth send slots, not 429s
+      if (i === maxPendingSends - 10) await new Promise(resolve => setTimeout(resolve, 1100))
+      const res = await preparedRes(mod)
+      res.destroy()
+      try { res.endParts([Buffer.from('x')]) } catch {} // swallow the pre-fix sync throw: this test pins the leak
+    }
+    // a live response from the same client must still be served
+    const res = await preparedRes(mod)
+    const body = new Promise<string>((resolve, reject) => {
+      const chunks: Buffer[] = []
+      res.on('data', (c: Buffer) => chunks.push(c))
+      res.on('end', () => resolve(Buffer.concat(chunks).toString()))
+      res.on('close', () => reject(new Error('response was torn down: leaked send slots exhausted the client bucket')))
+    })
+    res.endParts([Buffer.from('hello '), Buffer.from('world')])
+    assert.equal(await body, 'hello world')
+  })
+})


### PR DESCRIPTION
Fixes the production internal-error spikes on `/lines` after the 6.17.0 release (the sequential-write send path, #497).

When a client disconnects while the body is still being **assembled**, `res` is already destroyed by the time `res.endParts` pipes the parts — and on node ≥ 24 `pipeline()` into a closed stream throws `ERR_STREAM_UNABLE_TO_PIPE` **synchronously**, bypassing its error callback. Two consequences in prod:

- the throw escaped to the global handler on every mid-assembly disconnect (the logged error spikes);
- the send slot acquired by `res.throttle()` leaked forever (the Throttle is never wired into a pipeline, so the `'close'` that releases the slot never fires) — after `maxPendingSends` (100) aborted requests, every later response on that client's per-IP bucket was torn down by the queue-full guard, likely amplifying the spike through retries.

`res.endParts` now drops the parts when `res` is already destroyed/closed/ended, and wraps the `pipeline()` call so a residual synchronous throw destroys the throttle (releasing its slot) and routes through the normal teardown-tolerant error path — this also covers the queue-full teardown inside `res.throttle`, which returns an already-destroyed stream (same sync-throw hazard).

Pinned by `rate-limiting-end-parts.unit.spec.ts`, which drives the real middleware and reproduced both failure modes before the fix. Architecture doc updated.

**Heads-up:** the concurrent `s3 readStream error … aborted` logs from the incident are the pre-existing download path logging the same client-abort storm — not addressed here. A disconnect during assembly still lets the ES paging run to completion; short-circuiting that is a possible follow-up.
