### PR TITLE
chore: retire the listenWhenReady option, always open the port only when ready

### DIFF
--- a/agent-tools/aggregate-data.ts
+++ b/agent-tools/aggregate-data.ts
@@ -70,7 +70,7 @@ export interface Params {
 
 export function buildQuery (params: Params): { path: string, query: Record<string, string> } {
   const query: Record<string, string> = {
-    field: params.groupByColumns.join(';')
+    field: params.groupByColumns.join(',')
   }
   if (params.metric && params.metric.type && params.metric.type !== 'count') {
     query.metric = params.metric.type

--- a/api/config/custom-environment-variables.cjs
+++ b/api/config/custom-environment-variables.cjs
@@ -229,10 +229,6 @@ module.exports = {
       __format: 'json'
     },
   },
-  listenWhenReady: {
-    __name: 'LISTEN_WHEN_READY',
-    __format: 'json'
-  },
   applications: {
     __name: 'APPLICATIONS',
     __format: 'json'

--- a/api/config/default.cjs
+++ b/api/config/default.cjs
@@ -1,7 +1,6 @@
 module.exports = {
   mode: 'server_worker', // can be server_worker, server or worker
   port: 8080,
-  listenWhenReady: false,
   publicUrl: 'http://localhost:8080',
   oldPublicUrl: '', // special case when changing path of data-fair
   wsPublicUrl: 'ws://localhost:8080',

--- a/api/config/type/schema.json
+++ b/api/config/type/schema.json
@@ -61,9 +61,6 @@
     "port": {
       "type": "number"
     },
-    "listenWhenReady": {
-      "type": "boolean"
-    },
     "publicUrl": {
       "type": "string"
     },

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -79,10 +79,6 @@ export const run = async () => {
     })
 
     app.use((await import('cors')).default())
-    app.use((req, res, next) => {
-      if (!req.app.get('api-ready')) res.status(503).type('text/plain').send('Service indisponible pour cause de maintenance.')
-      else next()
-    })
 
     const bodyParser = express.json({ limit: '1000kb' })
     app.use((req, res, next) => {
@@ -248,15 +244,6 @@ export const run = async () => {
     server.keepAliveTimeout = (60 * 1000) + 1000
     server.headersTimeout = (60 * 1000) + 2000
     server.requestTimeout = (15 * 60 * 1000)
-
-    if (!config.listenWhenReady) {
-      // deep accept backlog: a single thread does both accept() and request work, so any event-loop hitch
-      // pauses accepting and connections queue in the kernel. The default 511 overflowed in production
-      // (TcpExt ListenOverflows) under connection bursts, dropping SYNs incl. the liveness probe's.
-      // Requires net.core.somaxconn >= 4096 on the node (checked: 4096), the kernel clamps silently otherwise.
-      server.listen({ port: config.port, backlog: 4096 })
-      await eventPromise(server, 'listening')
-    }
   }
 
   await mongo.init()
@@ -324,21 +311,14 @@ export const run = async () => {
         return permissions.can(type, resource, `realtime-${subject}`, sessionState, bypassPermissions)
       })
     ])
-    // At this stage the server is ready to respond to API requests
-    app.set('api-ready', true)
 
-    app.use((req, res, next) => {
-      if (!req.app.get('ui-ready')) res.status(503).type('text/plain').send('Service indisponible pour cause de maintenance.')
-      else next()
-    })
-
-    app.set('ui-ready', true)
-
-    if (config.listenWhenReady) {
-      // see the early listen above for the backlog rationale
-      server.listen({ port: config.port, backlog: 4096 })
-      await eventPromise(server, 'listening')
-    }
+    // at this stage the server is fully ready to respond to requests, we can open the port
+    // deep accept backlog: a single thread does both accept() and request work, so any event-loop hitch
+    // pauses accepting and connections queue in the kernel. The default 511 overflowed in production
+    // (TcpExt ListenOverflows) under connection bursts, dropping SYNs incl. the liveness probe's.
+    // Requires net.core.somaxconn >= 4096 on the node (checked: 4096), the kernel clamps silently otherwise.
+    server.listen({ port: config.port, backlog: 4096 })
+    await eventPromise(server, 'listening')
   }
 
   if (config.observer.active) {

--- a/tests/features/agent-tools/data-tools.unit.spec.ts
+++ b/tests/features/agent-tools/data-tools.unit.spec.ts
@@ -182,9 +182,9 @@ test.describe('aggregate_data buildQuery', () => {
     assert.equal(query.field, 'status')
   })
 
-  test('joins multiple group-by columns with semicolon', () => {
+  test('joins multiple group-by columns with comma', () => {
     const { query } = aggregateData.buildQuery({ datasetId: 'ds1', groupByColumns: ['city', 'status'] })
-    assert.equal(query.field, 'city;status')
+    assert.equal(query.field, 'city,status')
   })
 
   test('includes metric params when not count', () => {


### PR DESCRIPTION
Retire the `listenWhenReady` config option: the HTTP port is now always opened only once the service is fully initialized (mongo, ES, routers, websocket server), which was the opt-in `LISTEN_WHEN_READY=true` behavior already used in production.

- remove the early-listen path and the option from config (`default.cjs`, env mapping, config schema)
- remove the `api-ready` / `ui-ready` 503 maintenance gates, dead code once no request can arrive before initialization completes

**Why:** two boot paths for no benefit; listening before being able to serve is the less correct behavior.

**Heads-up:**
- Deployments that did *not* set `LISTEN_WHEN_READY` now open the port later in startup — startup/readiness probe timing should tolerate this (production already ran this way).
- The `LISTEN_WHEN_READY` env var is now an ignored no-op; the deployment manifests have been cleaned in the infrastructure repo.
