### PR TITLE
fix(datasets): sync cols, sort and display with the URL in the table views

### DIFF
--- a/tests/features/ui/dataset-pages.e2e.spec.ts
+++ b/tests/features/ui/dataset-pages.e2e.spec.ts
@@ -41,6 +41,24 @@ test.describe('dataset detail pages', () => {
     await expect(page.locator('.dataset-table')).toBeAttached({ timeout: 15000 })
   })
 
+  // The back-office /table page must sync its display state with the URL the same way the embed
+  // page does, otherwise a sorted view with a column selection cannot be bookmarked nor shared.
+  // Only the filters used to be synced (they go through composables/dataset/filters.ts, which is
+  // internal to dataset-table), the other models were left unbound and stayed local to the page.
+  test('dataset /table route syncs cols, sort and display with the URL', async ({ page, goToWithAuth }) => {
+    // state is restored from the URL: a single column, sorted descending
+    await goToWithAuth(`/data-fair/dataset/${datasetId}/table?cols=id&sort=-id`, 'test_user1')
+    await expect(page.locator('.dataset-table')).toBeAttached({ timeout: 15000 })
+    await expect(page.locator('thead th').filter({ hasText: 'id' })).toBeVisible()
+    await expect(page.locator('thead th').filter({ hasText: 'adr' })).toHaveCount(0)
+    await expect(page.locator('tbody tr').first().locator('td').first()).toHaveText('koumoul')
+
+    // and changes made from the UI are pushed back to the URL
+    await page.getByRole('button', { name: 'Choisir le type d\'affichage' }).click()
+    await page.getByText('Table dense', { exact: true }).click()
+    await expect(page).toHaveURL(/display=table-dense/)
+  })
+
   test('dataset api-doc page loads', async ({ page, goToWithAuth }) => {
     await goToWithAuth(`/data-fair/dataset/${datasetId}/api-doc`, 'test_user1')
     // d-frame is a custom element that renders hidden until loaded; check it's in the DOM

--- a/ui/src/pages/dataset/[id]/edit-data.vue
+++ b/ui/src/pages/dataset/[id]/edit-data.vue
@@ -5,6 +5,10 @@
     fluid
   >
     <dataset-table
+      v-model:cols="cols"
+      v-model:display="display"
+      v-model:q="q"
+      v-model:sort="sort"
       :height="contentHeight"
       edit
     />
@@ -36,6 +40,11 @@ const store = useDatasetStore()
 const { dataset } = store
 
 useDatasetWatch(store, ['info'])
+
+const cols = useStringsArraySearchParam('cols')
+const display = useStringSearchParam('display', 'table')
+const q = useStringSearchParam('q')
+const sort = useStringSearchParam('sort')
 
 const contentHeight = computed(() => windowHeight.value - mainRect.value.top - mainRect.value.bottom)
 

--- a/ui/src/pages/dataset/[id]/table.vue
+++ b/ui/src/pages/dataset/[id]/table.vue
@@ -4,7 +4,14 @@
     class="pa-0"
     fluid
   >
-    <dataset-table :height="contentHeight" />
+    <dataset-table
+      v-model:cols="cols"
+      v-model:display="display"
+      v-model:q="q"
+      v-model:sort="sort"
+      v-model:fixed="fixed"
+      :height="contentHeight"
+    />
   </v-container>
 </template>
 
@@ -33,6 +40,12 @@ const store = useDatasetStore()
 const { dataset } = store
 
 useDatasetWatch(store, ['info'])
+
+const cols = useStringsArraySearchParam('cols')
+const display = useStringSearchParam('display', 'table')
+const q = useStringSearchParam('q')
+const sort = useStringSearchParam('sort')
+const fixed = useStringSearchParam('fixed')
 
 const contentHeight = computed(() => windowHeight.value - mainRect.value.top - mainRect.value.bottom)
 


### PR DESCRIPTION
The back-office table views (`/dataset/:id/table` and `/dataset/:id/edit-data`) now bind their column selection, sort, search and display mode to the URL, the same way the embed table page already does. Only the filters used to be synced (they go through `composables/dataset/filters.ts`, which is internal to `dataset-table`), the other models were left unbound and stayed local to the page.

- `/table` binds `cols`, `display`, `q`, `sort` and `fixed`
- `/edit-data` binds `cols`, `display`, `q` and `sort` — no `fixed`, fixing a column is disabled in edit mode
- e2e test covering both directions on `/table`: state restored from the URL, and a display change pushed back to it

**Why:** a sorted view with a column selection could not be bookmarked nor shared from the back-office.
