### PR TITLE
feat(integrity): level 2 repair — payload storage, diff and restore

### DIFF
--- a/api/src/datasets/routes/integrity.ts
+++ b/api/src/datasets/routes/integrity.ts
@@ -1,14 +1,21 @@
 import { type Router } from 'express'
-import { reqAdminMode } from '@data-fair/lib-express'
+import path from 'node:path'
+import { reqAdminMode, reqSessionAuthenticated } from '@data-fair/lib-express'
+import clone from '@data-fair/lib-utils/clone.js'
 import { httpError } from '@data-fair/lib-utils/http-errors.js'
 import config from '#config'
 import mongo from '#mongo'
+import filesStorage from '#files-storage'
 import { reqDataset, readDataset } from '../middlewares.ts'
 import * as permissions from '../../misc/utils/permissions.ts'
+import * as datasetUtils from '../utils/index.ts'
+import { preparePatch } from '../utils/patch.ts'
+import { applyPatch } from '../service.ts'
 import { isFileDataset } from '#types/dataset/index.ts'
 import { integrityStore } from '../../integrity/store-factory.ts'
-import { revisionPrefix, parseRevisionIndex, isPayloadKey, revisionKey, restoreUpdate, rehydrateTopics } from '../../integrity/operations.ts'
+import { revisionPrefix, parseRevisionIndex, isPayloadKey, revisionKey, payloadKey, restoreUpdate, rehydrateTopics } from '../../integrity/operations.ts'
 import { anchorDataset } from '../../integrity/relay.ts'
+import { md5OfStorageFile } from '../../integrity/hash.ts'
 
 export const registerIntegrityRoutes = (router: Router) => {
   router.put('/:datasetId/_integrity', readDataset({ noCache: true }), async (req, res) => {
@@ -83,7 +90,39 @@ export const registerIntegrityRoutes = (router: Router) => {
       await mongo.datasets.updateOne({ id: dataset.id }, update)
     }
 
-    // metadata-only restore (file part comes in the next iteration of this route): re-anchor
+    // file part: the stored file's actual bytes vs the revision's md5 (metadata fields can lie)
+    const currentMd5 = isFileDataset(dataset)
+      ? await md5OfStorageFile(datasetUtils.originalFilePath(dataset)).catch((err: any) => {
+        if (err.status === 404) return undefined
+        throw err
+      })
+      : undefined
+    if (revision.payload.file && revision.hash.md5 !== currentMd5) {
+      // re-ingesting mutates the dataset through the full pipeline; refuse while it is mid-processing
+      // (only a settled finalized/error dataset is safe to route a fresh file replacement through)
+      if (dataset.status !== 'finalized' && dataset.status !== 'error') {
+        throw httpError(409, 'dataset is not in a stable state (finalized/error) for a file restore')
+      }
+      // re-ingest through the standard file-replacement path (spec §C): the payload lands in the
+      // loading dir exactly as an upload would, preparePatch/applyPatch route it through the
+      // draft pipeline, and finalize re-anchors with the restore context riding the draft
+      const filename = revision.payload.metadata.originalFile?.name ?? dataset.originalFile?.name ?? 'restored-file'
+      const destination = datasetUtils.loadingDir({ ...dataset, draftReason: true })
+      const finalPath = path.join(destination, filename)
+      const { body } = await store.readPayload(payloadKey(dataset.owner, dataset.id, i))
+      await filesStorage.writeStream(body, finalPath)
+      const stats = await filesStorage.fileStats(finalPath)
+      const files = [{ fieldname: 'file', originalname: filename, filename, destination, path: finalPath, size: stats.size, md5: revision.hash.md5 }]
+
+      const patch: any = { _needsHistorizing: { context: { operation: 'restore', origin: 'superadmin', ...(reason ? { reason } : {}) } } }
+      const datasetClone: any = clone(dataset)
+      await preparePatch(req.app, patch, datasetClone, reqSessionAuthenticated(req), req.getLocale(), 'always', files)
+      await applyPatch(datasetClone, patch)
+      res.json({ status: 'restoring' })
+      return
+    }
+
+    // metadata-only restore (file part handled above): re-anchor
     // synchronously with the restore context and respond with the fresh verdict, like _fix.
     // force: true — restore must always leave its own auditable revision, even when the
     // corrected state lands back on one identical to a prior anchor (anchorDataset's normal

--- a/api/src/datasets/routes/integrity.ts
+++ b/api/src/datasets/routes/integrity.ts
@@ -1,6 +1,7 @@
 import { type Router } from 'express'
 import path from 'node:path'
 import mime from 'mime-types'
+import contentDisposition from 'content-disposition'
 import { reqAdminMode, reqSessionAuthenticated } from '@data-fair/lib-express'
 import clone from '@data-fair/lib-utils/clone.js'
 import { httpError } from '@data-fair/lib-utils/http-errors.js'
@@ -15,9 +16,10 @@ import { fallbackMimeTypes } from '../utils/upload.ts'
 import { applyPatch } from '../service.ts'
 import { isFileDataset } from '#types/dataset/index.ts'
 import { integrityStore } from '../../integrity/store-factory.ts'
-import { revisionPrefix, parseRevisionIndex, isPayloadKey, revisionKey, payloadKey, restoreUpdate, rehydrateTopics } from '../../integrity/operations.ts'
+import { revisionPrefix, parseRevisionIndex, isPayloadKey, revisionKey, payloadKey, restoreUpdate, rehydrateTopics, coveredMetadata } from '../../integrity/operations.ts'
 import { anchorDataset } from '../../integrity/relay.ts'
 import { md5OfStorageFile } from '../../integrity/hash.ts'
+import pump from '../../misc/utils/pipe.ts'
 
 export const registerIntegrityRoutes = (router: Router) => {
   router.put('/:datasetId/_integrity', readDataset({ noCache: true }), async (req, res) => {
@@ -171,9 +173,44 @@ export const registerIntegrityRoutes = (router: Router) => {
         date: rev.context.date,
         operation: rev.context.operation,
         origin: rev.context.origin,
-        ...(rev.context.reason ? { reason: rev.context.reason } : {})
+        ...(rev.context.reason ? { reason: rev.context.reason } : {}),
+        hasPayload: !!rev.payload,
+        ...(rev.payload?.file ? { fileSize: rev.payload.file.size } : {})
       }
     }))
     res.json({ count, results })
+  })
+
+  router.get('/:datasetId/_integrity/revisions/:i', readDataset({ noCache: true }), permissions.middleware('readIntegrityRevisions', 'admin'), async (req, res) => {
+    const dataset: any = reqDataset(req)
+    if (!dataset.integrity?.active) throw httpError(400, 'integrity is not active on this dataset')
+    const i = parseInt(req.params.i as string, 10)
+    if (Number.isNaN(i) || i < 0) throw httpError(400, 'invalid revision index')
+    const store = integrityStore()
+    const rev = await store.getRevision(revisionKey(dataset.owner, dataset.id, i)).catch((err: any) => {
+      if (err.name === 'NoSuchKey' || err.$metadata?.httpStatusCode === 404) throw httpError(404, 'unknown revision')
+      throw err
+    })
+    const fresh = await mongo.datasets.findOne({ id: dataset.id })
+    // `current` is the live covered projection so the UI can render the metadata diff in one call
+    res.json({ i, hash: rev.hash, context: rev.context, payload: rev.payload, current: fresh ? coveredMetadata(fresh) : undefined })
+  })
+
+  router.get('/:datasetId/_integrity/revisions/:i/file', readDataset({ noCache: true }), permissions.middleware('readIntegrityRevisions', 'admin'), async (req, res) => {
+    const dataset: any = reqDataset(req)
+    if (!dataset.integrity?.active) throw httpError(400, 'integrity is not active on this dataset')
+    const i = parseInt(req.params.i as string, 10)
+    if (Number.isNaN(i) || i < 0) throw httpError(400, 'invalid revision index')
+    const store = integrityStore()
+    const rev = await store.getRevision(revisionKey(dataset.owner, dataset.id, i)).catch((err: any) => {
+      if (err.name === 'NoSuchKey' || err.$metadata?.httpStatusCode === 404) throw httpError(404, 'unknown revision')
+      throw err
+    })
+    if (!rev.payload?.file) throw httpError(404, 'this revision has no file payload')
+    const { body, size } = await store.readPayload(payloadKey(dataset.owner, dataset.id, i))
+    res.setHeader('content-disposition', contentDisposition(rev.payload.metadata.originalFile?.name ?? `${dataset.slug}-revision-${i}`))
+    res.setHeader('content-type', rev.payload.metadata.originalFile?.mimetype ?? 'application/octet-stream')
+    if (size !== undefined) res.setHeader('content-length', String(size))
+    await pump(body, res)
   })
 }

--- a/api/src/datasets/routes/integrity.ts
+++ b/api/src/datasets/routes/integrity.ts
@@ -7,7 +7,7 @@ import { reqDataset, readDataset } from '../middlewares.ts'
 import * as permissions from '../../misc/utils/permissions.ts'
 import { isFileDataset } from '#types/dataset/index.ts'
 import { integrityStore } from '../../integrity/store-factory.ts'
-import { revisionPrefix, parseRevisionIndex } from '../../integrity/operations.ts'
+import { revisionPrefix, parseRevisionIndex, isPayloadKey } from '../../integrity/operations.ts'
 import { anchorDataset } from '../../integrity/relay.ts'
 
 export const registerIntegrityRoutes = (router: Router) => {
@@ -68,7 +68,8 @@ export const registerIntegrityRoutes = (router: Router) => {
     if (!dataset.integrity?.active) throw httpError(400, 'integrity is not active on this dataset')
     const store = integrityStore()
     // zero-padded indices sort lexically == numerically; newest first = reversed
-    const keys = (await store.listRevisions(revisionPrefix(dataset.owner, dataset.id))).map((r) => r.key).sort().reverse()
+    const keys = (await store.listRevisions(revisionPrefix(dataset.owner, dataset.id))).map((r) => r.key)
+      .filter((k) => !isPayloadKey(k)).sort().reverse()
     const count = keys.length
     const size = Math.min(parseInt(String(req.query.size ?? '20'), 10) || 20, 100)
     const page = parseInt(String(req.query.page ?? '1'), 10) || 1

--- a/api/src/datasets/routes/integrity.ts
+++ b/api/src/datasets/routes/integrity.ts
@@ -120,7 +120,10 @@ export const registerIntegrityRoutes = (router: Router) => {
       const filename = revision.payload.metadata.originalFile?.name ?? dataset.originalFile?.name ?? 'restored-file'
       const destination = datasetUtils.loadingDir({ ...dataset, draftReason: true })
       const finalPath = path.join(destination, filename)
-      const { body } = await store.readPayload(payloadKey(dataset.owner, dataset.id, i))
+      // payload reference dedupe: the bytes may live under an earlier revision's `{i}.file`
+      // (absent `file.i` = this revision owns them)
+      const fileRefIndex = revision.payload.file?.i ?? i
+      const { body } = await store.readPayload(payloadKey(dataset.owner, dataset.id, fileRefIndex))
       await filesStorage.writeStream(body, finalPath)
       const stats = await filesStorage.fileStats(finalPath)
       // mime type is broken on windows it seems.. detect based on extension instead (mirrors upload.ts's fileFilter)
@@ -214,7 +217,9 @@ export const registerIntegrityRoutes = (router: Router) => {
       throw err
     })
     if (!rev.payload?.file) throw httpError(404, 'this revision has no file payload')
-    const { body, size } = await store.readPayload(payloadKey(dataset.owner, dataset.id, i))
+    // payload reference dedupe: resolve the revision that owns the bytes (absent `file.i` = self)
+    const refIndex = rev.payload.file.i ?? i
+    const { body, size } = await store.readPayload(payloadKey(dataset.owner, dataset.id, refIndex))
     res.setHeader('content-disposition', contentDisposition(rev.payload.metadata.originalFile?.name ?? `${dataset.slug}-revision-${i}`))
     res.setHeader('content-type', rev.payload.metadata.originalFile?.mimetype ?? 'application/octet-stream')
     if (size !== undefined) res.setHeader('content-length', String(size))

--- a/api/src/datasets/routes/integrity.ts
+++ b/api/src/datasets/routes/integrity.ts
@@ -128,7 +128,14 @@ export const registerIntegrityRoutes = (router: Router) => {
       const files = [{ fieldname: 'file', originalname: filename, filename, destination, path: finalPath, size: stats.size, md5: revision.hash.md5, mimetype }]
 
       const patch: any = { _needsHistorizing: { context: { operation: 'restore', origin: 'superadmin', ...(reason ? { reason } : {}) } } }
-      const datasetClone: any = clone(dataset)
+      // the metadata $set/$unset above may have just restored `file`/`originalFile` on the Mongo
+      // doc (both are covered fields a metadata tamper can unset); preparePatch/applyPatch must
+      // see that post-restore state, not the stale route-entry `dataset` — otherwise a healed
+      // `file` still reads as absent on the clone and preparePatch's file-based guard throws 400
+      // even though the metadata write already landed.
+      const postMetadataDataset = await mongo.datasets.findOne({ id: dataset.id })
+      if (!postMetadataDataset) throw httpError(404, 'dataset not found')
+      const datasetClone: any = clone(postMetadataDataset)
       await preparePatch(req.app, patch, datasetClone, reqSessionAuthenticated(req), req.getLocale(), 'always', files)
       await applyPatch(datasetClone, patch)
       res.json({ status: 'restoring' })

--- a/api/src/datasets/routes/integrity.ts
+++ b/api/src/datasets/routes/integrity.ts
@@ -7,7 +7,7 @@ import { reqDataset, readDataset } from '../middlewares.ts'
 import * as permissions from '../../misc/utils/permissions.ts'
 import { isFileDataset } from '#types/dataset/index.ts'
 import { integrityStore } from '../../integrity/store-factory.ts'
-import { revisionPrefix, parseRevisionIndex, isPayloadKey } from '../../integrity/operations.ts'
+import { revisionPrefix, parseRevisionIndex, isPayloadKey, revisionKey, restoreUpdate, rehydrateTopics } from '../../integrity/operations.ts'
 import { anchorDataset } from '../../integrity/relay.ts'
 
 export const registerIntegrityRoutes = (router: Router) => {
@@ -53,6 +53,46 @@ export const registerIntegrityRoutes = (router: Router) => {
     const checker = await import('../../integrity/checker.ts')
     const fresh = await mongo.datasets.findOne({ id: dataset.id })
     res.json(await checker.checkDataset(fresh as any))
+  })
+
+  router.post('/:datasetId/_integrity/_restore', readDataset({ noCache: true }), async (req, res) => {
+    reqAdminMode(req)
+    const dataset: any = reqDataset(req)
+    if (!dataset.integrity?.active) throw httpError(400, 'integrity is not active on this dataset')
+    const i = req.body?.i
+    if (!Number.isInteger(i) || i < 0) throw httpError(400, 'missing or invalid revision index "i"')
+    const reason = typeof req.body?.reason === 'string' ? req.body.reason : undefined
+    const store = integrityStore()
+    const revision = await store.getRevision(revisionKey(dataset.owner, dataset.id, i)).catch((err: any) => {
+      if (err.name === 'NoSuchKey' || err.$metadata?.httpStatusCode === 404) throw httpError(404, 'unknown revision')
+      throw err
+    })
+    if (!revision.payload) throw httpError(400, 'this revision has no payload (level-1 anchor): not restorable')
+
+    // metadata part: write back only the genuinely diverging covered keys
+    const fresh = await mongo.datasets.findOne({ id: dataset.id })
+    if (!fresh) throw httpError(404, 'dataset not found')
+    const { $set, $unset } = restoreUpdate(fresh, revision.payload.metadata)
+    if ($set.topics) {
+      const settings = await mongo.db.collection('settings').findOne({ type: dataset.owner.type, id: dataset.owner.id })
+      $set.topics = rehydrateTopics($set.topics, settings?.topics ?? [])
+    }
+    if (Object.keys($set).length || Object.keys($unset).length) {
+      const update: any = { $set: { ...$set, updatedAt: new Date().toISOString() } }
+      if (Object.keys($unset).length) update.$unset = $unset
+      await mongo.datasets.updateOne({ id: dataset.id }, update)
+    }
+
+    // metadata-only restore (file part comes in the next iteration of this route): re-anchor
+    // synchronously with the restore context and respond with the fresh verdict, like _fix.
+    // force: true — restore must always leave its own auditable revision, even when the
+    // corrected state lands back on one identical to a prior anchor (anchorDataset's normal
+    // dedupe would otherwise silently swallow the remediation, see relay.ts for detail)
+    await anchorDataset(dataset, { operation: 'restore', origin: 'superadmin', reason }, { force: true })
+    await mongo.datasets.updateOne({ id: dataset.id }, { $unset: { _needsHistorizing: '' } })
+    const checker = await import('../../integrity/checker.ts')
+    const freshAfter = await mongo.datasets.findOne({ id: dataset.id })
+    res.json(await checker.checkDataset(freshAfter as any))
   })
 
   router.post('/:datasetId/_integrity/_check', readDataset({ noCache: true }), async (req, res) => {

--- a/api/src/datasets/routes/integrity.ts
+++ b/api/src/datasets/routes/integrity.ts
@@ -11,24 +11,13 @@ import { reqDataset, readDataset } from '../middlewares.ts'
 import * as permissions from '../../misc/utils/permissions.ts'
 import * as datasetUtils from '../utils/index.ts'
 import { preparePatch } from '../utils/patch.ts'
+import { fallbackMimeTypes } from '../utils/upload.ts'
 import { applyPatch } from '../service.ts'
 import { isFileDataset } from '#types/dataset/index.ts'
 import { integrityStore } from '../../integrity/store-factory.ts'
 import { revisionPrefix, parseRevisionIndex, isPayloadKey, revisionKey, payloadKey, restoreUpdate, rehydrateTopics } from '../../integrity/operations.ts'
 import { anchorDataset } from '../../integrity/relay.ts'
 import { md5OfStorageFile } from '../../integrity/hash.ts'
-
-// mirrors upload.ts's fileFilter mimetype detection (mime type is broken on windows it seems ..
-// detect based on extension instead), so the synthetic `files` descriptor built for a restore
-// re-ingestion matches what a real multipart upload would have produced
-const fallbackMimeTypes: Record<string, string> = {
-  dbf: 'application/dbase',
-  dif: 'text/plain',
-  fods: 'application/vnd.oasis.opendocument.spreadsheet',
-  gpkg: 'application/geopackage+sqlite3',
-  jsonl: 'application/x-ndjson',
-  ndjson: 'application/x-ndjson',
-}
 
 export const registerIntegrityRoutes = (router: Router) => {
   router.put('/:datasetId/_integrity', readDataset({ noCache: true }), async (req, res) => {

--- a/api/src/datasets/routes/integrity.ts
+++ b/api/src/datasets/routes/integrity.ts
@@ -1,5 +1,6 @@
 import { type Router } from 'express'
 import path from 'node:path'
+import mime from 'mime-types'
 import { reqAdminMode, reqSessionAuthenticated } from '@data-fair/lib-express'
 import clone from '@data-fair/lib-utils/clone.js'
 import { httpError } from '@data-fair/lib-utils/http-errors.js'
@@ -16,6 +17,18 @@ import { integrityStore } from '../../integrity/store-factory.ts'
 import { revisionPrefix, parseRevisionIndex, isPayloadKey, revisionKey, payloadKey, restoreUpdate, rehydrateTopics } from '../../integrity/operations.ts'
 import { anchorDataset } from '../../integrity/relay.ts'
 import { md5OfStorageFile } from '../../integrity/hash.ts'
+
+// mirrors upload.ts's fileFilter mimetype detection (mime type is broken on windows it seems ..
+// detect based on extension instead), so the synthetic `files` descriptor built for a restore
+// re-ingestion matches what a real multipart upload would have produced
+const fallbackMimeTypes: Record<string, string> = {
+  dbf: 'application/dbase',
+  dif: 'text/plain',
+  fods: 'application/vnd.oasis.opendocument.spreadsheet',
+  gpkg: 'application/geopackage+sqlite3',
+  jsonl: 'application/x-ndjson',
+  ndjson: 'application/x-ndjson',
+}
 
 export const registerIntegrityRoutes = (router: Router) => {
   router.put('/:datasetId/_integrity', readDataset({ noCache: true }), async (req, res) => {
@@ -76,6 +89,25 @@ export const registerIntegrityRoutes = (router: Router) => {
     })
     if (!revision.payload) throw httpError(400, 'this revision has no payload (level-1 anchor): not restorable')
 
+    // file part: the stored file's actual bytes vs the revision's md5 (metadata fields can lie).
+    // Computed and gated up front, BEFORE the metadata write below: a file restore refused with 409
+    // must not have already applied its metadata $set/$unset. Metadata-only restores (no file
+    // divergence) stay ungated.
+    const currentMd5 = isFileDataset(dataset)
+      ? await md5OfStorageFile(datasetUtils.originalFilePath(dataset)).catch((err: any) => {
+        if (err.status === 404) return undefined
+        throw err
+      })
+      : undefined
+    const needsFileRestore = !!(revision.payload.file && revision.hash.md5 !== currentMd5)
+    if (needsFileRestore) {
+      // re-ingesting mutates the dataset through the full pipeline; refuse while it is mid-processing
+      // (only a settled finalized/error dataset is safe to route a fresh file replacement through)
+      if (dataset.status !== 'finalized' && dataset.status !== 'error') {
+        throw httpError(409, 'dataset is not in a stable state (finalized/error) for a file restore')
+      }
+    }
+
     // metadata part: write back only the genuinely diverging covered keys
     const fresh = await mongo.datasets.findOne({ id: dataset.id })
     if (!fresh) throw httpError(404, 'dataset not found')
@@ -90,19 +122,7 @@ export const registerIntegrityRoutes = (router: Router) => {
       await mongo.datasets.updateOne({ id: dataset.id }, update)
     }
 
-    // file part: the stored file's actual bytes vs the revision's md5 (metadata fields can lie)
-    const currentMd5 = isFileDataset(dataset)
-      ? await md5OfStorageFile(datasetUtils.originalFilePath(dataset)).catch((err: any) => {
-        if (err.status === 404) return undefined
-        throw err
-      })
-      : undefined
-    if (revision.payload.file && revision.hash.md5 !== currentMd5) {
-      // re-ingesting mutates the dataset through the full pipeline; refuse while it is mid-processing
-      // (only a settled finalized/error dataset is safe to route a fresh file replacement through)
-      if (dataset.status !== 'finalized' && dataset.status !== 'error') {
-        throw httpError(409, 'dataset is not in a stable state (finalized/error) for a file restore')
-      }
+    if (needsFileRestore) {
       // re-ingest through the standard file-replacement path (spec §C): the payload lands in the
       // loading dir exactly as an upload would, preparePatch/applyPatch route it through the
       // draft pipeline, and finalize re-anchors with the restore context riding the draft
@@ -112,7 +132,9 @@ export const registerIntegrityRoutes = (router: Router) => {
       const { body } = await store.readPayload(payloadKey(dataset.owner, dataset.id, i))
       await filesStorage.writeStream(body, finalPath)
       const stats = await filesStorage.fileStats(finalPath)
-      const files = [{ fieldname: 'file', originalname: filename, filename, destination, path: finalPath, size: stats.size, md5: revision.hash.md5 }]
+      // mime type is broken on windows it seems.. detect based on extension instead (mirrors upload.ts's fileFilter)
+      const mimetype = mime.lookup(filename) || fallbackMimeTypes[filename.split('.').pop() as string] || filename.split('.').pop()
+      const files = [{ fieldname: 'file', originalname: filename, filename, destination, path: finalPath, size: stats.size, md5: revision.hash.md5, mimetype }]
 
       const patch: any = { _needsHistorizing: { context: { operation: 'restore', origin: 'superadmin', ...(reason ? { reason } : {}) } } }
       const datasetClone: any = clone(dataset)

--- a/api/src/datasets/routes/metadata.ts
+++ b/api/src/datasets/routes/metadata.ts
@@ -27,7 +27,6 @@ import { syncDataset as syncRemoteService } from '../../remote-services/service.
 import { reqPublicBaseUrl } from '../../misc/utils/public-base-url.ts'
 import { reqPublicationSite } from '../../misc/utils/publication-sites.ts'
 import { findDatasets, applyPatch, deleteDataset } from '../service.ts'
-import { stampHistorize } from '../../integrity/operations.ts'
 import { preparePatch } from '../utils/patch.ts'
 import * as datasetUtils from '../utils/index.ts'
 import { tableSchema, jsonSchema, getSchemaBreakingChanges, filterSchema } from '../utils/data-schema.ts'
@@ -191,6 +190,12 @@ export const registerMetadataRoutes = (router: Router) => {
   router.put('/:datasetId/owner', readDataset({ noCache: true }), apiKeyMiddlewareAdmin, rateLimiting.middleware, permissions.middleware('changeOwner', 'admin'), async (req, res) => {
     const dataset: any = reqDataset(req)
 
+    // integrity anchors are owner-scoped (data-fair/‹owner.type›-‹owner.id›/…): transferring
+    // would orphan the anchor sequence. Deliberate simplification: disable integrity first.
+    if (dataset.integrity?.active) {
+      return res.status(400).type('text/plain').send('Le contrôle d\'intégrité doit être désactivé avant un changement de propriétaire')
+    }
+
     const sessionState = reqSessionAuthenticated(req)
 
     // Must be able to delete the current dataset, and to create a new one for the new owner to proceed
@@ -251,9 +256,6 @@ export const registerMetadataRoutes = (router: Router) => {
     await permissions.initResourcePermissions(patch, preservePermissions)
 
     const changeOwnerUpdate: any = { $set: patch }
-    // S3 anchor keys are owner-scoped (data-fair/‹owner.type›-‹owner.id›/…) — after a transfer
-    // there is no anchor under the new prefix, so a re-anchor must be stamped
-    if (dataset.integrity?.active) stampHistorize(changeOwnerUpdate, { operation: 'update', origin: 'user' })
     const patchedDataset: any = await mongo.db.collection('datasets')
       .findOneAndUpdate({ id: dataset.id }, changeOwnerUpdate, { returnDocument: 'after' })
 

--- a/api/src/datasets/utils/upload.ts
+++ b/api/src/datasets/utils/upload.ts
@@ -24,7 +24,7 @@ const md5Tee = () => {
   return { stream, digest: () => hash.digest('hex') }
 }
 
-const fallbackMimeTypes = {
+export const fallbackMimeTypes: Record<string, string> = {
   dbf: 'application/dbase',
   dif: 'text/plain',
   fods: 'application/vnd.oasis.opendocument.spreadsheet',

--- a/api/src/integrity/checker.ts
+++ b/api/src/integrity/checker.ts
@@ -56,9 +56,10 @@ export const checkDataset = async (dataset: DatasetInternal): Promise<Check> => 
   const prefix = ops.revisionPrefix(dataset.owner, dataset.id)
   const latest = ops.latestKey((await store.listRevisions(prefix)).map((r) => r.key))
   if (!latest) {
-    // no anchor written yet (e.g. right after an owner transfer, before the re-anchor lands under
-    // the new prefix): persist the verdict so a stale pre-transfer 'ok' cannot linger and the
-    // sweep cursor (sorted on lastCheck.date) advances past this dataset
+    // no anchor written yet (e.g. enable succeeded — integrity.active is set — but the inline
+    // anchor write then failed, S3 down, before any revision landed): persist the verdict so a
+    // stale 'ok' cannot linger and the sweep cursor (sorted on lastCheck.date) advances past this
+    // dataset
     const date = new Date().toISOString()
     await mongo.datasets.updateOne({ id: dataset.id }, { $set: { 'integrity.lastCheck': { date, status: 'unknown' } } })
     return { status: 'unknown', date }

--- a/api/src/integrity/checker.ts
+++ b/api/src/integrity/checker.ts
@@ -9,6 +9,8 @@ import type { DatasetInternal } from '#types'
 import { isFileDataset } from '#types/dataset/index.ts'
 import { integrityStore } from './store-factory.ts'
 import * as ops from './operations.ts'
+import { PAYLOAD_SUFFIX } from './operations.ts'
+import type { RevisionBody } from './store.ts'
 import { md5OfStorageFile } from './hash.ts'
 import * as datasetUtils from '../datasets/utils/index.ts'
 import * as notifications from '../misc/utils/notifications.ts'
@@ -22,13 +24,16 @@ export type Check = { status: 'ok' | 'breach' | 'unknown', date?: string, breach
 // anchor is "old" (per ops.needsRenewal), push its compliance retain-until forward in place so the
 // current state stays protected indefinitely. Failure is surfaced loudly, never thrown — the anchor
 // stays valid until its existing retain-until, leaving lead time to react.
-const maybeRenew = async (dataset: DatasetInternal, store: ReturnType<typeof integrityStore>, latestKey: string): Promise<void> => {
+const maybeRenew = async (dataset: DatasetInternal, store: ReturnType<typeof integrityStore>, latestKey: string, latestRevision: RevisionBody): Promise<void> => {
   const retentionDays = config.integrity?.retention?.days ?? 365
   if (!ops.needsRenewal((dataset.integrity as any)?.lastRevision?.retainUntil, Date.now(), retentionDays)) return
   const date = new Date().toISOString()
   const retainUntil = new Date(Date.now() + retentionDays * 24 * 3600 * 1000)
   try {
     await store.extendRetention(latestKey, retainUntil)
+    // the sliding anchor is the revision *pair*: a level-2 anchor's repairability dies with
+    // its payload's lock, so the .file sibling must slide forward too
+    if (latestRevision.payload?.file) await store.extendRetention(latestKey + PAYLOAD_SUFFIX, retainUntil)
     await mongo.datasets.updateOne({ id: dataset.id }, {
       $set: {
         'integrity.lastRevision.retainUntil': retainUntil.toISOString(),
@@ -59,7 +64,8 @@ export const checkDataset = async (dataset: DatasetInternal): Promise<Check> => 
     return { status: 'unknown', date }
   }
 
-  const expected = (await store.getRevision(latest)).hash
+  const latestRevision = await store.getRevision(latest)
+  const expected = latestRevision.hash
   const breach: Array<'file' | 'metadata'> = []
   // a missing file is the strongest tamper signal (deleted out-of-band) → breach, not an exception
   const actualMd5 = isFileDataset(dataset)
@@ -82,7 +88,7 @@ export const checkDataset = async (dataset: DatasetInternal): Promise<Check> => 
   if (status === 'breach' && !wasBreach) {
     await notifications.sendResourceEvent('datasets', dataset as any, 'worker:integrity-checker', 'integrity-breach')
   }
-  if (status === 'ok') await maybeRenew(dataset, store, latest)
+  if (status === 'ok') await maybeRenew(dataset, store, latest, latestRevision)
   return { status, date, ...(breach.length ? { breach } : {}) }
 }
 

--- a/api/src/integrity/checker.ts
+++ b/api/src/integrity/checker.ts
@@ -9,7 +9,6 @@ import type { DatasetInternal } from '#types'
 import { isFileDataset } from '#types/dataset/index.ts'
 import { integrityStore } from './store-factory.ts'
 import * as ops from './operations.ts'
-import { PAYLOAD_SUFFIX } from './operations.ts'
 import type { RevisionBody } from './store.ts'
 import { md5OfStorageFile } from './hash.ts'
 import * as datasetUtils from '../datasets/utils/index.ts'
@@ -31,9 +30,14 @@ const maybeRenew = async (dataset: DatasetInternal, store: ReturnType<typeof int
   const retainUntil = new Date(Date.now() + retentionDays * 24 * 3600 * 1000)
   try {
     await store.extendRetention(latestKey, retainUntil)
-    // the sliding anchor is the revision *pair*: a level-2 anchor's repairability dies with
-    // its payload's lock, so the .file sibling must slide forward too
-    if (latestRevision.payload?.file) await store.extendRetention(latestKey + PAYLOAD_SUFFIX, retainUntil)
+    // the sliding anchor is the revision *pair*: the latest revision JSON and the payload object it
+    // references. A level-2 anchor's repairability dies with its payload's lock, so the referenced
+    // .file must slide forward too — which may be an earlier revision's copy (payload reference
+    // dedupe): resolve `file.i`, or, absent, the latest revision owns its own bytes.
+    if (latestRevision.payload?.file) {
+      const refIndex = latestRevision.payload.file.i ?? ops.parseRevisionIndex(latestKey)
+      await store.extendRetention(ops.payloadKey(dataset.owner, dataset.id, refIndex), retainUntil)
+    }
     await mongo.datasets.updateOne({ id: dataset.id }, {
       $set: {
         'integrity.lastRevision.retainUntil': retainUntil.toISOString(),

--- a/api/src/integrity/hash.ts
+++ b/api/src/integrity/hash.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 import type { Readable } from 'node:stream'
+import { Transform } from 'node:stream'
 import { filesStorage } from '../files-storage/index.ts'
 
 export const md5OfStream = (stream: Readable): Promise<string> => new Promise((resolve, reject) => {
@@ -12,4 +13,12 @@ export const md5OfStream = (stream: Readable): Promise<string> => new Promise((r
 export const md5OfStorageFile = async (path: string): Promise<string> => {
   const { body } = await filesStorage.readStream(path)
   return md5OfStream(body)
+}
+
+// pass-through md5: hash the payload bytes while they stream to the store, so the anchor's
+// md5 always describes the bytes actually stored in the payload (single read of the file)
+export const md5Tee = () => {
+  const hash = createHash('md5')
+  const stream = new Transform({ transform (chunk, _enc, cb) { hash.update(chunk); cb(null, chunk) } })
+  return { stream, digest: () => hash.digest('hex') }
 }

--- a/api/src/integrity/operations.ts
+++ b/api/src/integrity/operations.ts
@@ -16,6 +16,15 @@ export const parseRevisionIndex = (key: string): number => {
   return parseInt(last, 10)
 }
 
+// Level-2 file payloads are sibling objects `{revisionKey}.file` under the dataset prefix;
+// every consumer of a prefix listing must distinguish them from revision JSONs.
+export const PAYLOAD_SUFFIX = '.file'
+
+export const payloadKey = (owner: { type: string, id: string }, datasetId: string, i: number): string =>
+  revisionKey(owner, datasetId, i) + PAYLOAD_SUFFIX
+
+export const isPayloadKey = (key: string): boolean => key.endsWith(PAYLOAD_SUFFIX)
+
 // The covered projection (spec §2): the whole doc minus underscore-prefixed fields and the
 // operational denylist; a field added to the model later is covered by default (fail-loud).
 const EXCLUDED_TOP_LEVEL = new Set([
@@ -72,6 +81,7 @@ export const metadataHash = (dataset: Record<string, any>): string =>
 export const nextIndex = (keys: string[]): number => {
   let max = -1
   for (const k of keys) {
+    if (isPayloadKey(k)) continue
     const i = parseRevisionIndex(k)
     if (!Number.isNaN(i) && i > max) max = i
   }
@@ -79,8 +89,9 @@ export const nextIndex = (keys: string[]): number => {
 }
 
 export const latestKey = (keys: string[]): string | undefined => {
-  if (!keys.length) return undefined
-  return [...keys].sort().at(-1) // zero-padded ⇒ lexical sort == numeric order
+  const revisionKeys = keys.filter((k) => !isPayloadKey(k))
+  if (!revisionKeys.length) return undefined
+  return revisionKeys.sort().at(-1) // zero-padded ⇒ lexical sort == numeric order
 }
 
 export type RevisionOperation = 'create' | 'update' | 'enable' | 'fixIntegrity'

--- a/api/src/integrity/operations.ts
+++ b/api/src/integrity/operations.ts
@@ -94,7 +94,7 @@ export const latestKey = (keys: string[]): string | undefined => {
   return revisionKeys.sort().at(-1) // zero-padded ⇒ lexical sort == numeric order
 }
 
-export type RevisionOperation = 'create' | 'update' | 'enable' | 'fixIntegrity'
+export type RevisionOperation = 'create' | 'update' | 'enable' | 'fixIntegrity' | 'restore'
 // actor CATEGORY, never an identity: user ids are personal data and must not enter the
 // undeletable WORM store — identity-level attribution lives in the events/journal system
 export type RevisionOrigin = 'user' | 'superadmin' | 'worker' | 'propagation' | 'upgrade'
@@ -111,6 +111,33 @@ export const stampHistorize = (
   update.$set = { ...update.$set, _needsHistorizing: context ? { context } : {} }
   return update
 }
+
+// Level-2 metadata restore (spec §C): compare the hot doc's *covered projection* against the
+// snapshot per key, and write back only genuinely diverging keys. Comparing projections (not raw
+// fields) means a field whose only difference is denormalized-name noise (owner/topics display
+// names) is left untouched — normalized loss only happens where tampering actually happened.
+export const restoreUpdate = (
+  hot: Record<string, any>,
+  snapshot: Record<string, any>
+): { $set: Record<string, any>, $unset: Record<string, any> } => {
+  const hotCovered = coveredMetadata(hot)
+  const $set: Record<string, any> = {}
+  const $unset: Record<string, any> = {}
+  for (const key of Object.keys(snapshot)) {
+    if (stableStringify(hotCovered[key] ?? null) !== stableStringify(snapshot[key] ?? null)) $set[key] = snapshot[key]
+  }
+  // covered keys present on the hot doc but absent from the snapshot were added out-of-band
+  for (const key of Object.keys(hotCovered)) {
+    if (!(key in snapshot)) $unset[key] = ''
+  }
+  return { $set, $unset }
+}
+
+// snapshots store topics as { id } only (D1 normalization); on restore, re-hydrate the display
+// fields from their authoritative source (the owner's settings.topics). An id no longer present
+// in settings stays bare — the same state a topic-deletion propagation would leave.
+export const rehydrateTopics = (topics: Array<{ id: string }>, settingsTopics: any[]): any[] =>
+  topics.map((t) => settingsTopics.find((st) => st.id === t.id) ?? t)
 
 export const RENEW_INTERVAL = 1 / 12 // ≈ monthly for a 1-year retention window (hardcoded)
 

--- a/api/src/integrity/relay.ts
+++ b/api/src/integrity/relay.ts
@@ -107,7 +107,12 @@ export const historize = async (dataset: DatasetInternal): Promise<void> => {
   // drop silently rather than anchoring an un-enrolled dataset
   if (!dataset.integrity?.active) { await clearFlag(); return }
 
-  await anchorDataset(dataset, dataset._needsHistorizing?.context)
+  // a 'restore' context reaching the async relay comes from the _restore route's file path
+  // (finalize preserved the context through the draft): force the anchor so the remediation
+  // always leaves its own auditable revision, even when the re-ingested bytes/metadata land
+  // back on a state byte-identical to a prior anchor — mirrors the metadata path's force:true
+  const context = dataset._needsHistorizing?.context
+  await anchorDataset(dataset, context, { force: context?.operation === 'restore' })
   // Known narrow window (accepted): a stamp written while this relay run is in-flight can be
   // cleared by this unconditional $unset and thus dropped. Fail-loud: the next sliding check
   // re-detects the mismatch and alerts; a follow-up _fix recovers.

--- a/api/src/integrity/relay.ts
+++ b/api/src/integrity/relay.ts
@@ -12,8 +12,8 @@ import * as ops from './operations.ts'
 // Compute both hashes from the authoritative sources (stored file bytes + fresh Mongo doc),
 // dedupe against the latest anchor, write the next locked revision and persist the
 // integrity.lastRevision hint. Shared by the async relay (organic writes) and the synchronous
-// admin routes (enable / fixIntegrity).
-export const anchorDataset = async (dataset: DatasetInternal, hint?: ops.HistorizeContextHint): Promise<void> => {
+// admin routes (enable / fixIntegrity / restore).
+export const anchorDataset = async (dataset: DatasetInternal, hint?: ops.HistorizeContextHint, opts?: { force?: boolean }): Promise<void> => {
   const store = integrityStore()
   const date = new Date().toISOString()
   const retainUntil = new Date(Date.now() + (config.integrity!.retention?.days ?? 365) * 24 * 3600 * 1000)
@@ -39,7 +39,11 @@ export const anchorDataset = async (dataset: DatasetInternal, hint?: ops.Histori
   const prefix = ops.revisionPrefix(dataset.owner, dataset.id)
   const keys = (await store.listRevisions(prefix)).map((r) => r.key)
   const latest = ops.latestKey(keys)
-  if (latest) {
+  // restore bypasses the dedupe: it is a rare, explicitly-reasoned remediation action that must
+  // always leave its own auditable 'restore' revision, even when it lands back on a state that is
+  // byte-identical to a prior anchor (e.g. undoing an out-of-band tamper restores the exact
+  // pre-tamper metadata) — otherwise the action would silently vanish from the revision history.
+  if (latest && !opts?.force) {
     const latestRevision = await store.getRevision(latest)
     const latestHash = latestRevision.hash
     // level 2: only a payload-bearing anchor is a valid dedupe target — an L1-era anchor

--- a/api/src/integrity/relay.ts
+++ b/api/src/integrity/relay.ts
@@ -1,10 +1,12 @@
 import mongo from '#mongo'
 import config from '#config'
+import filesStorage from '#files-storage'
 import type { DatasetInternal } from '#types'
 import { isFileDataset } from '#types/dataset/index.ts'
 import * as datasetUtils from '../datasets/utils/index.ts'
 import { integrityStore } from './store-factory.ts'
-import { md5OfStorageFile } from './hash.ts'
+import { md5OfStorageFile, md5Tee } from './hash.ts'
+import type { RevisionBody } from './store.ts'
 import * as ops from './operations.ts'
 
 // Compute both hashes from the authoritative sources (stored file bytes + fresh Mongo doc),
@@ -40,7 +42,9 @@ export const anchorDataset = async (dataset: DatasetInternal, hint?: ops.Histori
   if (latest) {
     const latestRevision = await store.getRevision(latest)
     const latestHash = latestRevision.hash
-    if (latestHash.md5 === hash.md5 && latestHash.sha256 === hash.sha256) {
+    // level 2: only a payload-bearing anchor is a valid dedupe target — an L1-era anchor
+    // with matching hashes still gets a fresh revision, so the store self-heals to level 2
+    if (latestHash.md5 === hash.md5 && latestHash.sha256 === hash.sha256 && latestRevision.payload) {
       // disable→re-enable dedupe constraint: PUT _integrity {active:false} replaces the whole
       // integrity object (wiping integrity.lastRevision); a later re-enable that dedupes against
       // this unchanged anchor must still restore that mirror, or it stays unset forever and the
@@ -64,10 +68,24 @@ export const anchorDataset = async (dataset: DatasetInternal, hint?: ops.Histori
     date,
     ...(hint?.reason ? { reason: hint.reason } : {})
   }
+  // payload FIRST, revision JSON second: a crash in between leaves an orphan .file that ages
+  // out harmlessly — the reverse would leave a revision claiming a payload it doesn't have
+  const payload: NonNullable<RevisionBody['payload']> = { metadata: ops.coveredMetadata(fresh) }
+  if (hash.md5) {
+    const { body, size } = await filesStorage.readStream(datasetUtils.originalFilePath(dataset))
+    const tee = md5Tee()
+    body.on('error', (err) => tee.stream.destroy(err))
+    await store.writePayload(ops.payloadKey(dataset.owner, dataset.id, i), body.pipe(tee.stream), retainUntil)
+    // the file may have changed since the dedupe-check read: the anchor must describe the
+    // payload's actual bytes, so the teed md5 wins over the first-pass one
+    hash.md5 = tee.digest()
+    payload.file = { size }
+  }
   await store.writeRevision(ops.revisionKey(dataset.owner, dataset.id, i), {
     hash,
     context,
-    dataset: { id: dataset.id, slug: dataset.slug }
+    dataset: { id: dataset.id, slug: dataset.slug },
+    payload
   }, retainUntil)
   await mongo.datasets.updateOne({ id: dataset.id }, {
     $set: { 'integrity.lastRevision': { i, hash, date, retainUntil: retainUntil.toISOString() } }

--- a/api/src/integrity/relay.ts
+++ b/api/src/integrity/relay.ts
@@ -39,12 +39,14 @@ export const anchorDataset = async (dataset: DatasetInternal, hint?: ops.Histori
   const prefix = ops.revisionPrefix(dataset.owner, dataset.id)
   const keys = (await store.listRevisions(prefix)).map((r) => r.key)
   const latest = ops.latestKey(keys)
+  // read the latest revision once: the full dedupe below needs its hash pair, and the payload
+  // reference dedupe further down needs its payload.file descriptor (both on force and non-force)
+  const latestRevision = latest ? await store.getRevision(latest) : undefined
   // restore bypasses the dedupe: it is a rare, explicitly-reasoned remediation action that must
   // always leave its own auditable 'restore' revision, even when it lands back on a state that is
   // byte-identical to a prior anchor (e.g. undoing an out-of-band tamper restores the exact
   // pre-tamper metadata) — otherwise the action would silently vanish from the revision history.
-  if (latest && !opts?.force) {
-    const latestRevision = await store.getRevision(latest)
+  if (latest && latestRevision && !opts?.force) {
     const latestHash = latestRevision.hash
     // level 2: only a payload-bearing anchor is a valid dedupe target — an L1-era anchor
     // with matching hashes still gets a fresh revision, so the store self-heals to level 2
@@ -76,14 +78,28 @@ export const anchorDataset = async (dataset: DatasetInternal, hint?: ops.Histori
   // out harmlessly — the reverse would leave a revision claiming a payload it doesn't have
   const payload: NonNullable<RevisionBody['payload']> = { metadata: ops.coveredMetadata(fresh) }
   if (hash.md5) {
-    const { body, size } = await filesStorage.readStream(datasetUtils.originalFilePath(dataset))
-    const tee = md5Tee()
-    body.on('error', (err) => tee.stream.destroy(err))
-    await store.writePayload(ops.payloadKey(dataset.owner, dataset.id, i), body.pipe(tee.stream), retainUntil)
-    // the file may have changed since the dedupe-check read: the anchor must describe the
-    // payload's actual bytes, so the teed md5 wins over the first-pass one
-    hash.md5 = tee.digest()
-    payload.file = { size }
+    // payload reference dedupe: when the stored file is byte-identical to the latest anchor's
+    // payload (a metadata-only change, or a metadata-only restore that lands back on the same
+    // bytes), do NOT upload a second locked copy — reference the existing one. References always
+    // collapse to the bytes-owning revision (never chain): the latest anchor's `file.i` already
+    // points at the owner, or, absent, the latest revision owns its own bytes.
+    if (latestRevision?.payload?.file && latestRevision.hash.md5 === hash.md5) {
+      const refIndex = latestRevision.payload.file.i ?? ops.parseRevisionIndex(latest!)
+      // extend the referenced payload's lock to this revision's retain-until so every referencing
+      // revision's file outlives it, even after the superseded payload itself stops sliding
+      await store.extendRetention(ops.payloadKey(dataset.owner, dataset.id, refIndex), retainUntil)
+      payload.file = { size: latestRevision.payload.file.size, i: refIndex }
+      // no tee on this branch: the bytes are unchanged, so the first-pass md5 already describes them
+    } else {
+      const { body, size } = await filesStorage.readStream(datasetUtils.originalFilePath(dataset))
+      const tee = md5Tee()
+      body.on('error', (err) => tee.stream.destroy(err))
+      await store.writePayload(ops.payloadKey(dataset.owner, dataset.id, i), body.pipe(tee.stream), retainUntil)
+      // the file may have changed since the dedupe-check read: the anchor must describe the
+      // payload's actual bytes, so the teed md5 wins over the first-pass one
+      hash.md5 = tee.digest()
+      payload.file = { size }
+    }
   }
   await store.writeRevision(ops.revisionKey(dataset.owner, dataset.id, i), {
     hash,

--- a/api/src/integrity/store.ts
+++ b/api/src/integrity/store.ts
@@ -7,9 +7,12 @@ export type RevisionBody = {
   hash: { md5?: string, sha256?: string }
   context: RevisionContext
   dataset: { id: string, slug?: string }
-  // level 2: the full covered-metadata projection, and the descriptor of the sibling
-  // `{key}.file` locked object when the revision carries a file copy
-  payload?: { metadata: Record<string, any>, file?: { size: number } }
+  // level 2: the full covered-metadata projection, and the descriptor of the file payload the
+  // revision carries. `file.i` is the index of the revision whose `{i}.file` object OWNS the bytes
+  // (payload reference dedupe): a metadata-only revision references an earlier copy instead of
+  // uploading a duplicate. An ABSENT `i` means "own index" — the bytes live at this revision's own
+  // `{i}.file` sibling. References always collapse to the owning revision (never chain).
+  payload?: { metadata: Record<string, any>, file?: { size: number, i?: number } }
 }
 
 export type IntegrityS3Options = {

--- a/api/src/integrity/store.ts
+++ b/api/src/integrity/store.ts
@@ -1,10 +1,15 @@
 import { S3Client, PutObjectCommand, GetObjectCommand, ListObjectsV2Command, PutObjectRetentionCommand, HeadObjectCommand } from '@aws-sdk/client-s3'
+import { Upload } from '@aws-sdk/lib-storage'
+import type { Readable } from 'node:stream'
 import type { RevisionContext } from './operations.ts'
 
 export type RevisionBody = {
   hash: { md5?: string, sha256?: string }
   context: RevisionContext
   dataset: { id: string, slug?: string }
+  // level 2: the full covered-metadata projection, and the descriptor of the sibling
+  // `{key}.file` locked object when the revision carries a file copy
+  payload?: { metadata: Record<string, any>, file?: { size: number } }
 }
 
 export type IntegrityS3Options = {
@@ -69,5 +74,27 @@ export class IntegrityStore {
   async getRetention (key: string): Promise<Date | undefined> {
     const res = await this.client.send(new HeadObjectCommand({ Bucket: this.bucket, Key: key }))
     return res.ObjectLockRetainUntilDate
+  }
+
+  // Level-2 file payload: a sibling `{revisionKey}.file` object under the same compliance
+  // lock, streamed via multipart upload (files can be many GB).
+  async writePayload (key: string, body: Readable, retainUntil: Date): Promise<void> {
+    const upload = new Upload({
+      client: this.client,
+      params: {
+        Bucket: this.bucket,
+        Key: key,
+        Body: body,
+        ContentType: 'application/octet-stream',
+        ObjectLockMode: 'COMPLIANCE',
+        ObjectLockRetainUntilDate: retainUntil
+      }
+    })
+    await upload.done()
+  }
+
+  async readPayload (key: string): Promise<{ body: Readable, size?: number }> {
+    const res = await this.client.send(new GetObjectCommand({ Bucket: this.bucket, Key: key }))
+    return { body: res.Body as Readable, size: res.ContentLength }
   }
 }

--- a/api/src/misc/routers/test-env.ts
+++ b/api/src/misc/routers/test-env.ts
@@ -97,10 +97,18 @@ router.get('/pending-tasks', (req, res) => {
   res.json(pendingTasks)
 })
 
-// Patch a dataset document directly in MongoDB (test-only)
+// Patch a dataset document directly in MongoDB (test-only). The body is normally a flat object
+// of fields to $set (backward-compatible shape), but a `$unset` key is also recognized so tests
+// can simulate an out-of-band tamper that REMOVES a covered field (e.g. `file`/`originalFile`),
+// not just overwrites one.
 router.post('/patch-dataset/:datasetId', async (req, res, next) => {
   try {
-    await mongo.datasets.updateOne({ id: req.params.datasetId }, { $set: req.body })
+    const { $unset, ...flatSet } = req.body ?? {}
+    const update: any = {}
+    if (Object.keys(flatSet).length) update.$set = flatSet
+    if ($unset) update.$unset = $unset
+    if (!update.$set && !update.$unset) update.$set = {}
+    await mongo.datasets.updateOne({ id: req.params.datasetId }, update)
     res.status(204).send()
   } catch (err) {
     next(err)

--- a/api/src/workers/short-processor/finalize.ts
+++ b/api/src/workers/short-processor/finalize.ts
@@ -37,7 +37,10 @@ export default async function (_dataset: DatasetInternal) {
   // with `draft.` based on its TARGET's draftReason, which routes this correctly: a plain draft
   // finalize persists `draft._needsHistorizing` (never matched by the relay filter → drafts are NOT
   // historized), while a draft validation patches the published doc → top-level flag → anchored.
-  if (dataset.integrity?.active) result._needsHistorizing = { context: { operation: 'update', origin: 'worker' } }
+  // preserve a caller-provided context (e.g. the _restore route rides its 'restore' context
+  // through the draft: mergeDraft overlays draft._needsHistorizing onto the working doc);
+  // default to the generic worker context otherwise
+  if (dataset.integrity?.active) result._needsHistorizing = (dataset as any)._needsHistorizing ?? { context: { operation: 'update', origin: 'worker' } }
 
   if (isVirtualDataset(dataset)) {
     queryableDataset.descendants = await virtualDatasetsUtils.descendants(dataset)

--- a/api/types/dataset/index.ts
+++ b/api/types/dataset/index.ts
@@ -7,7 +7,7 @@ export * from './.type/index.js'
 // mirrors HistorizeContextHint in api/src/integrity/operations.ts — declared inline because this
 // package must not import from src (a src import drags API code into the UI's vue-tsc type graph)
 type HistorizeContextHint = {
-  operation: 'create' | 'update' | 'enable' | 'fixIntegrity'
+  operation: 'create' | 'update' | 'enable' | 'fixIntegrity' | 'restore'
   origin: 'user' | 'superadmin' | 'worker' | 'propagation' | 'upgrade'
   reason?: string
 }

--- a/dev/fixtures.ts
+++ b/dev/fixtures.ts
@@ -223,6 +223,11 @@ async function ensureBreachState () {
     check = await runCheck(id)
   }
   console.log(`${id}: breach state (status=${check.status}, breach=${check.breach?.join(',') || 'none'})`)
+  // level 2: every anchor revision (including revision 0) carries the full
+  // payload, so the breach can be diffed and repaired from the UI or the API —
+  // not auto-demoed here, the fixture keeps showing the breach state as-is
+  console.log(`  level 2: la révision 0 porte le payload complet — diff/téléchargement dans l'onglet intégrité,`)
+  console.log(`  restauration superadmin: POST /api/v1/datasets/${id}/_integrity/_restore {"i": 0}`)
 }
 
 /** CSV file dataset: tabular reference data (product catalog). */

--- a/docs/architecture/integrity.md
+++ b/docs/architecture/integrity.md
@@ -108,10 +108,11 @@ reasonable (it may never be reasonable for large editable datasets — see §5).
   enables per-owner access scoping (§7).
 - Cold storage (e.g. Scaleway **Glacier**, which supports object-lock) is acceptable for the
   historized store, since it is not on the hot read path.
-- Keys are **owner-scoped** (`‹owner.type›-‹owner.id›` segment): an owner transfer therefore
-  re-anchors the dataset under the new owner's prefix (one stamp re-anchors the joint sequence —
-  both hashes), since the old-prefix anchors do not carry over. The old prefix's anchors simply
-  age out at their existing retention — they are not migrated or deleted.
+- Keys are **owner-scoped** (`‹owner.type›-‹owner.id›` segment). Owner transfer is
+  **forbidden while integrity is active** (the transfer route returns 400): a transfer would
+  orphan the anchor sequence under the old prefix. To transfer, a superadmin disables
+  integrity (anchors age out at their existing retention), transfers, and re-enables — a
+  deliberate simplification over re-anchoring under the new prefix.
 
 ### 3.2 The inline write wrapper — *this is the definition of a legitimate write*
 

--- a/docs/architecture/integrity.md
+++ b/docs/architecture/integrity.md
@@ -98,16 +98,28 @@ reasonable (it may never be reasonable for large editable datasets — see §5).
     and an optional free-text reason (on `fixIntegrity` only). It carries **no user identity**
     by construction (§1's trail/journal split), so it holds no personal data — see §8.
   - `dataset` — `{ id, slug }`, a small denormalized descriptor of the anchored dataset.
-  - `payload` — present only at level 2: `{ metadata: <covered projection>, file?: { size } }`.
+  - `payload` — present only at level 2: `{ metadata: <covered projection>, file?: { size, i? } }`.
     `metadata` is the **full** `coveredMetadata()` projection (not merely its hash), stored so it
     can be diffed and restored field-by-field; `file`, present when the anchor covers a file
-    dataset, records the payload's byte size. The file's actual bytes are **not** inlined in this
-    JSON — they live in a **sibling** locked object at `‹revisionKey›.file` (the `PAYLOAD_SUFFIX`),
-    under the **same** compliance lock and retain-until date as the revision JSON, **written
-    payload-first**: the relay uploads the `.file` object before writing the revision JSON that
-    references it, so a crash in between leaves an orphan `.file` that ages out harmlessly —
-    never a revision claiming a payload it doesn't have (the reverse order would risk exactly
-    that). Every consumer of a prefix listing is **suffix-aware**: `nextIndex`, `latestKey`, the
+    dataset, records the payload's byte `size` and an optional reference index `i`. The file's
+    actual bytes are **not** inlined in this JSON — they live in a **sibling** locked object at
+    `‹revisionKey›.file` (the `PAYLOAD_SUFFIX`), under the **same** compliance lock and retain-until
+    date as the revision JSON, **written payload-first**: the relay uploads the `.file` object before
+    writing the revision JSON that references it, so a crash in between leaves an orphan `.file` that
+    ages out harmlessly — never a revision claiming a payload it doesn't have (the reverse order
+    would risk exactly that).
+  - **Payload reference dedupe (`file.i`) — one locked copy per distinct file version.** A locked
+    file copy is stored **once per distinct file version**, not once per revision. When a new
+    anchor's file bytes are **unchanged** from the latest anchor (a metadata-only edit, or a
+    metadata-only restore that lands back on the same bytes), the relay does **not** upload a second
+    copy: the new revision's `payload.file` carries `{ size, i }`, where `i` is the index of the
+    revision whose `.file` object **owns** the bytes. An **absent `i` means "own index"** — the
+    bytes live at this revision's own `‹i›.file` sibling (so already-written L2 revisions need no
+    migration). References always **collapse to the bytes-owning revision — they never chain**: a
+    reference resolves through the owner's `file.i` (or, absent, the latest revision's own index) in
+    one hop. The `.file`-reading endpoints (`revisions/{i}/file`, the restore file re-ingest) and
+    lock renewal all resolve `refIndex = file.i ?? i` before reading or extending the payload object.
+    Every consumer of a prefix listing is **suffix-aware**: `nextIndex`, `latestKey`, the
     dedupe check, and the revisions endpoints all filter out `.file` keys before parsing an index,
     so a payload sibling is never mistaken for its own revision.
 - **Key layout (flat, id-keyed, one joint sequence per dataset):**
@@ -258,10 +270,14 @@ pushing the current anchor's retain-until date forward in place — no new revis
 This is the standard object-lock pattern (the same refresh-retention approach backup tools
 such as Veeam/Kopia use). Owned by the sliding checker (§3.3): when a long-lived resource's
 check passes and its horizon nears expiry, the checker extends the anchor's lock; on a
-mismatch it raises a breach instead. **At level 2 the anchor is a revision *pair***: the
-revision JSON and, when present, its `‹i›.file` payload sibling (§3.1) share the same
-retain-until, so renewal extends **both** locks together — a payload's repairability would
-otherwise silently expire while the revision JSON itself stayed protected.
+mismatch it raises a breach instead. **At level 2 the anchor is a revision *pair***: the latest
+revision JSON and the payload object it **references** (§3.1). Renewal extends the latest revision
+JSON and, resolving `refIndex = file.i ?? i`, the `‹refIndex›.file` payload it points at — which,
+under payload reference dedupe, may be an **earlier** revision's copy. Extending both together keeps
+a payload's repairability from silently expiring while the revision JSON stays protected. A
+**superseded** payload (one the latest revision no longer references) stops sliding at renewal, but
+it was already extended to each referencing revision's retain-until at *write* time (§3.1, §3.5), so
+it outlives every revision that references it.
 
 > **Dependency — resolved 2026-07-16:** lock prolongation is validated on Scaleway
 > (staging, fr-par; aws-cli spike covering inline and default-retention locks, with and
@@ -293,10 +309,16 @@ applied identically to files, metadata documents, and dataset lines:
 
 > Every write appends a new write-once locked revision (object-lock makes *all* revisions
 > immutable — nothing is special to any class). The **latest** revision is the anchor: its lock
-> slides forward (§3.4) — extending the revision *and*, at level 2, its `.file` payload sibling
-> together as one pair — so the **current state is preserved indefinitely**, while older
-> revisions age out at retention so **history is recoverable only within the retention window**.
-> A deletion is just a tombstone latest-revision that stops being renewed and ages out.
+> slides forward (§3.4) — extending the revision *and*, at level 2, the `.file` payload it
+> **references** (its own copy, or, under payload reference dedupe, an earlier revision's) together
+> as one pair — so the **current state is preserved indefinitely**, while older revisions age out at
+> retention so **history is recoverable only within the retention window**. A deletion is just a
+> tombstone latest-revision that stops being renewed and ages out.
+
+At **write** time a revision that *references* an earlier payload also extends that payload's lock to
+its own retain-until, so a payload's lifetime is the max over every revision that references it —
+each referencing revision's file survives at least as long as its revision JSON, even once the
+payload itself is superseded and stops sliding (§3.4).
 
 This gives every resource the same guarantee as a single file: current state always restorable
 (level 2), any past state restorable within the retention window.
@@ -559,10 +581,12 @@ static-content / storage quota**: the per-owner historized prefix size (§3.1) i
 data-fair already meters. Activating integrity for an owner is a setting, not a separately
 priced product.
 
-The dominant cost driver is level 2's payload retention: it stores a full locked file copy per
-revision (N revisions × file size, within the retention window) — including revisions triggered
-by metadata-only edits, since every anchor is a joint one — and that accumulated size is metered
-into the owner's storage consumption.
+The dominant cost driver is level 2's payload retention: it stores one full locked file copy per
+**distinct file version** within the retention window (not per revision). Metadata-only revisions —
+the joint anchor re-records them whenever covered metadata changes — carry only a lightweight
+reference (`payload.file.i`) to the existing copy rather than duplicating the bytes (payload
+reference dedupe, §3.1). So the accumulated payload size scales with the number of *file* changes,
+not the number of revisions, and that size is metered into the owner's storage consumption.
 
 ## 10. Decomposition & build order
 

--- a/docs/architecture/integrity.md
+++ b/docs/architecture/integrity.md
@@ -219,6 +219,11 @@ preferred precisely because it eliminates this gap.
   refuses with 409 if the dataset isn't in a stable `finalized`/`error` state, and the `restore`
   context rides the draft's `_needsHistorizing` stamp through to `finalize`, which the async relay
   then anchors with `force: true` for the same reason.
+- **Accepted transient-breach window on file restore.** Between the synchronous metadata write
+  and the draft's validation landing at `finalize`, the hot doc reflects healed metadata over
+  still-stale (or mid-reprocessing) file bytes; a sliding-checker pass or a manual check that lands
+  in that narrow window can compare against the old anchor and record a transient breach — an
+  accepted window, resolved once the anchor written at finalize supersedes it.
 - Automatic re-push into the history is **not** done initially, but is possible by API.
 - **No realtime channel.** The admin actions (enable / check / fix) are synchronous and their
   response carries the fresh state, so the panel updates on the action's own await — there is no
@@ -374,7 +379,7 @@ once per environment; on a fresh environment both datasets seed automatically.
 
 | Resource class | Level 1 (detect) | Level 2 (repair) | Hashing |
 |---|---|---|---|
-| Mongo metadata docs (dataset/app metadata, settings, …) | ✅ **delivered for datasets** (target 2); applications/settings deferred | ✅ **delivered for datasets** (bundled with the file-class joint anchor, §3.1); applications/settings deferred | canonical (stable-key-sorted) JSON of a **denylist projection** → SHA-256 |
+| Mongo metadata docs (dataset/app metadata, settings, …) | ✅ **delivered for datasets** (target 2); applications/settings deferred | ✅ **delivered for datasets** (bundled with the file-class joint anchor, §3.1); applications/settings deferred — note the metadata half rides the file-class joint anchor, so **enrollment itself is gated on a finalized file dataset** (the `_integrity` enable check, §3): a non-file dataset cannot enroll today, even for metadata-only protection | canonical (stable-key-sorted) JSON of a **denylist projection** → SHA-256 |
 | Data files | trivial (md5 already stored) | ✅ **delivered — always-on, no size gate** | reuse existing `md5` |
 | Editable (REST) dataset — **Mongo lines** (source of truth) | feasible (see below) | size/cardinality-gated | exact fold over the precomputed per-line `_hash`, sorted by `_i` |
 | Editable dataset — **ES index** (derived) | n/a — rebuildable projection | n/a — repair = reindex | not historized (rebuildable projection) |
@@ -553,6 +558,11 @@ No separate billing surface. Historized storage is **counted toward the owner's 
 static-content / storage quota**: the per-owner historized prefix size (§3.1) is added to what
 data-fair already meters. Activating integrity for an owner is a setting, not a separately
 priced product.
+
+The dominant cost driver is level 2's payload retention: it stores a full locked file copy per
+revision (N revisions × file size, within the retention window) — including revisions triggered
+by metadata-only edits, since every anchor is a joint one — and that accumulated size is metered
+into the owner's storage consumption.
 
 ## 10. Decomposition & build order
 

--- a/docs/architecture/integrity.md
+++ b/docs/architecture/integrity.md
@@ -1,18 +1,20 @@
 # Data integrity & traceability
 
-> Status: **target 1 (dataset files) — level 1 detection delivered; target 2 (dataset
-> metadata) — level 1 detection delivered**, then **simplified** (joint anchor, depersonalized
-> context, synchronous admin actions — see
+> Status: **target 1 (dataset files) — level 1 detection + level 2 repair delivered; target 2
+> (dataset metadata) — level 1 detection delivered**, then **simplified** (joint anchor,
+> depersonalized context, synchronous admin actions — see
 > [docs/plans/2026-07-16-integrity-simplification-design.md](../plans/2026-07-16-integrity-simplification-design.md)).
 > The shared core (locked-revision store, transactional-outbox relay, sliding checker) uses a
 > **single joint anchor per dataset**: one revision sequence records **both** the file md5 and the
 > covered-metadata sha256 on every revision, with one verdict, one outbox stamp and one API/UI
 > surface — the file and metadata parts are named inside a breach, not carried as separate anchor
-> classes. The superadmin API and admin UI ship in this iteration;
-> [§10](#10-decomposition--build-order) records precisely what is built vs. what remains (level
-> 2 repair, applications/settings metadata, target 3). This document describes a focused
-> **data-fair feature**, delivered as **three progressive targets** (dataset files → dataset
-> metadata → editable-dataset collections); target 3 and level 2 each get their own
+> classes. **Level 2 (repair) delivered for file datasets** — every anchor carries the full
+> payload (file copy + covered-metadata snapshot); diff, audit download and restore-from-any-
+> revision ship with it; owner transfer is forbidden while integrity is active. The superadmin API
+> and admin UI ship in this iteration; [§10](#10-decomposition--build-order) records precisely
+> what is built vs. what remains (applications/settings metadata, target 3). This document
+> describes a focused **data-fair feature**, delivered as **three progressive targets** (dataset
+> files → dataset metadata → editable-dataset collections); target 3 gets its own
 > spec → plan → implementation cycle next. Scope deliberately left out for now —
 > generalization beyond data-fair, an immutable append-only **log posture** (events, HTTP
 > logs), and a central integrity service — is parked in
@@ -67,10 +69,12 @@ the same machinery; they differ only in what each revision stores.
   check recomputes the hot resource's hash and compares it to the latest stored hash; any
   divergence means something wrote out-of-band → breach. Cheap. **Baseline goal for every
   sensitive resource.**
-- **Level 2 — Repair.** The same revision additionally stores the **full payload** alongside
-  the hash. This unlocks the admin-facing diff *and* "restore the hot resource from the
-  latest verified revision." An opt-in *upgrade* of level 1, applied **where the storage cost
-  is reasonable**.
+- **Level 2 — Repair.** ✅ **Delivered for file datasets.** The same revision additionally
+  stores the **full payload** alongside the hash. This unlocks the admin-facing diff *and*
+  restore-from-**any** historized revision (not just the latest). **Always-on, no size
+  gate** — the maintainer's call: storage cost is proportional to the file size and already
+  metered into the owner's existing storage consumption (§9), so there is no threshold below
+  which level 2 is skipped.
 - **Level 3 — Prevention.** **Out of scope** here, and mechanically different: a superadmin
   marks a resource read-only even to client admins. Noted for completeness; it would be a
   separate feature, not built on this store.
@@ -94,9 +98,21 @@ reasonable (it may never be reasonable for large editable datasets — see §5).
     and an optional free-text reason (on `fixIntegrity` only). It carries **no user identity**
     by construction (§1's trail/journal split), so it holds no personal data — see §8.
   - `dataset` — `{ id, slug }`, a small denormalized descriptor of the anchored dataset.
-  - `payload` — present only at level 2 (the full covered projection / file copy).
+  - `payload` — present only at level 2: `{ metadata: <covered projection>, file?: { size } }`.
+    `metadata` is the **full** `coveredMetadata()` projection (not merely its hash), stored so it
+    can be diffed and restored field-by-field; `file`, present when the anchor covers a file
+    dataset, records the payload's byte size. The file's actual bytes are **not** inlined in this
+    JSON — they live in a **sibling** locked object at `‹revisionKey›.file` (the `PAYLOAD_SUFFIX`),
+    under the **same** compliance lock and retain-until date as the revision JSON, **written
+    payload-first**: the relay uploads the `.file` object before writing the revision JSON that
+    references it, so a crash in between leaves an orphan `.file` that ages out harmlessly —
+    never a revision claiming a payload it doesn't have (the reverse order would risk exactly
+    that). Every consumer of a prefix listing is **suffix-aware**: `nextIndex`, `latestKey`, the
+    dedupe check, and the revisions endpoints all filter out `.file` keys before parsing an index,
+    so a payload sibling is never mistaken for its own revision.
 - **Key layout (flat, id-keyed, one joint sequence per dataset):**
-  `‹service›/‹owner.type›-‹owner.id›/‹resourceId›/‹i›` (zero-padded `‹i›`). There is no
+  `‹service›/‹owner.type›-‹owner.id›/‹resourceId›/‹i›` (zero-padded `‹i›`), plus the optional
+  `‹i›.file` payload sibling above. There is no
   `‹class›` segment — the file and metadata parts share a **single revision sequence** indexed
   from `0`, since they always enable, anchor and check together (per-class enable was never
   exposed). Zero-padding makes the keys sort lexically == numerically, so "latest" is the
@@ -187,6 +203,22 @@ preferred precisely because it eliminates this gap.
   (`anchorDataset()`), then runs `checkDataset()` and **responds with the fresh verdict** — the
   reconcile action completes on its own await, with no outbox stamp and no waiting for the next
   sweep.
+- **Diff and restore (level 2, delivered).** `GET …/_integrity/revisions/{i}` returns the
+  snapshot alongside the dataset's *current* covered projection in one call, so the UI renders
+  the metadata diff without a second round-trip; `GET …/_integrity/revisions/{i}/file` streams
+  the payload back with a `content-disposition` taken from the snapshot's `originalFile`. `POST
+  _integrity/_restore { i, reason? }` writes back **any** payload-bearing revision (not only the
+  latest) and always leaves its own auditable `restore` revision — dedupe is bypassed
+  (`force: true`) so a remediation that lands back on a byte-identical state cannot silently
+  vanish from the trail. Metadata-only restores (no file divergence) are **synchronous**, exactly
+  like `_fix`: `restoreUpdate()` writes back only the covered keys that genuinely diverge from the
+  snapshot, then the route re-anchors inline and responds with the fresh verdict. A **file**
+  restore instead re-ingests the stored payload through the **standard draft pipeline** — the
+  same path a manual file replacement takes — because replacing bytes must go through the usual
+  validation/finalize flow, not a raw overwrite; the route responds `{ status: 'restoring' }`,
+  refuses with 409 if the dataset isn't in a stable `finalized`/`error` state, and the `restore`
+  context rides the draft's `_needsHistorizing` stamp through to `finalize`, which the async relay
+  then anchors with `force: true` for the same reason.
 - Automatic re-push into the history is **not** done initially, but is possible by API.
 - **No realtime channel.** The admin actions (enable / check / fix) are synchronous and their
   response carries the fresh state, so the panel updates on the action's own await — there is no
@@ -221,7 +253,10 @@ pushing the current anchor's retain-until date forward in place — no new revis
 This is the standard object-lock pattern (the same refresh-retention approach backup tools
 such as Veeam/Kopia use). Owned by the sliding checker (§3.3): when a long-lived resource's
 check passes and its horizon nears expiry, the checker extends the anchor's lock; on a
-mismatch it raises a breach instead.
+mismatch it raises a breach instead. **At level 2 the anchor is a revision *pair***: the
+revision JSON and, when present, its `‹i›.file` payload sibling (§3.1) share the same
+retain-until, so renewal extends **both** locks together — a payload's repairability would
+otherwise silently expire while the revision JSON itself stayed protected.
 
 > **Dependency — resolved 2026-07-16:** lock prolongation is validated on Scaleway
 > (staging, fr-par; aws-cli spike covering inline and default-retention locks, with and
@@ -253,9 +288,10 @@ applied identically to files, metadata documents, and dataset lines:
 
 > Every write appends a new write-once locked revision (object-lock makes *all* revisions
 > immutable — nothing is special to any class). The **latest** revision is the anchor: its lock
-> slides forward (§3.4) so the **current state is preserved indefinitely**, while older revisions
-> age out at retention so **history is recoverable only within the retention window**. A deletion
-> is just a tombstone latest-revision that stops being renewed and ages out.
+> slides forward (§3.4) — extending the revision *and*, at level 2, its `.file` payload sibling
+> together as one pair — so the **current state is preserved indefinitely**, while older
+> revisions age out at retention so **history is recoverable only within the retention window**.
+> A deletion is just a tombstone latest-revision that stops being renewed and ages out.
 
 This gives every resource the same guarantee as a single file: current state always restorable
 (level 2), any past state restorable within the retention window.
@@ -338,8 +374,8 @@ once per environment; on a fresh environment both datasets seed automatically.
 
 | Resource class | Level 1 (detect) | Level 2 (repair) | Hashing |
 |---|---|---|---|
-| Mongo metadata docs (dataset/app metadata, settings, …) | ✅ **delivered for datasets** (target 2); applications/settings deferred | cheap — reasonable, deferred alongside file-class level 2 | canonical (stable-key-sorted) JSON of a **denylist projection** → SHA-256 |
-| Data files | trivial (md5 already stored) | duplication cost — reasonable up to a size threshold | reuse existing `md5` |
+| Mongo metadata docs (dataset/app metadata, settings, …) | ✅ **delivered for datasets** (target 2); applications/settings deferred | ✅ **delivered for datasets** (bundled with the file-class joint anchor, §3.1); applications/settings deferred | canonical (stable-key-sorted) JSON of a **denylist projection** → SHA-256 |
+| Data files | trivial (md5 already stored) | ✅ **delivered — always-on, no size gate** | reuse existing `md5` |
 | Editable (REST) dataset — **Mongo lines** (source of truth) | feasible (see below) | size/cardinality-gated | exact fold over the precomputed per-line `_hash`, sorted by `_i` |
 | Editable dataset — **ES index** (derived) | n/a — rebuildable projection | n/a — repair = reindex | not historized (rebuildable projection) |
 
@@ -389,10 +425,10 @@ once per environment; on a fresh environment both datasets seed automatically.
   metadata field is computed on create and, even with the maintain-on-update fix, an *out-of-band*
   edit (exactly what `fixIntegrity` reconciles) never updates it — so anchoring the metadata would
   dedupe and never re-anchor. Relay and checker therefore call the same `md5OfStorageFile(...)`,
-  keeping them symmetric. Level 2 copies the file into the historized bucket and is **gated by a
-  size threshold**. The historized bucket stays fully separate from the main storage bucket
-  (which is unchanged), keeping the model homogeneous with the Mongo case at the cost of some
-  duplication.
+  keeping them symmetric. **Level 2 is delivered and always-on (no size gate**, §2): every anchor
+  copies the file into the historized bucket as its `‹i›.file` payload sibling (§3.1). The
+  historized bucket stays fully separate from the main storage bucket (which is unchanged),
+  keeping the model homogeneous with the Mongo case at the cost of some duplication.
 - **ES is not a historization target — it is a rebuildable projection.** For REST datasets
   Mongo is the source of truth; the ES index is derived (the indexer strips `_hash`/`_deleted`,
   the ES `_id` is a throwaway `nanoid`, and a full reindex rebuilds the index from Mongo). So ES
@@ -526,18 +562,22 @@ detect-only where repair is too costly. The shared core primitive (locked-revisi
 write wrapper, checker) is **extracted from target 1 and reused**, not built up front as a
 speculative framework.
 
-1. **Dataset data files** — ✅ **level 1 (detect) + lock renewal delivered.** The relay historizes
-   the *stored file's* md5 on every finalize (transactional outbox, §3.2); the sliding checker
-   recomputes and compares it, raising a breach on divergence (§3.3); and it now **renews the
-   anchor's lock by extension** (§3.4 Option B) — pushing the compliance retain-until forward on a
-   ~monthly cadence (`RENEW_INTERVAL = 1/12` of the retention window) so the current state stays
-   protected indefinitely, and surfacing a loud `lastRenewal: failed` state (alert + UI warning) if
-   a provider rejects the prolongation. The superadmin enable/disable/check/fix API plus the admin
-   UI panel (§7) are wired end to end. Lock prolongation is **validated on Scaleway** (spike,
-   2026-07-16 — §12), so renewal-by-extension stands as the primary model on the target provider.
-   **Immediate next step for this target:** *level 2 (repair)* — copy the file into the historized
-   bucket, size-gated. Re-anchoring (§3.4 Option A) is not needed for Scaleway; it remains a
-   portability note for providers that cannot prolong a lock.
+1. **Dataset data files** — ✅ **level 1 (detect) + level 2 (repair) + lock renewal delivered.**
+   The relay historizes the *stored file's* md5 on every finalize (transactional outbox, §3.2);
+   the sliding checker recomputes and compares it, raising a breach on divergence (§3.3); and it
+   **renews the anchor's lock by extension** (§3.4 Option B) — pushing the compliance retain-until
+   forward on a ~monthly cadence (`RENEW_INTERVAL = 1/12` of the retention window) so the current
+   state stays protected indefinitely, and surfacing a loud `lastRenewal: failed` state (alert +
+   UI warning) if a provider rejects the prolongation. The superadmin enable/disable/check/fix/
+   restore API plus the admin UI panel (§7) are wired end to end. Lock prolongation is **validated
+   on Scaleway** (spike, 2026-07-16 — §12), so renewal-by-extension stands as the primary model on
+   the target provider. **Level 2 (repair) ships always-on, no size gate** (§2, §5): every anchor
+   additionally carries the covered-metadata projection and, for file datasets, a `.file` payload
+   sibling (§3.1) — unlocking the admin-facing diff, an audit download of any historized revision,
+   and restore-from-any-revision (§3.3, §7). Restoring metadata alone is synchronous; restoring a
+   file re-ingests through the standard draft pipeline, with the restore context preserved by
+   finalize. Re-anchoring (§3.4 Option A) is not needed for Scaleway; it remains a portability note
+   for providers that cannot prolong a lock.
 2. **Dataset Mongo metadata** — ✅ **level 1 (detect) delivered this iteration, for datasets**,
    then folded into the **joint anchor** (§3.1). A dataset has one revision sequence carrying
    **both** the file md5 and the covered-metadata sha256, one verdict
@@ -551,8 +591,8 @@ speculative framework.
    `stampHistorizeMany`, §5). Superadmin API and admin UI (§7) cover file and metadata uniformly
    (per-class enable was never exposed — enabling integrity anchors both together).
    **Explicitly deferred:** applications and settings metadata (this iteration covers **datasets
-   only**); level 2 (payload snapshots, diff, restore) — file and metadata level 2 stay a single
-   follow-on unit of work since they share the same payload-storage machinery.
+   only**) — level 2 (payload snapshots, diff, restore) shipped together with target 1 above,
+   since file and metadata level 2 share the same payload-storage machinery.
 
    **Simplification (2026-07-16,
    [design](../plans/2026-07-16-integrity-simplification-design.md)).** After targets 1+2 landed,

--- a/docs/plans/2026-07-17-integrity-level2-repair-design.md
+++ b/docs/plans/2026-07-17-integrity-level2-repair-design.md
@@ -1,0 +1,155 @@
+# Integrity level 2 (repair) — design
+
+> Status: approved 2026-07-17, to be implemented on feat-integrity4. Companion to
+> [docs/architecture/integrity.md](../architecture/integrity.md) (§2 levels, §3 mechanism,
+> §10 build order — "level 2 repair, file and metadata as a single follow-on unit").
+
+## Goal
+
+Upgrade the delivered level-1 detection (joint anchor per dataset: file md5 +
+covered-metadata sha256 in a compliance-locked S3 store) to **level 2 — repair**: every
+anchor revision additionally stores the **full payload** (file copy + covered-metadata
+snapshot), unlocking the admin-facing **diff**, **audit download** of any historical
+version, and **restore** of the hot resource from any stored revision.
+
+Decisions settled with the maintainer before this design:
+
+- **Always-on for file datasets — no size gate.** Enabling integrity gives level 2
+  unconditionally; storage cost is proportional and simply counted toward the owner's
+  static-storage consumption (§9 of the architecture doc). Editable/incremental datasets
+  are out of scope (target 3, discussed later).
+- **Any stored revision is restorable** (not just the latest) — the §3.5 promise: current
+  state always restorable, any past state restorable within the retention window.
+- **Owner transfer is forbidden while integrity is active.** `changeOwner` refuses
+  integrity-active datasets instead of re-anchoring under the new owner prefix. To
+  transfer, a superadmin disables integrity first (anchors age out under the old prefix),
+  transfers, re-enables.
+- **File restore re-ingests through the normal worker pipeline** (as if the user
+  re-uploaded that version), so all derived state (schema, index, previews) is rebuilt
+  consistently.
+
+## A. Payload storage layout
+
+Extends the existing key layout `data-fair/{owner.type}-{owner.id}/{datasetId}/{i}`
+(zero-padded `i`, one joint sequence per dataset):
+
+- **Metadata snapshot — inline.** The revision JSON at `{i}` gains
+  `payload: { metadata: <covered projection> }` — the exact object that was hashed
+  (stable-key-sorted at hash time; stored as-is). It is small (KBs) and GDPR-clean by
+  construction: the covered denylist already strips `createdBy` / `updatedBy`, and
+  denormalized names are normalized out (D1). One GET returns a complete revision.
+- **File copy — sibling object** at `{i}.file`: same bucket, same COMPLIANCE lock and
+  retain-until as its revision JSON, streamed from `filesStorage.readStream()` (fs or S3
+  backend) via multipart upload (`@aws-sdk/lib-storage` `Upload`). The revision JSON
+  records `payload.file = { size }` so listings can tell a revision is restorable without
+  HEADing the payload object. Non-file parts (a dataset whose stored file is missing)
+  simply have no `.file` object and no `payload.file`.
+- **Write order: payload first, then the revision JSON.** A crash in between leaves an
+  orphan `.file` that ages out harmlessly at retention; the reverse order would leave a
+  revision claiming a repairability it doesn't have.
+- `latestKey` / `nextIndex` / the revisions listing become **suffix-aware**: keys ending
+  in `.file` are payload objects, not revisions, and are filtered out of index parsing.
+- **Rejected alternatives.** All-in-one object (cannot mix GB binary into JSON, no
+  streaming); a separate `payload/` prefix (second list call, and breaks the
+  one-prefix-per-dataset storage-accounting simplicity).
+
+## B. Anchor & enable flow changes
+
+- `anchorDataset()` keeps its two-pass shape: compute hashes first, run the dedupe check,
+  and only if a new revision is needed re-read the stored file to upload the payload, then
+  write the revision JSON. (A one-pass hash-while-uploading needs a staging key and S3 has
+  no rename — not worth it.)
+- **Dedupe gains one condition:** skip only if the hash pair matches **and** the latest
+  anchor carries a payload. A payload-less L1-era anchor with matching hashes gets a fresh
+  payload-bearing revision instead — the store self-heals to level 2. The
+  disable→re-enable `lastRevision` restore branch is preserved.
+- **No backfill needed:** no production deployment holds L1 anchors, so there is no
+  upgrade script. The payload-aware dedupe above self-heals the few dev/staging
+  enrollments on their next anchor.
+- **Enable stays synchronous** (D4 of the simplification) but now includes the file
+  upload: for a multi-GB file this is a long request. Accepted — enable is a rare
+  superadmin action; the request-timeout caveat is noted in the architecture doc.
+- **`changeOwner` refusal:** the owner-transfer route returns 400 for integrity-active
+  datasets ("disable integrity before transferring ownership"). The transfer re-anchor
+  stamp in `datasets/routes/metadata.ts` is deleted; integrity.md §3.1's owner-transfer
+  note is rewritten accordingly.
+
+## C. Restore
+
+New superadmin route `POST /datasets/{id}/_integrity/_restore { i, reason? }`
+(admin-mode gated, same posture as `_fix`):
+
+- **Guards:** 400 if integrity isn't active, if revision `i` doesn't exist, or if it
+  carries no payload (L1-era anchor).
+- **Metadata part.** Replace the hot doc's covered keys with the snapshot's: every covered
+  key present in the snapshot is written; covered keys present on the hot doc but absent
+  from the snapshot are unset; operational/denylisted fields are untouched. Special cases:
+  - `owner` — written back as the snapshot's normalized `{ type, id, department? }` only
+    when it differs from the hot owner. Since transfers are forbidden while active, a
+    difference can only come from tampering; restoring the normalized form heals it (names
+    re-sync from simple-directory on the next propagation).
+  - `topics` — restored as `{ id }` entries, then re-hydrated (title/color/icon) from the
+    owner's `settings.topics`; ids no longer present in settings stay as bare ids (same
+    state a topic deletion propagation would leave).
+  - `permissions[].name` — display-only; stays absent until natural re-sync.
+- **File part.** Only when the snapshot md5 differs from the current stored file's md5:
+  download `{i}.file` to a tmp file and feed it through the standard file-replacement
+  path, so the worker pipeline (analyze → index → finalize) rebuilds all derived state.
+  The write stamps the outbox with `{ operation: 'restore', origin: 'superadmin',
+  reason? }`; finalize's existing re-anchor then produces the new revision. The finalize
+  stamp must **preserve** a pre-set restore context rather than overwrite it with the
+  generic worker context.
+- **Response.** Metadata-only restore is fully synchronous: write metadata, inline
+  `anchorDataset()` with the restore context, `checkDataset()`, respond with the fresh
+  verdict (same shape as `_fix`). A restore that includes the file responds with the
+  dataset in its normal processing state; the anchor lands at finalize and the panel shows
+  it on next load (consistent with the no-realtime posture, D4).
+- **Append-only.** Restore always appends a new revision (`operation: 'restore'` joins
+  the `RevisionOperation` enum) — the sequence never rewinds; the restored state becomes
+  the new latest anchor with a fresh lock.
+
+## D. Diff & payload read API
+
+- `GET /datasets/{id}/_integrity/revisions/{i}` — guarded by the existing
+  `readIntegrityRevisions` admin-class permission. Returns the full revision (hash,
+  context, `payload.metadata`) **plus the current covered projection**, so the UI renders
+  a metadata diff in one call.
+- `GET /datasets/{id}/_integrity/revisions/{i}/file` — same permission; streams the
+  locked `.file` payload with sensible content headers — audit download of any historical
+  version.
+- **UI** (integrity tab, revisions table): per-row actions — view metadata diff (dialog),
+  download file payload; **restore** shown in admin mode only, behind a confirm dialog
+  with an optional reason field. Payload-less rows are marked non-restorable.
+
+## E. Lifecycle details
+
+- **Lock renewal:** `maybeRenew` extends retention on **both** `{i}` and `{i}.file` of the
+  latest revision (the sliding anchor is the revision *pair*).
+- **Storage accounting:** automatic — payloads live under the owner prefix, whose size §9
+  already meters into the owner's storage consumption.
+- **Deletion:** unchanged — renewal stops when the dataset is deleted, and payloads age
+  out with their revisions at retention.
+
+## F. Testing
+
+Following the existing three-file split under `tests/features/integrity/`:
+
+- **operations.unit.spec.ts** — new pure functions in `integrity/operations.ts`:
+  restore-projection merge (covered-key replace/unset, owner/topics handling),
+  suffix-aware key filtering (`latestKey` / `nextIndex` / revision listing ignore
+  `.file`), payload-aware dedupe predicate.
+- **core.api.spec.ts** — against MinIO: payload written with the anchor (revision JSON
+  `payload.metadata` + `.file` object, locked), dedupe skip when latest has payload,
+  self-healing upgrade when it doesn't.
+- **admin.api.spec.ts** — end to end: file tamper → restore → reprocessed dataset + fresh
+  `restore` anchor + `ok` verdict; metadata tamper → synchronous restore verdict;
+  restore of an older revision; `changeOwner` refusal; revision detail (diff payload) and
+  file download endpoints; payload-less revision returns 400 on restore.
+- **Dev fixture:** extend the breach fixture demo with a restore step.
+
+## Documentation
+
+- `docs/architecture/integrity.md`: §2 (level 2 delivered), §3.1 (payload layout, sibling
+  `.file` object, owner-transfer forbidden), §3.3 (diff/restore now available), §3.4/§3.5
+  (renewal covers the payload object), §5 (files row: level 2 delivered, no size gate),
+  §10 (status update).

--- a/docs/plans/2026-07-17-integrity-level2-repair-design.md
+++ b/docs/plans/2026-07-17-integrity-level2-repair-design.md
@@ -153,3 +153,32 @@ Following the existing three-file split under `tests/features/integrity/`:
   `.file` object, owner-transfer forbidden), §3.3 (diff/restore now available), §3.4/§3.5
   (renewal covers the payload object), §5 (files row: level 2 delivered, no size gate),
   §10 (status update).
+
+## Amendment (2026-07-17) — payload reference dedupe
+
+The original design above stored **one locked file copy per anchor revision** (`payload.file =
+{ size }`, a `‹i›.file` sibling on every revision). Because the joint anchor re-anchors on
+**metadata-only** edits too, that duplicated the full file bytes for every metadata change — an
+unacceptable storage cost the maintainer **rejected**. The agreed replacement stores **one locked
+copy per distinct file version**; metadata-only revisions reference the existing copy.
+
+Semantics (as implemented):
+
+- **Shape.** `payload.file` becomes `{ size, i? }`. `i` is the index of the revision whose `.file`
+  object **owns** the bytes. **Absent `i` means "own index"** — the bytes live at this revision's own
+  `‹i›.file` sibling, so already-written L2 revisions need no migration. References always **collapse
+  to the bytes-owning revision — never chain**.
+- **Anchor (`anchorDataset`).** The two-hash full dedupe is unchanged. When writing a new revision
+  with `hash.md5` set: if the latest anchor carries a `payload.file` **and** its `hash.md5` equals
+  the new file's md5 (file unchanged), do **not** upload — resolve `refIndex = latest.payload.file.i
+  ?? parseRevisionIndex(latest)`, **extend the referenced payload's retention** to the new revision's
+  retain-until, and set `payload.file = { size: latest.payload.file.size, i: refIndex }` (keeping the
+  first-pass md5, no tee). Otherwise upload a fresh copy at the own key (`payload.file = { size }`).
+- **Renewal (`maybeRenew`).** The sliding pair is the latest revision JSON **plus the payload it
+  references**: extend `latestKey`, and `payloadKey(refIndex)` where `refIndex = latest.payload.file.i
+  ?? parseRevisionIndex(latestKey)`.
+- **Readers.** `GET revisions/{i}/file` and the `_restore` file re-ingest resolve `refIndex =
+  file.i ?? i` before reading the payload object.
+- **Retention aging.** Because each referencing revision extends the owning payload at **write**
+  time, a superseded payload stops sliding at renewal but still outlives every revision that
+  references it — each revision's file payload survives at least as long as its revision JSON.

--- a/docs/plans/2026-07-17-integrity-level2-repair-plan.md
+++ b/docs/plans/2026-07-17-integrity-level2-repair-plan.md
@@ -1,0 +1,1236 @@
+# Integrity Level 2 (Repair) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every integrity anchor revision additionally stores the full payload (file copy + covered-metadata snapshot), unlocking metadata diff, audit download of any historical file version, and restore of the hot dataset from any stored revision.
+
+**Architecture:** The spec is `docs/plans/2026-07-17-integrity-level2-repair-design.md` — read it first. Metadata snapshot goes inline in the revision JSON (`payload.metadata`); the file copy is a sibling locked object at `{i}.file` written *before* the revision JSON. Dedupe becomes payload-aware (self-healing upgrade of L1-era anchors). Restore is a superadmin route: metadata-only restores are synchronous (like `_fix`); file restores re-ingest through the standard draft/worker pipeline with a `restore` outbox context preserved by finalize. Owner transfer is forbidden while integrity is active.
+
+**Tech Stack:** TypeScript (Node, `--experimental-strip-types`), Express 5, MongoDB, S3 (`@aws-sdk/client-s3` + `@aws-sdk/lib-storage` — already a dependency), MinIO in dev/test, Playwright tests, Vue 3 + Vuetify UI.
+
+## Global Constraints
+
+- Never start/stop dev processes; tests run against the test env (`npx playwright test <file>` — see `docs/architecture/testing.md`). Run only the related spec files, not the whole suite.
+- Type ratchet: no net-new tsc errors (`dev/check-types-ratchet.sh` gates pushes). `npm run lint` must stay clean (a pre-commit hook runs it).
+- Key layout is frozen: `data-fair/{owner.type}-{owner.id}/{datasetId}/{i}` (zero-padded width 9). The payload suffix is exactly `.file`.
+- The WORM store must never receive personal data: `payload.metadata` is the covered projection only (already strips `createdBy`/`updatedBy`, normalizes denormalized names).
+- Write order is payload first, then revision JSON — never the reverse.
+- All code comments in English; UI strings in French + English (component `<i18n>` blocks).
+
+---
+
+### Task 1: Store payload primitives
+
+**Files:**
+- Modify: `api/src/integrity/store.ts`
+- Test: `tests/features/integrity/core.api.spec.ts`
+
+**Interfaces:**
+- Consumes: existing `IntegrityStore` (S3 client wrapper), `RevisionBody`.
+- Produces: `RevisionBody.payload?: { metadata: Record<string, any>, file?: { size: number } }`; `IntegrityStore.writePayload(key: string, body: Readable, retainUntil: Date): Promise<void>`; `IntegrityStore.readPayload(key: string): Promise<{ body: Readable, size?: number }>`. Later tasks (4, 8, 9, 10) rely on these exact names.
+
+- [ ] **Step 1: Write the failing tests** — append to the "store" section of `tests/features/integrity/core.api.spec.ts`:
+
+```ts
+test('writePayload stores a compliance-locked binary sibling object', async () => {
+  const store = integrityTestStore
+  const base = `data-fair/test-store-payload/${Date.now()}/000000000`
+  const retainUntil = new Date(Date.now() + 24 * 3600 * 1000)
+  const { Readable } = await import('node:stream')
+  await store.writePayload(base + '.file', Readable.from(Buffer.from('payload-bytes')), retainUntil)
+
+  const { body, size } = await store.readPayload(base + '.file')
+  const chunks: Buffer[] = []
+  for await (const c of body) chunks.push(c as Buffer)
+  expect(Buffer.concat(chunks).toString()).toBe('payload-bytes')
+  expect(size).toBe('payload-bytes'.length)
+
+  // WORM: the locked payload version cannot be destroyed within retention
+  const versionId = await originalVersionId(base + '.file')
+  await expect(integrityTestClient.send(new DeleteObjectCommand({ Bucket: store.bucket, Key: base + '.file', VersionId: versionId })))
+    .rejects.toThrow()
+})
+
+test('a revision body can carry an inline metadata payload', async () => {
+  const store = integrityTestStore
+  const key = `data-fair/test-store-meta/${Date.now()}/000000000`
+  await store.writeRevision(key, {
+    hash: { md5: 'abc', sha256: 'def' },
+    context: { operation: 'create', origin: 'worker', date: new Date().toISOString() },
+    dataset: { id: 'ds-meta' },
+    payload: { metadata: { title: 'snap' }, file: { size: 13 } }
+  }, new Date(Date.now() + 24 * 3600 * 1000))
+  const back = await store.getRevision(key)
+  expect(back.payload?.metadata.title).toBe('snap')
+  expect(back.payload?.file?.size).toBe(13)
+})
+```
+
+Note: `originalVersionId` and `DeleteObjectCommand` already exist in this file (reuse them — `originalVersionId` reads the *first* version of a key, which is the only one here).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx playwright test tests/features/integrity/core.api.spec.ts -g "writePayload|inline metadata payload"`
+Expected: FAIL — `store.writePayload is not a function` / TS type error on `payload`.
+
+- [ ] **Step 3: Implement in `api/src/integrity/store.ts`**
+
+Add to imports: `import { Upload } from '@aws-sdk/lib-storage'` and `import type { Readable } from 'node:stream'`. Extend `RevisionBody`:
+
+```ts
+export type RevisionBody = {
+  hash: { md5?: string, sha256?: string }
+  context: RevisionContext
+  dataset: { id: string, slug?: string }
+  // level 2: the full covered-metadata projection, and the descriptor of the sibling
+  // `{key}.file` locked object when the revision carries a file copy
+  payload?: { metadata: Record<string, any>, file?: { size: number } }
+}
+```
+
+Add two methods to `IntegrityStore`:
+
+```ts
+  // Level-2 file payload: a sibling `{revisionKey}.file` object under the same compliance
+  // lock, streamed via multipart upload (files can be many GB).
+  async writePayload (key: string, body: Readable, retainUntil: Date): Promise<void> {
+    const upload = new Upload({
+      client: this.client,
+      params: {
+        Bucket: this.bucket,
+        Key: key,
+        Body: body,
+        ContentType: 'application/octet-stream',
+        ObjectLockMode: 'COMPLIANCE',
+        ObjectLockRetainUntilDate: retainUntil
+      }
+    })
+    await upload.done()
+  }
+
+  async readPayload (key: string): Promise<{ body: Readable, size?: number }> {
+    const res = await this.client.send(new GetObjectCommand({ Bucket: this.bucket, Key: key }))
+    return { body: res.Body as Readable, size: res.ContentLength }
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx playwright test tests/features/integrity/core.api.spec.ts -g "writePayload|inline metadata payload"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/integrity/store.ts tests/features/integrity/core.api.spec.ts
+git commit -m "feat(integrity): store primitives for level-2 payloads (inline metadata + .file sibling)"
+```
+
+---
+
+### Task 2: Suffix-aware key operations
+
+**Files:**
+- Modify: `api/src/integrity/operations.ts`
+- Test: `tests/features/integrity/operations.unit.spec.ts`
+
+**Interfaces:**
+- Produces: `PAYLOAD_SUFFIX = '.file'`, `payloadKey(owner, datasetId, i): string`, `isPayloadKey(key): boolean`; `latestKey` and `nextIndex` now ignore payload keys. Tasks 4, 5, 8, 9, 10 use `payloadKey`/`isPayloadKey`.
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/features/integrity/operations.unit.spec.ts`:
+
+```ts
+test('payloadKey appends the .file suffix to the revision key', () => {
+  expect(ops.payloadKey(owner, 'ds1', 7)).toBe('data-fair/organization-acme/ds1/000000007.file')
+  expect(ops.isPayloadKey('data-fair/organization-acme/ds1/000000007.file')).toBe(true)
+  expect(ops.isPayloadKey('data-fair/organization-acme/ds1/000000007')).toBe(false)
+})
+
+test('latestKey and nextIndex ignore payload keys', () => {
+  const keys = [
+    'data-fair/organization-acme/ds1/000000000',
+    'data-fair/organization-acme/ds1/000000001',
+    'data-fair/organization-acme/ds1/000000001.file'
+  ]
+  expect(ops.latestKey(keys)).toBe('data-fair/organization-acme/ds1/000000001')
+  expect(ops.nextIndex(keys)).toBe(2)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx playwright test tests/features/integrity/operations.unit.spec.ts -g "payloadKey|ignore payload keys"`
+Expected: FAIL — `ops.payloadKey is not a function`; `latestKey` returns the `.file` key (lexically greater).
+
+- [ ] **Step 3: Implement in `api/src/integrity/operations.ts`** — add after `parseRevisionIndex`:
+
+```ts
+// Level-2 file payloads are sibling objects `{revisionKey}.file` under the dataset prefix;
+// every consumer of a prefix listing must distinguish them from revision JSONs.
+export const PAYLOAD_SUFFIX = '.file'
+
+export const payloadKey = (owner: { type: string, id: string }, datasetId: string, i: number): string =>
+  revisionKey(owner, datasetId, i) + PAYLOAD_SUFFIX
+
+export const isPayloadKey = (key: string): boolean => key.endsWith(PAYLOAD_SUFFIX)
+```
+
+And make `nextIndex` and `latestKey` filter (payload keys would otherwise win the lexical sort):
+
+```ts
+export const nextIndex = (keys: string[]): number => {
+  let max = -1
+  for (const k of keys) {
+    if (isPayloadKey(k)) continue
+    const i = parseRevisionIndex(k)
+    if (!Number.isNaN(i) && i > max) max = i
+  }
+  return max + 1
+}
+
+export const latestKey = (keys: string[]): string | undefined => {
+  const revisionKeys = keys.filter((k) => !isPayloadKey(k))
+  if (!revisionKeys.length) return undefined
+  return revisionKeys.sort().at(-1) // zero-padded ⇒ lexical sort == numeric order
+}
+```
+
+- [ ] **Step 4: Run the whole unit spec to verify pass + no regression**
+
+Run: `npx playwright test tests/features/integrity/operations.unit.spec.ts`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/integrity/operations.ts tests/features/integrity/operations.unit.spec.ts
+git commit -m "feat(integrity): suffix-aware revision key operations for .file payloads"
+```
+
+---
+
+### Task 3: `anchorDataset` writes payloads, payload-aware dedupe
+
+**Files:**
+- Modify: `api/src/integrity/relay.ts`, `api/src/integrity/hash.ts`
+- Test: `tests/features/integrity/core.api.spec.ts`
+
+**Interfaces:**
+- Consumes: Task 1 (`writePayload`, `RevisionBody.payload`), Task 2 (`payloadKey`, filtered `latestKey`/`nextIndex`).
+- Produces: every new anchor written by `anchorDataset` carries `payload.metadata` (+ `payload.file` and the `.file` object for file datasets). Dedupe rule: skip only when hashes match AND the latest revision has a payload. `hash.ts` exports `md5Tee(): { stream: Transform, digest: () => string }`.
+
+- [ ] **Step 1: Write the failing tests** — append to the relay section of `core.api.spec.ts`:
+
+```ts
+test('anchor carries the level-2 payload: inline metadata snapshot + locked .file sibling', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  const prefix = revisionsPrefix(dataset)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+
+  const keys = await listIntegrityKeys(prefix)
+  expect(keys).toContain(`${prefix}000000000`)
+  expect(keys).toContain(`${prefix}000000000.file`)
+
+  const rev = await integrityTestStore.getRevision(`${prefix}000000000`)
+  expect(rev.payload?.metadata.title).toBe(dataset.title)
+  expect(rev.payload?.metadata.createdBy).toBeUndefined() // covered projection only
+  expect(rev.payload?.file?.size).toBeGreaterThan(0)
+
+  const { body } = await integrityTestStore.readPayload(`${prefix}000000000.file`)
+  const chunks: Buffer[] = []
+  for await (const c of body) chunks.push(c as Buffer)
+  const { createHash } = await import('node:crypto')
+  expect(createHash('md5').update(Buffer.concat(chunks)).digest('hex')).toBe(rev.hash.md5)
+})
+
+test('dedupe is payload-aware: an L1-era anchor self-heals to level 2', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  const prefix = revisionsPrefix(dataset)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+  expect((await listIntegrityKeys(prefix)).filter(k => !k.endsWith('.file')).length).toBe(1)
+
+  // unchanged state and a payload-bearing latest anchor → dedupe, no new revision
+  await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_fix`)
+  expect((await listIntegrityKeys(prefix)).filter(k => !k.endsWith('.file')).length).toBe(1)
+
+  // simulate an L1-era anchor: write a payload-less revision as index 1 directly to the store
+  const rev0 = await integrityTestStore.getRevision(`${prefix}000000000`)
+  await integrityTestStore.writeRevision(`${prefix}000000001`, {
+    hash: rev0.hash, context: { operation: 'update', origin: 'worker', date: new Date().toISOString() }, dataset: { id: dataset.id }
+  }, new Date(Date.now() + 24 * 3600 * 1000))
+
+  // hashes match but the latest anchor has no payload → a fresh payload-bearing revision is written
+  await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_fix`)
+  const keys = await listIntegrityKeys(prefix)
+  expect(keys).toContain(`${prefix}000000002`)
+  expect(keys).toContain(`${prefix}000000002.file`)
+  expect((await integrityTestStore.getRevision(`${prefix}000000002`)).payload?.metadata).toBeTruthy()
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx playwright test tests/features/integrity/core.api.spec.ts -g "level-2 payload|self-heals"`
+Expected: FAIL — no `.file` key, `rev.payload` undefined, index-1 dedupe skips.
+
+- [ ] **Step 3: Implement**
+
+In `api/src/integrity/hash.ts`, add (mirrors the md5 tee in `api/src/datasets/utils/upload.ts:21`):
+
+```ts
+import { Transform } from 'node:stream'
+
+// pass-through md5: hash the payload bytes while they stream to the store, so the anchor's
+// md5 always describes the bytes actually stored in the payload (single read of the file)
+export const md5Tee = () => {
+  const hash = createHash('md5')
+  const stream = new Transform({ transform (chunk, _enc, cb) { hash.update(chunk); cb(null, chunk) } })
+  return { stream, digest: () => hash.digest('hex') }
+}
+```
+
+In `api/src/integrity/relay.ts`, import `filesStorage` (`import filesStorage from '#files-storage'`), `md5Tee` from `./hash.ts`, and rework the second half of `anchorDataset` (after `hash.sha256 = ops.metadataHash(fresh)`):
+
+```ts
+  const prefix = ops.revisionPrefix(dataset.owner, dataset.id)
+  const keys = (await store.listRevisions(prefix)).map((r) => r.key)
+  const latest = ops.latestKey(keys)
+  if (latest) {
+    const latestRevision = await store.getRevision(latest)
+    const latestHash = latestRevision.hash
+    // level 2: only a payload-bearing anchor is a valid dedupe target — an L1-era anchor
+    // with matching hashes still gets a fresh revision, so the store self-heals to level 2
+    if (latestHash.md5 === hash.md5 && latestHash.sha256 === hash.sha256 && latestRevision.payload) {
+      // (keep the existing lastRevision-restore branch body unchanged)
+      ...
+      return // already anchored
+    }
+  }
+
+  const i = ops.nextIndex(keys)
+  const operation: ops.RevisionOperation = hint?.operation ?? (i === 0 ? 'create' : 'update')
+  const context: ops.RevisionContext = {
+    operation,
+    origin: hint?.origin ?? 'worker',
+    date,
+    ...(hint?.reason ? { reason: hint.reason } : {})
+  }
+  // payload FIRST, revision JSON second: a crash in between leaves an orphan .file that ages
+  // out harmlessly — the reverse would leave a revision claiming a payload it doesn't have
+  const payload: NonNullable<RevisionBody['payload']> = { metadata: ops.coveredMetadata(fresh) }
+  if (hash.md5) {
+    const { body, size } = await filesStorage.readStream(datasetUtils.originalFilePath(dataset))
+    const tee = md5Tee()
+    body.on('error', (err) => tee.stream.destroy(err))
+    await store.writePayload(ops.payloadKey(dataset.owner, dataset.id, i), body.pipe(tee.stream), retainUntil)
+    // the file may have changed since the dedupe-check read: the anchor must describe the
+    // payload's actual bytes, so the teed md5 wins over the first-pass one
+    hash.md5 = tee.digest()
+    payload.file = { size }
+  }
+  await store.writeRevision(ops.revisionKey(dataset.owner, dataset.id, i), {
+    hash,
+    context,
+    dataset: { id: dataset.id, slug: dataset.slug },
+    payload
+  }, retainUntil)
+  await mongo.datasets.updateOne({ id: dataset.id }, {
+    $set: { 'integrity.lastRevision': { i, hash, date, retainUntil: retainUntil.toISOString() } }
+  })
+```
+
+Import `RevisionBody` as a type from `./store.ts`.
+
+- [ ] **Step 4: Run tests to verify pass + no regression on the whole file**
+
+Run: `npx playwright test tests/features/integrity/core.api.spec.ts`
+Expected: PASS (all — pre-existing relay/checker tests must still pass; if a pre-existing test asserts exact key counts, update it for the new `.file` siblings)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/integrity/relay.ts api/src/integrity/hash.ts tests/features/integrity/core.api.spec.ts
+git commit -m "feat(integrity): anchors carry level-2 payloads with payload-aware self-healing dedupe"
+```
+
+---
+
+### Task 4: Lock renewal covers the payload object
+
+**Files:**
+- Modify: `api/src/integrity/checker.ts`
+- Test: `tests/features/integrity/core.api.spec.ts`
+
+**Interfaces:**
+- Consumes: Task 2 (`isPayloadKey` not needed here; `latest + PAYLOAD_SUFFIX` addressing), Task 3 (revisions carry `payload`).
+- Produces: `maybeRenew(dataset, store, latestKey, latestRevision)` — the extra `latestRevision: RevisionBody` parameter. `checkDataset` already fetches the latest revision; it now passes the whole body, not just `.hash`.
+
+- [ ] **Step 1: Write the failing test** — append to the checker section of `core.api.spec.ts` (pattern on the existing renewal test in that file, which forces `integrity.lastRevision.retainUntil` into the past via `test-env` raw patch or direct mongo access — reuse its exact mechanism):
+
+```ts
+test('lock renewal extends the payload object too', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  const prefix = revisionsPrefix(dataset)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+
+  // age the lock hint so needsRenewal fires (same trick as the existing renewal test)
+  await admin.post(`${apiUrl}/test-env/patch-dataset/${dataset.id}`, {
+    'integrity.lastRevision.retainUntil': new Date(Date.now() + 1000).toISOString()
+  })
+  await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)
+
+  const { HeadObjectCommand } = await import('@aws-sdk/client-s3')
+  const revHead = await integrityTestClient.send(new HeadObjectCommand({ Bucket: 'data-fair-integrity', Key: `${prefix}000000000` }))
+  const payloadHead = await integrityTestClient.send(new HeadObjectCommand({ Bucket: 'data-fair-integrity', Key: `${prefix}000000000.file` }))
+  const yearFromNow = Date.now() + 300 * 24 * 3600 * 1000
+  expect(revHead.ObjectLockRetainUntilDate!.getTime()).toBeGreaterThan(yearFromNow)
+  expect(payloadHead.ObjectLockRetainUntilDate!.getTime()).toBeGreaterThan(yearFromNow)
+})
+```
+
+(Adjust the aging mechanism to exactly match the existing renewal test in this file — read it first; the `test-env/patch-dataset` route at `api/src/misc/routers/test-env.ts:101` does a raw `$set`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx playwright test tests/features/integrity/core.api.spec.ts -g "payload object too"`
+Expected: FAIL — the `.file` head still shows the original ~1-day (dev retention) retain-until while the revision JSON was extended.
+
+- [ ] **Step 3: Implement in `api/src/integrity/checker.ts`**
+
+Change `maybeRenew` to receive the revision body and extend both objects:
+
+```ts
+import { PAYLOAD_SUFFIX } from './operations.ts'
+import type { RevisionBody } from './store.ts'
+
+const maybeRenew = async (dataset: DatasetInternal, store: ReturnType<typeof integrityStore>, latestKey: string, latestRevision: RevisionBody): Promise<void> => {
+  const retentionDays = config.integrity?.retention?.days ?? 365
+  if (!ops.needsRenewal((dataset.integrity as any)?.lastRevision?.retainUntil, Date.now(), retentionDays)) return
+  const date = new Date().toISOString()
+  const retainUntil = new Date(Date.now() + retentionDays * 24 * 3600 * 1000)
+  try {
+    await store.extendRetention(latestKey, retainUntil)
+    // the sliding anchor is the revision *pair*: a level-2 anchor's repairability dies with
+    // its payload's lock, so the .file sibling must slide forward too
+    if (latestRevision.payload?.file) await store.extendRetention(latestKey + PAYLOAD_SUFFIX, retainUntil)
+    ... // (existing success updateOne unchanged)
+  } catch (err) {
+    ... // (existing failure branch unchanged)
+  }
+}
+```
+
+In `checkDataset`, replace `const expected = (await store.getRevision(latest)).hash` with:
+
+```ts
+  const latestRevision = await store.getRevision(latest)
+  const expected = latestRevision.hash
+```
+
+and the renewal call with `if (status === 'ok') await maybeRenew(dataset, store, latest, latestRevision)`.
+
+- [ ] **Step 4: Run the whole core spec**
+
+Run: `npx playwright test tests/features/integrity/core.api.spec.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/integrity/checker.ts tests/features/integrity/core.api.spec.ts
+git commit -m "feat(integrity): lock renewal slides the payload object's lock with the revision's"
+```
+
+---
+
+### Task 5: Forbid owner transfer while integrity is active
+
+**Files:**
+- Modify: `api/src/datasets/routes/metadata.ts` (route `PUT /:datasetId/owner`, ~line 191)
+- Modify: `docs/architecture/integrity.md` (§3.1 owner-transfer note)
+- Test: `tests/features/integrity/admin.api.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `PUT /datasets/{id}/owner` → 400 when `dataset.integrity?.active`; the `stampHistorize` import and call in `metadata.ts` are deleted.
+
+- [ ] **Step 1: Write the failing test** — append to `admin.api.spec.ts`:
+
+```ts
+test('owner transfer is refused while integrity is active', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+
+  await expect(admin.put(`/api/v1/datasets/${dataset.id}/owner`, { type: 'organization', id: 'test_org', name: 'Org' }))
+    .rejects.toMatchObject({ status: 400 })
+
+  // disabling integrity unblocks the transfer
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: false })
+  const res = await admin.put(`/api/v1/datasets/${dataset.id}/owner`, { type: 'organization', id: 'test_org', name: 'Org' })
+  expect(res.status).toBe(200)
+})
+```
+
+(Check how existing tests in the suite name a transfer-target organization the superadmin can use — grep `'/owner'` under `tests/` and reuse that owner body; adjust `test_org` accordingly.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx playwright test tests/features/integrity/admin.api.spec.ts -g "owner transfer is refused"`
+Expected: FAIL — the transfer currently succeeds (200).
+
+- [ ] **Step 3: Implement**
+
+In `api/src/datasets/routes/metadata.ts`, at the top of the `PUT /:datasetId/owner` handler (right after `const dataset: any = reqDataset(req)`):
+
+```ts
+    // integrity anchors are owner-scoped (data-fair/‹owner.type›-‹owner.id›/…): transferring
+    // would orphan the anchor sequence. Deliberate simplification: disable integrity first.
+    if (dataset.integrity?.active) {
+      return res.status(400).type('text/plain').send('Le contrôle d\'intégrité doit être désactivé avant un changement de propriétaire')
+    }
+```
+
+Then delete the now-dead re-anchor stamp (lines ~253-256): remove the `stampHistorize(changeOwnerUpdate, …)` call, its comment, and the `import { stampHistorize } from '../../integrity/operations.ts'` (line 30) if no other use remains in the file. Also delete any existing test that asserted the transfer-re-anchor behavior (grep `owner` in `tests/features/integrity/`).
+
+In `docs/architecture/integrity.md` §3.1, replace the owner-transfer bullet ("Keys are **owner-scoped** … not migrated or deleted.") with:
+
+```markdown
+- Keys are **owner-scoped** (`‹owner.type›-‹owner.id›` segment). Owner transfer is
+  **forbidden while integrity is active** (the transfer route returns 400): a transfer would
+  orphan the anchor sequence under the old prefix. To transfer, a superadmin disables
+  integrity (anchors age out at their existing retention), transfers, and re-enables — a
+  deliberate simplification over re-anchoring under the new prefix.
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx playwright test tests/features/integrity/admin.api.spec.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/datasets/routes/metadata.ts docs/architecture/integrity.md tests/features/integrity/admin.api.spec.ts
+git commit -m "feat(integrity): forbid owner transfer while integrity is active"
+```
+
+---
+
+### Task 6: Restore pure functions
+
+**Files:**
+- Modify: `api/src/integrity/operations.ts`
+- Test: `tests/features/integrity/operations.unit.spec.ts`
+
+**Interfaces:**
+- Consumes: `coveredMetadata`, `coveredPatchKeys` (existing).
+- Produces: `restoreUpdate(hot: Record<string, any>, snapshot: Record<string, any>): { $set: Record<string, any>, $unset: Record<string, any> }` and `rehydrateTopics(topics: Array<{ id: string }>, settingsTopics: any[]): any[]`. `RevisionOperation` union gains `'restore'`. Task 8/9 (the route) consume all three.
+
+- [ ] **Step 1: Write the failing tests** — append to `operations.unit.spec.ts`:
+
+```ts
+test('restoreUpdate writes only diverging covered keys and unsets extra ones', () => {
+  const snapshot = { title: 'legit', description: 'legit desc', owner: { type: 'organization', id: 'acme' } }
+  const hot = {
+    title: 'tampered',
+    description: 'legit desc',
+    injected: 'evil',
+    status: 'finalized', // denylisted: must never be touched
+    owner: { type: 'organization', id: 'acme', name: 'Acme Corp' } // normalizes to snapshot → untouched
+  }
+  const { $set, $unset } = ops.restoreUpdate(hot, snapshot)
+  expect($set).toEqual({ title: 'legit' }) // description equal → skipped; owner equal after normalization → skipped
+  expect($unset).toEqual({ injected: '' })
+})
+
+test('restoreUpdate restores a tampered owner as its normalized form', () => {
+  const snapshot = { owner: { type: 'organization', id: 'acme' } }
+  const hot = { owner: { type: 'organization', id: 'evil', name: 'Evil' } }
+  expect(ops.restoreUpdate(hot, snapshot).$set.owner).toEqual({ type: 'organization', id: 'acme' })
+})
+
+test('rehydrateTopics fills titles back from settings, keeps unknown ids bare', () => {
+  const settingsTopics = [{ id: 't1', title: 'Topic 1', color: '#f00' }]
+  expect(ops.rehydrateTopics([{ id: 't1' }, { id: 'gone' }], settingsTopics))
+    .toEqual([{ id: 't1', title: 'Topic 1', color: '#f00' }, { id: 'gone' }])
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx playwright test tests/features/integrity/operations.unit.spec.ts -g "restoreUpdate|rehydrateTopics"`
+Expected: FAIL — functions not defined.
+
+- [ ] **Step 3: Implement in `api/src/integrity/operations.ts`**
+
+Extend the operation enum: `export type RevisionOperation = 'create' | 'update' | 'enable' | 'fixIntegrity' | 'restore'`.
+
+Add:
+
+```ts
+// Level-2 metadata restore (spec §C): compare the hot doc's *covered projection* against the
+// snapshot per key, and write back only genuinely diverging keys. Comparing projections (not raw
+// fields) means a field whose only difference is denormalized-name noise (owner/topics display
+// names) is left untouched — normalized loss only happens where tampering actually happened.
+export const restoreUpdate = (
+  hot: Record<string, any>,
+  snapshot: Record<string, any>
+): { $set: Record<string, any>, $unset: Record<string, any> } => {
+  const hotCovered = coveredMetadata(hot)
+  const $set: Record<string, any> = {}
+  const $unset: Record<string, any> = {}
+  for (const key of Object.keys(snapshot)) {
+    if (stableStringify(hotCovered[key] ?? null) !== stableStringify(snapshot[key] ?? null)) $set[key] = snapshot[key]
+  }
+  // covered keys present on the hot doc but absent from the snapshot were added out-of-band
+  for (const key of Object.keys(hotCovered)) {
+    if (!(key in snapshot)) $unset[key] = ''
+  }
+  return { $set, $unset }
+}
+
+// snapshots store topics as { id } only (D1 normalization); on restore, re-hydrate the display
+// fields from their authoritative source (the owner's settings.topics). An id no longer present
+// in settings stays bare — the same state a topic-deletion propagation would leave.
+export const rehydrateTopics = (topics: Array<{ id: string }>, settingsTopics: any[]): any[] =>
+  topics.map((t) => settingsTopics.find((st) => st.id === t.id) ?? t)
+```
+
+- [ ] **Step 4: Run the whole unit spec**
+
+Run: `npx playwright test tests/features/integrity/operations.unit.spec.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/integrity/operations.ts tests/features/integrity/operations.unit.spec.ts
+git commit -m "feat(integrity): restoreUpdate/rehydrateTopics pure operations + restore operation type"
+```
+
+---
+
+### Task 7: `_restore` route — metadata-only path (synchronous)
+
+**Files:**
+- Modify: `api/src/datasets/routes/integrity.ts`
+- Test: `tests/features/integrity/admin.api.spec.ts`
+
+**Interfaces:**
+- Consumes: Task 6 (`restoreUpdate`, `rehydrateTopics`, `'restore'`), Task 3 (payload-bearing anchors), Task 1 (`getRevision`).
+- Produces: `POST /datasets/{id}/_integrity/_restore` body `{ i: number, reason?: string }` — superadmin-only; metadata-only restores respond with the fresh check verdict `{ status, date, breach? }`. Task 8 extends the same route with the file path; Task 9's endpoints share its guards.
+
+- [ ] **Step 1: Write the failing tests** — append to `admin.api.spec.ts` (the raw out-of-band metadata write uses the dev/test-only `test-env/patch-dataset` route, as the existing breach tests in this file do — mirror their call shape exactly):
+
+```ts
+test('restore heals a tampered metadata field synchronously and appends a restore revision', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  const prefix = revisionsPrefix(dataset)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+
+  // out-of-band tamper (no outbox stamp)
+  await admin.post(`${apiUrl}/test-env/patch-dataset/${dataset.id}`, { description: 'tampered-oob' })
+  const check = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data
+  expect(check.status).toBe('breach')
+
+  const res = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_restore`, { i: 0, reason: 'undo tamper' })).data
+  expect(res.status).toBe('ok') // synchronous: responds with the fresh verdict
+
+  const raw = await getRawDataset(dataset.id)
+  expect(raw.description ?? '').not.toBe('tampered-oob')
+
+  // the restore appended a new revision with the restore context
+  const keys = (await listIntegrityKeys(prefix)).filter(k => !k.endsWith('.file')).sort()
+  const latest = await integrityTestStore.getRevision(keys.at(-1)!)
+  expect(latest.context.operation).toBe('restore')
+  expect(latest.context.origin).toBe('superadmin')
+  expect(latest.context.reason).toBe('undo tamper')
+})
+
+test('restore guards: inactive, unknown index, payload-less revision, non-admin', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const user = await axiosAuth('test_superadmin@test.com', undefined, false)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  const prefix = revisionsPrefix(dataset)
+
+  await expect(admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_restore`, { i: 0 })).rejects.toMatchObject({ status: 400 }) // inactive
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+  await expect(user.post(`/api/v1/datasets/${dataset.id}/_integrity/_restore`, { i: 0 })).rejects.toMatchObject({ status: 403 })
+  await expect(admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_restore`, { i: 99 })).rejects.toMatchObject({ status: 404 })
+
+  // an L1-era (payload-less) revision is not restorable
+  await integrityTestStore.writeRevision(`${prefix}000000001`, {
+    hash: (await integrityTestStore.getRevision(`${prefix}000000000`)).hash,
+    context: { operation: 'update', origin: 'worker', date: new Date().toISOString() },
+    dataset: { id: dataset.id }
+  }, new Date(Date.now() + 24 * 3600 * 1000))
+  await expect(admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_restore`, { i: 1 })).rejects.toMatchObject({ status: 400 })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx playwright test tests/features/integrity/admin.api.spec.ts -g "restore heals|restore guards"`
+Expected: FAIL — 404 route not found.
+
+- [ ] **Step 3: Implement in `api/src/datasets/routes/integrity.ts`**
+
+Add imports: `restoreUpdate`, `rehydrateTopics`, `revisionKey` from `../../integrity/operations.ts`; `isFileDataset` is already imported; `md5OfStorageFile` from `../../integrity/hash.ts`; `originalFilePath` via existing dataset utils import pattern (`import * as datasetUtils from '../utils/index.ts'`).
+
+```ts
+  router.post('/:datasetId/_integrity/_restore', readDataset({ noCache: true }), async (req, res) => {
+    reqAdminMode(req)
+    const dataset: any = reqDataset(req)
+    if (!dataset.integrity?.active) throw httpError(400, 'integrity is not active on this dataset')
+    const i = req.body?.i
+    if (!Number.isInteger(i) || i < 0) throw httpError(400, 'missing or invalid revision index "i"')
+    const reason = typeof req.body?.reason === 'string' ? req.body.reason : undefined
+    const store = integrityStore()
+    const revision = await store.getRevision(revisionKey(dataset.owner, dataset.id, i)).catch((err: any) => {
+      if (err.name === 'NoSuchKey' || err.$metadata?.httpStatusCode === 404) throw httpError(404, 'unknown revision')
+      throw err
+    })
+    if (!revision.payload) throw httpError(400, 'this revision has no payload (level-1 anchor): not restorable')
+
+    // metadata part: write back only the genuinely diverging covered keys
+    const fresh = await mongo.datasets.findOne({ id: dataset.id })
+    if (!fresh) throw httpError(404, 'dataset not found')
+    const { $set, $unset } = restoreUpdate(fresh, revision.payload.metadata)
+    if ($set.topics) {
+      const settings = await mongo.db.collection('settings').findOne({ type: dataset.owner.type, id: dataset.owner.id })
+      $set.topics = rehydrateTopics($set.topics, settings?.topics ?? [])
+    }
+    if (Object.keys($set).length || Object.keys($unset).length) {
+      const update: any = { $set: { ...$set, updatedAt: new Date().toISOString() } }
+      if (Object.keys($unset).length) update.$unset = $unset
+      await mongo.datasets.updateOne({ id: dataset.id }, update)
+    }
+
+    // metadata-only restore (file part comes in the next iteration of this route): re-anchor
+    // synchronously with the restore context and respond with the fresh verdict, like _fix
+    await anchorDataset(dataset, { operation: 'restore', origin: 'superadmin', reason })
+    await mongo.datasets.updateOne({ id: dataset.id }, { $unset: { _needsHistorizing: '' } })
+    const checker = await import('../../integrity/checker.ts')
+    const freshAfter = await mongo.datasets.findOne({ id: dataset.id })
+    res.json(await checker.checkDataset(freshAfter as any))
+  })
+```
+
+(The exact shape of the store's 404 error against MinIO: verify in the test run and adjust the catch condition; `err.name === 'NoSuchKey'` is the AWS SDK v3 shape.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx playwright test tests/features/integrity/admin.api.spec.ts -g "restore heals|restore guards"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/datasets/routes/integrity.ts tests/features/integrity/admin.api.spec.ts
+git commit -m "feat(integrity): synchronous metadata restore route (_restore)"
+```
+
+---
+
+### Task 8: `_restore` route — file path (re-ingest via pipeline)
+
+**Files:**
+- Modify: `api/src/datasets/routes/integrity.ts`, `api/src/workers/short-processor/finalize.ts` (line ~40)
+- Test: `tests/features/integrity/admin.api.spec.ts`
+
+**Interfaces:**
+- Consumes: Task 7 (route skeleton), Task 1 (`readPayload`), Task 2 (`payloadKey`); `preparePatch` from `api/src/datasets/utils/patch.ts:18` (`preparePatch(app, patch, dataset, sessionState, locale, draftValidationMode, files)`), `applyPatch` from `api/src/datasets/service.ts:430`, `loadingDir` from `api/src/datasets/utils/index.ts:39`.
+- Produces: a restore whose stored-file md5 differs re-ingests the payload through the standard draft pipeline and responds `{ status: 'restoring' }`; finalize preserves a pre-set `_needsHistorizing` context instead of overwriting it.
+
+- [ ] **Step 1: Write the failing test** — append to `admin.api.spec.ts` (the file tamper uses the dev/test-only `test-env/tamper-dataset-file` route, as existing breach tests do; `doAndWaitForFinalize` comes from `tests/support/workers.ts` — check its exact signature in `core.api.spec.ts` usage before writing):
+
+```ts
+test('restore re-ingests a tampered file through the pipeline and anchors with restore context', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  const prefix = revisionsPrefix(dataset)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+  const originalMd5 = dataset.originalFile.md5
+
+  await admin.post(`${apiUrl}/test-env/tamper-dataset-file/${dataset.id}`, { content: 'a,b\n1,tampered' })
+  expect((await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data.status).toBe('breach')
+
+  const res = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_restore`, { i: 0, reason: 'undo file tamper' })).data
+  expect(res.status).toBe('restoring')
+
+  // the pipeline reprocesses the restored bytes; finalize re-anchors with the restore context
+  const keys = await waitForIntegrityRevisions(prefix, 3) // rev 0, its .file, + the new pair
+  const raw = await waitForFlagCleared(dataset.id)
+  expect(raw.originalFile.md5).toBe(originalMd5)
+
+  const revKeys = keys.filter(k => !k.endsWith('.file')).sort()
+  const latest = await integrityTestStore.getRevision(revKeys.at(-1)!)
+  expect(latest.context.operation).toBe('restore')
+  expect(latest.context.origin).toBe('superadmin')
+
+  expect((await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data.status).toBe('ok')
+})
+```
+
+Note on `waitForIntegrityRevisions(prefix, 3)`: the helper counts raw keys under the prefix (payloads included). After enable there are 2 keys (rev 0 + `.file`); wait for ≥4 if the count proves off — assert on the *filtered* revision list, not the raw count.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx playwright test tests/features/integrity/admin.api.spec.ts -g "re-ingests a tampered file"`
+Expected: FAIL — the current route answers with a check verdict (`ok`/`breach`), never `restoring`, and `originalFile.md5` stays the tampered value... (the sync `anchorDataset` in Task 7's version would anchor the *tampered* file — this task fixes that).
+
+- [ ] **Step 3: Implement**
+
+**(a) `api/src/workers/short-processor/finalize.ts` line ~40** — preserve a pre-set context. Replace:
+
+```ts
+  if (dataset.integrity?.active) result._needsHistorizing = { context: { operation: 'update', origin: 'worker' } }
+```
+
+with:
+
+```ts
+  // preserve a caller-provided context (e.g. the _restore route rides its 'restore' context
+  // through the draft: mergeDraft overlays draft._needsHistorizing onto the working doc);
+  // default to the generic worker context otherwise
+  if (dataset.integrity?.active) result._needsHistorizing = (dataset as any)._needsHistorizing ?? { context: { operation: 'update', origin: 'worker' } }
+```
+
+(Keep the existing draft-routing comment above it — it still applies.)
+
+**(b) `api/src/datasets/routes/integrity.ts`** — in the `_restore` handler, after the metadata write and **before** the synchronous anchor, insert the file branch. New imports: `path` (`import path from 'node:path'`), `clone` (`import clone from '@data-fair/lib-utils/clone.js'`), `filesStorage` (`import filesStorage from '#files-storage'`), `preparePatch` (`import { preparePatch } from '../utils/patch.ts'`), `applyPatch` (`import { applyPatch } from '../service.ts'`), `payloadKey` from operations, `md5OfStorageFile` from `../../integrity/hash.ts`, `reqSessionAuthenticated` from `@data-fair/lib-express`:
+
+```ts
+    // file part: the stored file's actual bytes vs the revision's md5 (metadata fields can lie)
+    const currentMd5 = isFileDataset(dataset)
+      ? await md5OfStorageFile(datasetUtils.originalFilePath(dataset)).catch((err: any) => {
+        if (err.status === 404) return undefined
+        throw err
+      })
+      : undefined
+    if (revision.payload.file && revision.hash.md5 !== currentMd5) {
+      // re-ingest through the standard file-replacement path (spec §C): the payload lands in the
+      // loading dir exactly as an upload would, preparePatch/applyPatch route it through the
+      // draft pipeline, and finalize re-anchors with the restore context riding the draft
+      const filename = revision.payload.metadata.originalFile?.name ?? dataset.originalFile?.name ?? 'restored-file'
+      const destination = datasetUtils.loadingDir({ ...dataset, draftReason: true })
+      const finalPath = path.join(destination, filename)
+      const { body } = await store.readPayload(payloadKey(dataset.owner, dataset.id, i))
+      await filesStorage.writeStream(body, finalPath)
+      const stats = await filesStorage.fileStats(finalPath)
+      const files = [{ fieldname: 'file', originalname: filename, filename, destination, path: finalPath, size: stats.size, md5: revision.hash.md5 }]
+
+      const patch: any = { _needsHistorizing: { context: { operation: 'restore', origin: 'superadmin', ...(reason ? { reason } : {}) } } }
+      const datasetClone: any = clone(dataset)
+      await preparePatch(req.app, patch, datasetClone, reqSessionAuthenticated(req), req.getLocale(), 'always', files)
+      await applyPatch(datasetClone, patch)
+      res.json({ status: 'restoring' })
+      return
+    }
+
+    // metadata-only restore: … (Task 7's synchronous anchor block, unchanged)
+```
+
+Mirror `updateDatasetRoute` (`api/src/datasets/routes/write.ts:127`) when in doubt about `preparePatch` details — it is the reference consumer. If `preparePatch` rejects the internal `_needsHistorizing` patch key (schema validation), set the flag via `datasetClone` draft routing as applyPatch does for finalize's internal keys — read `applyPatch` (`service.ts:430`) first; internal `_`-keys are routinely patched through it (`_esCopyToSearch` in finalize), so this should pass as-is.
+
+- [ ] **Step 4: Run the whole admin spec**
+
+Run: `npx playwright test tests/features/integrity/admin.api.spec.ts`
+Expected: PASS (including Task 7's tests — the metadata-only path must still respond with a verdict)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/datasets/routes/integrity.ts api/src/workers/short-processor/finalize.ts tests/features/integrity/admin.api.spec.ts
+git commit -m "feat(integrity): file restore re-ingests the payload through the standard pipeline"
+```
+
+---
+
+### Task 9: Revision detail, metadata diff data & file payload download
+
+**Files:**
+- Modify: `api/src/datasets/routes/integrity.ts`
+- Test: `tests/features/integrity/admin.api.spec.ts`
+
+**Interfaces:**
+- Consumes: Tasks 1-3 (payload-bearing revisions, `readPayload`, `payloadKey`), `coveredMetadata` from operations, `pump` from `api/src/misc/utils/pipe.ts`, `contentDisposition` (`content-disposition` package, used in `routes/files.ts`).
+- Produces: `GET /datasets/{id}/_integrity/revisions/{i}` → `{ i, hash, context, payload, current }` (`current` = live covered projection, for the UI diff); `GET /datasets/{id}/_integrity/revisions/{i}/file` → payload bytes; the list endpoint's rows gain `hasPayload: boolean` and `fileSize?: number`. Task 10 (UI) consumes all three.
+
+- [ ] **Step 1: Write the failing tests** — append to `admin.api.spec.ts`:
+
+```ts
+test('revision detail returns snapshot + current projection; file endpoint streams the payload', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+  await admin.patch(`/api/v1/datasets/${dataset.id}`, { description: 'edited legitimately' })
+  await waitForFlagCleared(dataset.id)
+
+  const list = (await admin.get(`/api/v1/datasets/${dataset.id}/_integrity/revisions`)).data
+  expect(list.results[0].hasPayload).toBe(true)
+  expect(list.results[0].fileSize).toBeGreaterThan(0)
+
+  const detail = (await admin.get(`/api/v1/datasets/${dataset.id}/_integrity/revisions/0`)).data
+  expect(detail.i).toBe(0)
+  expect(detail.payload.metadata.description ?? '').not.toBe('edited legitimately') // the old snapshot
+  expect(detail.current.description).toBe('edited legitimately') // the live projection
+
+  const file = await admin.get(`/api/v1/datasets/${dataset.id}/_integrity/revisions/0/file`, { responseType: 'arraybuffer' })
+  const { createHash } = await import('node:crypto')
+  expect(createHash('md5').update(Buffer.from(file.data)).digest('hex')).toBe(detail.hash.md5)
+  expect(file.headers['content-disposition']).toContain(dataset.originalFile.name)
+
+  // reads follow the readIntegrityRevisions permission (same as the list endpoint)
+  const anon = anonymousAx ?? (await import('../../support/axios.ts')).anonymousAx
+  await expect(anon.get(`/api/v1/datasets/${dataset.id}/_integrity/revisions/0`)).rejects.toMatchObject({ status: 403 })
+})
+```
+
+(`anonymousAx` is already imported at the top of `admin.api.spec.ts` — use it directly; the existing permission-scoping test in this file shows the expected rejection status, mirror it.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx playwright test tests/features/integrity/admin.api.spec.ts -g "revision detail"`
+Expected: FAIL — 404 on `/revisions/0`, `hasPayload` undefined.
+
+- [ ] **Step 3: Implement in `api/src/datasets/routes/integrity.ts`**
+
+**(a)** In the existing `GET /:datasetId/_integrity/revisions` handler: filter payload keys out of the listing and expose the payload descriptor. Replace the `keys` line with:
+
+```ts
+    const keys = (await store.listRevisions(revisionPrefix(dataset.owner, dataset.id))).map((r) => r.key)
+      .filter((k) => !isPayloadKey(k)).sort().reverse()
+```
+
+and extend the mapped row:
+
+```ts
+      return {
+        i: parseRevisionIndex(key),
+        hash: rev.hash,
+        date: rev.context.date,
+        operation: rev.context.operation,
+        origin: rev.context.origin,
+        ...(rev.context.reason ? { reason: rev.context.reason } : {}),
+        hasPayload: !!rev.payload,
+        ...(rev.payload?.file ? { fileSize: rev.payload.file.size } : {})
+      }
+```
+
+**(b)** Add the two read endpoints (same `readIntegrityRevisions` guard as the list; register them AFTER the list route — Express 5 matches them fine as distinct static/param paths):
+
+```ts
+  router.get('/:datasetId/_integrity/revisions/:i', readDataset({ noCache: true }), permissions.middleware('readIntegrityRevisions', 'admin'), async (req, res) => {
+    const dataset: any = reqDataset(req)
+    if (!dataset.integrity?.active) throw httpError(400, 'integrity is not active on this dataset')
+    const i = parseInt(req.params.i as string, 10)
+    if (Number.isNaN(i) || i < 0) throw httpError(400, 'invalid revision index')
+    const store = integrityStore()
+    const rev = await store.getRevision(revisionKey(dataset.owner, dataset.id, i)).catch((err: any) => {
+      if (err.name === 'NoSuchKey' || err.$metadata?.httpStatusCode === 404) throw httpError(404, 'unknown revision')
+      throw err
+    })
+    const fresh = await mongo.datasets.findOne({ id: dataset.id })
+    // `current` is the live covered projection so the UI can render the metadata diff in one call
+    res.json({ i, hash: rev.hash, context: rev.context, payload: rev.payload, current: fresh ? coveredMetadata(fresh) : undefined })
+  })
+
+  router.get('/:datasetId/_integrity/revisions/:i/file', readDataset({ noCache: true }), permissions.middleware('readIntegrityRevisions', 'admin'), async (req, res) => {
+    const dataset: any = reqDataset(req)
+    if (!dataset.integrity?.active) throw httpError(400, 'integrity is not active on this dataset')
+    const i = parseInt(req.params.i as string, 10)
+    if (Number.isNaN(i) || i < 0) throw httpError(400, 'invalid revision index')
+    const store = integrityStore()
+    const rev = await store.getRevision(revisionKey(dataset.owner, dataset.id, i)).catch((err: any) => {
+      if (err.name === 'NoSuchKey' || err.$metadata?.httpStatusCode === 404) throw httpError(404, 'unknown revision')
+      throw err
+    })
+    if (!rev.payload?.file) throw httpError(404, 'this revision has no file payload')
+    const { body, size } = await store.readPayload(payloadKey(dataset.owner, dataset.id, i))
+    res.setHeader('content-disposition', contentDisposition(rev.payload.metadata.originalFile?.name ?? `${dataset.slug}-revision-${i}`))
+    res.setHeader('content-type', rev.payload.metadata.originalFile?.mimetype ?? 'application/octet-stream')
+    if (size !== undefined) res.setHeader('content-length', String(size))
+    await pump(body, res)
+  })
+```
+
+New imports: `isPayloadKey`, `payloadKey`, `coveredMetadata`, `revisionKey` from operations; `contentDisposition` (`import contentDisposition from 'content-disposition'`); `pump` (`import pump from '../../misc/utils/pipe.ts'`).
+
+- [ ] **Step 4: Run the whole admin spec**
+
+Run: `npx playwright test tests/features/integrity/admin.api.spec.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/datasets/routes/integrity.ts tests/features/integrity/admin.api.spec.ts
+git commit -m "feat(integrity): revision detail (diff data) and file payload download endpoints"
+```
+
+---
+
+### Task 10: UI — diff dialog, payload download, restore action
+
+**Files:**
+- Modify: `ui/src/components/dataset/dataset-integrity.vue`
+
+**Interfaces:**
+- Consumes: Task 9's endpoints (`revisions/{i}` → `{ i, hash, context, payload, current }`, `revisions/{i}/file`), Task 7/8's `POST _restore { i, reason? }` (responds `{ status: 'ok'|'breach'|'unknown'|'restoring' }`).
+- Produces: revisions-table row actions. No automated test (matches the existing component, which has none) — verified by lint + types + the dev fixture (Task 11).
+
+- [ ] **Step 1: Extend the revisions table.** In `dataset-integrity.vue`:
+
+Add to `RevisionEntry`: `hasPayload?: boolean, fileSize?: number`.
+
+Add an actions column to `headers`:
+
+```ts
+  { title: '', key: 'actions', sortable: false, align: 'end' as const }
+```
+
+Add the actions cell in the `<v-data-table-server>` (icons: add `mdiFileCompare`, `mdiDownload`, `mdiBackupRestore` to the `@mdi/js` import):
+
+```html
+          <template #item.actions="{ item }">
+            <template v-if="item.hasPayload">
+              <v-btn
+                :icon="mdiFileCompare"
+                variant="text"
+                size="x-small"
+                :title="t('viewDiff')"
+                @click="openDiff(item.i)"
+              />
+              <v-btn
+                v-if="item.fileSize"
+                :icon="mdiDownload"
+                variant="text"
+                size="x-small"
+                :title="t('downloadPayload')"
+                :href="`${$apiPath}/datasets/${dataset!.id}/_integrity/revisions/${item.i}/file`"
+              />
+              <v-btn
+                v-if="adminMode"
+                :icon="mdiBackupRestore"
+                variant="text"
+                size="x-small"
+                color="warning"
+                :title="t('restore')"
+                @click="restoreTarget = item.i; restoreReason = ''"
+              />
+            </template>
+            <span
+              v-else
+              class="text-caption text-disabled"
+            >{{ t('noPayload') }}</span>
+          </template>
+```
+
+(Check how sibling components build download hrefs — grep `href` + `$apiPath` under `ui/src/components/dataset/`; reuse that exact base-path idiom instead of `$apiPath` if it differs.)
+
+- [ ] **Step 2: Add the diff dialog** (simple two-column JSON compare of the changed keys):
+
+```html
+    <v-dialog
+      v-model="diffOpen"
+      max-width="1100"
+    >
+      <v-card :title="t('diffTitle', { i: diffData?.i })">
+        <v-card-text v-if="diffData">
+          <p
+            v-if="!diffKeys.length"
+            class="text-caption"
+          >
+            {{ t('noDiff') }}
+          </p>
+          <template
+            v-for="key of diffKeys"
+            :key="key"
+          >
+            <h4 class="text-subtitle-2 mt-2">
+              {{ key }}
+            </h4>
+            <v-row dense>
+              <v-col cols="6">
+                <div class="text-caption">{{ t('diffRevision') }}</div>
+                <pre class="text-caption bg-surface-light pa-2 overflow-auto">{{ pretty(diffData.payload.metadata[key]) }}</pre>
+              </v-col>
+              <v-col cols="6">
+                <div class="text-caption">{{ t('diffCurrent') }}</div>
+                <pre class="text-caption bg-surface-light pa-2 overflow-auto">{{ pretty(diffData.current?.[key]) }}</pre>
+              </v-col>
+            </v-row>
+          </template>
+        </v-card-text>
+      </v-card>
+    </v-dialog>
+```
+
+```ts
+type RevisionDetail = { i: number, hash: { md5?: string, sha256?: string }, context: any, payload: { metadata: Record<string, any>, file?: { size: number } }, current?: Record<string, any> }
+const diffOpen = ref(false)
+const diffData = ref<RevisionDetail | null>(null)
+const pretty = (v: any) => v === undefined ? '—' : JSON.stringify(v, null, 2)
+const diffKeys = computed(() => {
+  if (!diffData.value) return []
+  const snapshot = diffData.value.payload.metadata
+  const current = diffData.value.current ?? {}
+  return [...new Set([...Object.keys(snapshot), ...Object.keys(current)])]
+    .filter(k => JSON.stringify(snapshot[k]) !== JSON.stringify(current[k])).sort()
+})
+const openDiff = async (i: number) => {
+  diffData.value = await $fetch<RevisionDetail>(`datasets/${dataset.value!.id}/_integrity/revisions/${i}`)
+  diffOpen.value = true
+}
+```
+
+- [ ] **Step 3: Add the restore confirm dialog** (admin only):
+
+```html
+    <v-dialog
+      :model-value="restoreTarget !== null"
+      max-width="500"
+      @update:model-value="(v) => { if (!v) restoreTarget = null }"
+    >
+      <v-card :title="t('restoreTitle', { i: restoreTarget })">
+        <v-card-text>
+          <p class="mb-2">
+            {{ t('restoreWarning') }}
+          </p>
+          <v-text-field
+            v-model="restoreReason"
+            :label="t('restoreReason')"
+            density="compact"
+          />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="restoreTarget = null">
+            {{ t('cancel') }}
+          </v-btn>
+          <v-btn
+            color="warning"
+            :loading="restore.loading.value"
+            @click="restore.execute()"
+          >
+            {{ t('restore') }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+```
+
+```ts
+const restoreTarget = ref<number | null>(null)
+const restoreReason = ref('')
+const restore = useAsyncAction(async () => {
+  const body: any = { i: restoreTarget.value }
+  if (restoreReason.value) body.reason = restoreReason.value
+  const res = await $fetch<{ status: string }>(`datasets/${dataset.value!.id}/_integrity/_restore`, { method: 'POST', body })
+  restoreTarget.value = null
+  await load.execute()
+  datasetStore.datasetFetch.refresh()
+  return res
+}, { success: t('restoreOk') })
+```
+
+- [ ] **Step 4: Add i18n strings** to both `fr:` and `en:` blocks:
+
+```yaml
+fr:
+  viewDiff: Voir les différences
+  downloadPayload: Télécharger le fichier historisé
+  restore: Restaurer
+  noPayload: non restaurable
+  diffTitle: "Révision {i} — différences avec l'état courant"
+  noDiff: Aucune différence de métadonnées avec l'état courant.
+  diffRevision: Révision
+  diffCurrent: État courant
+  restoreTitle: "Restaurer la révision {i}"
+  restoreWarning: Les métadonnées couvertes et le fichier de données seront restaurés à l'état de cette révision. Un fichier différent déclenche un retraitement complet du jeu de données.
+  restoreReason: Raison (optionnelle, tracée dans l'historique)
+  cancel: Annuler
+  restoreOk: Restauration lancée
+  op_restore: Restauration
+en:
+  viewDiff: View diff
+  downloadPayload: Download historized file
+  restore: Restore
+  noPayload: not restorable
+  diffTitle: "Revision {i} — diff with current state"
+  noDiff: No metadata difference with the current state.
+  diffRevision: Revision
+  diffCurrent: Current state
+  restoreTitle: "Restore revision {i}"
+  restoreWarning: Covered metadata and the data file will be restored to this revision's state. A differing file triggers a full reprocessing of the dataset.
+  restoreReason: Reason (optional, recorded in the history)
+  cancel: Cancel
+  restoreOk: Restore started
+  op_restore: Restore
+```
+
+- [ ] **Step 5: Verify types and lint**
+
+Run: `npm run lint && npm run check-types`
+Expected: lint clean; check-types with no NET-NEW errors (compare with `dev/check-types-ratchet.sh` if the full check is noisy).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/src/components/dataset/dataset-integrity.vue
+git commit -m "feat(integrity): UI revision actions — metadata diff, payload download, restore"
+```
+
+---
+
+### Task 11: Dev fixture restore demo + architecture doc update
+
+**Files:**
+- Modify: `dev/fixtures.ts` (the `fixtures-integrite-breach` block, ~line 218)
+- Modify: `docs/architecture/integrity.md`
+
+**Interfaces:**
+- Consumes: everything above. Produces: docs + demo only.
+
+- [ ] **Step 1: Extend the breach fixture.** Read the `fixtures-integrite-breach` block in `dev/fixtures.ts` first (it tampers file + metadata and logs the breach verdict). Append, after the breach check log, a commented demonstration of the new capability — following the block's existing style of logged explanations (do NOT auto-restore: the fixture must keep demonstrating the breach state; the restore is a manual demo action). Add to the block's final log lines:
+
+```ts
+  console.log(`  level 2: la révision 0 porte le payload complet — diff/téléchargement dans l'onglet intégrité,`)
+  console.log(`  restauration superadmin: POST /api/v1/datasets/${id}/_integrity/_restore {"i": 0}`)
+```
+
+- [ ] **Step 2: Update `docs/architecture/integrity.md`.** Precise edits (keep the surrounding prose intact):
+  - Header status blockquote: add "**level 2 (repair) delivered for file datasets** — every anchor carries the full payload (file copy + covered-metadata snapshot); diff, audit download and restore-from-any-revision ship with it; owner transfer is forbidden while integrity is active."
+  - §2 "Level 2 — Repair" bullet: mark delivered for file datasets, always-on (no size gate — the maintainer's call: storage cost is proportional and metered into the owner's consumption, §9).
+  - §3.1: document the `payload` field in the revision object and the `{i}.file` sibling key (same lock, written payload-first), and the suffix-aware key parsing.
+  - §3.3: check unchanged; note diff + restore now available (restore = new `restore` revision, metadata-only synchronous / file via pipeline re-ingest with context preserved by finalize).
+  - §3.4/§3.5: renewal extends the revision *pair* (`{i}` + `{i}.file`).
+  - §5 files row: "level 2 delivered — always-on, no size gate".
+  - §10 target 1: mark level 2 delivered; target 2's "deferred" list loses "level 2" (keep applications/settings metadata deferred).
+
+- [ ] **Step 3: Run the full integrity suite one last time**
+
+Run: `npx playwright test tests/features/integrity/`
+Expected: PASS (all three specs)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dev/fixtures.ts docs/architecture/integrity.md
+git commit -m "docs(integrity): level 2 delivered — fixture demo pointers and architecture doc update"
+```
+
+---
+
+## Self-review notes (already applied)
+
+- Spec §A/§B/§C/§D/§E/§F each map to tasks: A→1-3, B→3+5, C→6-8, D→9-10, E→4 (+automatic accounting: no code), F→ per-task tests + 11.
+- The Task 7 route intentionally anchors the tampered *file* state if run before Task 8 lands — Task 8's test documents and fixes this; the two tasks must ship in order (single branch, both before merge).
+- `waitForIntegrityRevisions` counts raw keys (payloads included) — tests assert on filtered revision lists where exact counts matter.
+- Type consistency: `payload.metadata` / `payload.file.size` / `hasPayload` / `fileSize` / `{ status: 'restoring' }` used identically across Tasks 1, 3, 7, 8, 9, 10.

--- a/tests/features/integrity/admin.api.spec.ts
+++ b/tests/features/integrity/admin.api.spec.ts
@@ -246,9 +246,11 @@ test('a legitimate metadata PATCH historizes a new revision', async () => {
 
   await admin.patch(`/api/v1/datasets/${dataset.id}`, { description: 'legitimate new description' })
 
-  // 4 raw keys: 2 revisions × (JSON + .file payload)
-  const keys = await waitForIntegrityRevisions(prefix, 4)
+  // 3 raw keys: 2 revisions (JSON) + 1 .file payload — the metadata-only edit references rev 0's
+  // payload rather than uploading a second copy (payload reference dedupe)
+  const keys = await waitForIntegrityRevisions(prefix, 3)
   expect(keys.filter(k => !k.endsWith('.file')).length).toBe(2)
+  expect(keys.filter(k => k.endsWith('.file')).length).toBe(1)
   await waitForFlagCleared(dataset.id)
   const check = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data
   expect(check.status).toBe('ok')
@@ -268,7 +270,8 @@ test('a permissions change historizes a new revision', async () => {
 
   await admin.put(`/api/v1/datasets/${dataset.id}/permissions`, [{ classes: ['list', 'read'] }])
 
-  expect((await waitForIntegrityRevisions(prefix, 4)).filter(k => !k.endsWith('.file')).length).toBe(2)
+  // metadata-only change → the new revision references rev 0's payload (3 keys, one .file)
+  expect((await waitForIntegrityRevisions(prefix, 3)).filter(k => !k.endsWith('.file')).length).toBe(2)
   await waitForFlagCleared(dataset.id)
   const check = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data
   expect(check.status).toBe('ok')
@@ -290,7 +293,8 @@ test('a topic removed from owner settings historizes a new revision', async () =
 
   // topics is a covered field: assigning it to the dataset is itself a legitimate PATCH that historizes
   await admin.patch(`/api/v1/datasets/${dataset.id}`, { topics: [{ id: topicId, title: 'Integrity topic' }] })
-  expect((await waitForIntegrityRevisions(prefix, 4)).filter(k => !k.endsWith('.file')).length).toBe(2)
+  // metadata-only → the new revision references rev 0's payload (3 keys, one .file)
+  expect((await waitForIntegrityRevisions(prefix, 3)).filter(k => !k.endsWith('.file')).length).toBe(2)
   await waitForFlagCleared(dataset.id)
 
   // renaming the topic in settings propagates the display name, but topics are hashed as ids only
@@ -307,7 +311,8 @@ test('a topic removed from owner settings historizes a new revision', async () =
   await admin.patch('/api/v1/settings/user/test_superadmin', { topics: settingsBeforeRemoval.filter((t: any) => t.id !== topicId) })
 
   await waitForFlagCleared(dataset.id)
-  const keys = await waitForIntegrityRevisions(prefix, 6)
+  // metadata-only propagation → the new revision references rev 0's payload (4 keys, one .file)
+  const keys = await waitForIntegrityRevisions(prefix, 4)
   expect(keys.filter(k => !k.endsWith('.file')).length).toBe(3)
   const check = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data
   expect(check.status).toBe('ok')
@@ -326,14 +331,16 @@ test('deleting a publication site historizes a new revision', async () => {
 
   // publicationSites is a covered field: assigning it to the dataset is itself a legitimate PATCH
   await admin.patch(`/api/v1/datasets/${dataset.id}`, { publicationSites: [`data-fair-portals:${siteId}`] })
-  expect((await waitForIntegrityRevisions(prefix, 4)).filter(k => !k.endsWith('.file')).length).toBe(2)
+  // metadata-only → the new revision references rev 0's payload (3 keys, one .file)
+  expect((await waitForIntegrityRevisions(prefix, 3)).filter(k => !k.endsWith('.file')).length).toBe(2)
   await waitForFlagCleared(dataset.id)
 
   // deleting the publication site fires the propagation $pull on the dataset
   await admin.delete(`/api/v1/settings/user/test_superadmin/publication-sites/data-fair-portals/${siteId}`)
 
   await waitForFlagCleared(dataset.id)
-  const keys = await waitForIntegrityRevisions(prefix, 6)
+  // metadata-only propagation → the new revision references rev 0's payload (4 keys, one .file)
+  const keys = await waitForIntegrityRevisions(prefix, 4)
   expect(keys.filter(k => !k.endsWith('.file')).length).toBe(3)
   const check = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data
   expect(check.status).toBe('ok')
@@ -352,7 +359,8 @@ test('a settings write with unchanged topics does not re-anchor tagged datasets'
   const existingTopics = (await admin.get('/api/v1/settings/user/test_superadmin')).data.topics ?? []
   await admin.patch('/api/v1/settings/user/test_superadmin', { topics: [...existingTopics, { id: topicId, title: 'Unchanged topic' }] })
   await admin.patch(`/api/v1/datasets/${dataset.id}`, { topics: [{ id: topicId, title: 'Unchanged topic' }] })
-  await waitForIntegrityRevisions(prefix, 4)
+  // metadata-only → the new revision references rev 0's payload (3 keys, one .file)
+  await waitForIntegrityRevisions(prefix, 3)
   await waitForFlagCleared(dataset.id)
 
   // tamper out-of-band, then save settings with the SAME topics: the propagation must NOT
@@ -391,6 +399,31 @@ test('restore heals a tampered metadata field synchronously and appends a restor
   expect(latest.context.operation).toBe('restore')
   expect(latest.context.origin).toBe('superadmin')
   expect(latest.context.reason).toBe('undo tamper')
+  // metadata-only restore leaves the file bytes unchanged → it references rev 0's payload and
+  // writes NO new .file key (payload reference dedupe)
+  expect(keys.length).toBe(2)
+  expect((await listIntegrityKeys(prefix)).filter(k => k.endsWith('.file')).length).toBe(1)
+  expect(latest.payload?.file?.i).toBe(0)
+})
+
+test('file download of a referencing revision streams the owning payload bytes', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  const prefix = revisionsPrefix(dataset)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+
+  // metadata-only edit → rev 1 references rev 0's payload (no rev1.file)
+  await admin.patch(`/api/v1/datasets/${dataset.id}`, { description: 'metadata only' })
+  await waitForIntegrityRevisions(prefix, 3)
+  await waitForFlagCleared(dataset.id)
+  expect((await listIntegrityKeys(prefix)).filter(k => k.endsWith('.file')).length).toBe(1)
+
+  const rev1 = (await admin.get(`/api/v1/datasets/${dataset.id}/_integrity/revisions/1`)).data
+  expect(rev1.payload.file.i).toBe(0)
+  // downloading rev 1's file resolves the reference and streams rev 0's bytes; md5 matches
+  const file = await admin.get(`/api/v1/datasets/${dataset.id}/_integrity/revisions/1/file`, { responseType: 'arraybuffer' })
+  const { createHash } = await import('node:crypto')
+  expect(createHash('md5').update(Buffer.from(file.data)).digest('hex')).toBe(rev1.hash.md5)
 })
 
 test('restore re-ingests a tampered file through the pipeline and anchors with restore context', async () => {

--- a/tests/features/integrity/admin.api.spec.ts
+++ b/tests/features/integrity/admin.api.spec.ts
@@ -458,6 +458,42 @@ test('restore re-ingests a tampered non-basic-format (xlsx) file through the pip
   expect((await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data.status).toBe('ok')
 })
 
+// Regression: `file`/`originalFile` are covered fields, so an out-of-band tamper that UNSETS
+// `file` is exactly what the metadata restore heals. Before the fix, the file branch fed
+// preparePatch/applyPatch the STALE route-entry `dataset` clone (still missing `file`) instead of
+// re-reading the doc after the metadata $set/$unset landed, so preparePatch's file-based guard
+// ("this dataset is not file based") threw a 400 even though the metadata write had already healed
+// `file` on Mongo. The stored bytes are also corrupted here so the restore must genuinely
+// re-ingest through the pipeline, not just rely on the metadata heal.
+test('restore heals a tampered doc whose `file` field was unset out-of-band (stale-clone regression)', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  const prefix = revisionsPrefix(dataset)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+  const originalMd5 = dataset.originalFile.md5
+
+  // out-of-band tamper: unset the covered `file` field (the metadata restore itself would heal
+  // this key) AND corrupt the stored bytes, so the file branch must actually re-ingest.
+  await admin.post(`${apiUrl}/api/v1/test-env/patch-dataset/${dataset.id}`, { $unset: { file: '' } })
+  await admin.post(`${apiUrl}/api/v1/test-env/tamper-dataset-file/${dataset.id}`, { content: 'a,b\n1,tampered' })
+
+  const res = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_restore`, { i: 0, reason: 'undo unset-file tamper' })).data
+  expect(res.status).toBe('restoring') // NOT a 400 — the pipeline must be fed the post-restore doc
+
+  // the pipeline reprocesses the restored bytes; finalize re-anchors with the restore context
+  const keys = await waitForIntegrityRevisions(prefix, 4) // rev 0 + .file, plus the new pair
+  const raw = await waitForFlagCleared(dataset.id)
+  expect(raw.originalFile.md5).toBe(originalMd5)
+  expect(raw.file).toBeTruthy()
+
+  const revKeys = keys.filter(k => !k.endsWith('.file')).sort()
+  const latest = await integrityTestStore.getRevision(revKeys.at(-1)!)
+  expect(latest.context.operation).toBe('restore')
+  expect(latest.context.origin).toBe('superadmin')
+
+  expect((await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data.status).toBe('ok')
+})
+
 test('restore guards: inactive, unknown index, payload-less revision, non-admin', async () => {
   const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
   const user = await axiosAuth('test_superadmin@test.com', undefined, false)

--- a/tests/features/integrity/admin.api.spec.ts
+++ b/tests/features/integrity/admin.api.spec.ts
@@ -419,6 +419,45 @@ test('restore re-ingests a tampered file through the pipeline and anchors with r
   expect((await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data.status).toBe('ok')
 })
 
+// Regression: the file branch's synthetic `files` descriptor omitted `mimetype`, so
+// originalFile.mimetype ended up undefined after re-ingestion. normalize.ts branches strictly on
+// that field, so any non-basic format (xlsx, ods, ical, plain json, zipped shapefile, gzip, gpx)
+// fails with "format not supported" — silently, since the _restore route already answered
+// {status: 'restoring'}. A plain CSV restore does not catch this: csv's mimetype is a basicType,
+// and a stale fallback in the normalizeFile task filter (tasks.ts isNormalizedMongoFilter, the
+// 'draft.originalFile: {$exists:false}' branch) reads the PARENT (pre-restore) dataset's
+// originalFile.mimetype instead of the draft's, so the missing mimetype on the draft's own
+// descriptor goes unnoticed for csv. xlsx has no such accidental cover.
+test('restore re-ingests a tampered non-basic-format (xlsx) file through the pipeline and carries mimetype', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/misc.xlsx', admin)
+  const prefix = revisionsPrefix(dataset)
+  expect(dataset.originalFile.mimetype).toBe('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+  const originalMd5 = dataset.originalFile.md5
+
+  await admin.post(`${apiUrl}/api/v1/test-env/tamper-dataset-file/${dataset.id}`, { content: 'corrupted bytes' })
+  expect((await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data.status).toBe('breach')
+
+  const res = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_restore`, { i: 0, reason: 'undo file tamper' })).data
+  expect(res.status).toBe('restoring')
+
+  // the pipeline reprocesses the restored bytes; finalize re-anchors with the restore context
+  const keys = await waitForIntegrityRevisions(prefix, 4) // rev 0 + .file, plus the new pair
+  const raw = await waitForFlagCleared(dataset.id)
+  expect(raw.originalFile.md5).toBe(originalMd5)
+  // proves normalization actually ran on the restored xlsx bytes instead of erroring the draft out
+  expect(raw.originalFile.mimetype).toBe('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+  expect(raw.status).toBe('finalized')
+
+  const revKeys = keys.filter(k => !k.endsWith('.file')).sort()
+  const latest = await integrityTestStore.getRevision(revKeys.at(-1)!)
+  expect(latest.context.operation).toBe('restore')
+  expect(latest.context.origin).toBe('superadmin')
+
+  expect((await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data.status).toBe('ok')
+})
+
 test('restore guards: inactive, unknown index, payload-less revision, non-admin', async () => {
   const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
   const user = await axiosAuth('test_superadmin@test.com', undefined, false)

--- a/tests/features/integrity/admin.api.spec.ts
+++ b/tests/features/integrity/admin.api.spec.ts
@@ -4,7 +4,7 @@
 import { test, expect } from '@playwright/test'
 import { axiosAuth, apiUrl, anonymousAx, clean } from '../../support/axios.ts'
 import { sendDataset, getRawDataset, collectNotifications } from '../../support/workers.ts'
-import { ensureIntegrityBucket, listIntegrityKeys, waitForIntegrityRevisions, waitForFlagCleared, revisionsPrefix } from '../../support/integrity.ts'
+import { ensureIntegrityBucket, listIntegrityKeys, waitForIntegrityRevisions, waitForFlagCleared, revisionsPrefix, integrityTestStore } from '../../support/integrity.ts'
 
 test.beforeAll(async () => { await ensureIntegrityBucket() })
 // reset test-owned datasets + limit counters before each test (the shared suite convention); the
@@ -366,6 +366,51 @@ test('a settings write with unchanged topics does not re-anchor tagged datasets'
   // and the tamper is still detectable
   const check = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data
   expect(check.status).toBe('breach')
+})
+
+test('restore heals a tampered metadata field synchronously and appends a restore revision', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  const prefix = revisionsPrefix(dataset)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+
+  // out-of-band tamper (no outbox stamp)
+  await admin.post(`${apiUrl}/api/v1/test-env/patch-dataset/${dataset.id}`, { description: 'tampered-oob' })
+  const check = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data
+  expect(check.status).toBe('breach')
+
+  const res = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_restore`, { i: 0, reason: 'undo tamper' })).data
+  expect(res.status).toBe('ok') // synchronous: responds with the fresh verdict
+
+  const raw = await getRawDataset(dataset.id)
+  expect(raw.description ?? '').not.toBe('tampered-oob')
+
+  // the restore appended a new revision with the restore context
+  const keys = (await listIntegrityKeys(prefix)).filter(k => !k.endsWith('.file')).sort()
+  const latest = await integrityTestStore.getRevision(keys.at(-1)!)
+  expect(latest.context.operation).toBe('restore')
+  expect(latest.context.origin).toBe('superadmin')
+  expect(latest.context.reason).toBe('undo tamper')
+})
+
+test('restore guards: inactive, unknown index, payload-less revision, non-admin', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const user = await axiosAuth('test_superadmin@test.com', undefined, false)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  const prefix = revisionsPrefix(dataset)
+
+  await expect(admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_restore`, { i: 0 })).rejects.toMatchObject({ status: 400 }) // inactive
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+  await expect(user.post(`/api/v1/datasets/${dataset.id}/_integrity/_restore`, { i: 0 })).rejects.toMatchObject({ status: 403 })
+  await expect(admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_restore`, { i: 99 })).rejects.toMatchObject({ status: 404 })
+
+  // an L1-era (payload-less) revision is not restorable
+  await integrityTestStore.writeRevision(`${prefix}000000001`, {
+    hash: (await integrityTestStore.getRevision(`${prefix}000000000`)).hash,
+    context: { operation: 'update', origin: 'worker', date: new Date().toISOString() },
+    dataset: { id: dataset.id }
+  }, new Date(Date.now() + 24 * 3600 * 1000))
+  await expect(admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_restore`, { i: 1 })).rejects.toMatchObject({ status: 400 })
 })
 
 test('owner transfer is refused while integrity is active', async () => {

--- a/tests/features/integrity/admin.api.spec.ts
+++ b/tests/features/integrity/admin.api.spec.ts
@@ -478,6 +478,31 @@ test('restore guards: inactive, unknown index, payload-less revision, non-admin'
   await expect(admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_restore`, { i: 1 })).rejects.toMatchObject({ status: 400 })
 })
 
+test('revision detail returns snapshot + current projection; file endpoint streams the payload', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+  await admin.patch(`/api/v1/datasets/${dataset.id}`, { description: 'edited legitimately' })
+  await waitForFlagCleared(dataset.id)
+
+  const list = (await admin.get(`/api/v1/datasets/${dataset.id}/_integrity/revisions`)).data
+  expect(list.results[0].hasPayload).toBe(true)
+  expect(list.results[0].fileSize).toBeGreaterThan(0)
+
+  const detail = (await admin.get(`/api/v1/datasets/${dataset.id}/_integrity/revisions/0`)).data
+  expect(detail.i).toBe(0)
+  expect(detail.payload.metadata.description ?? '').not.toBe('edited legitimately') // the old snapshot
+  expect(detail.current.description).toBe('edited legitimately') // the live projection
+
+  const file = await admin.get(`/api/v1/datasets/${dataset.id}/_integrity/revisions/0/file`, { responseType: 'arraybuffer' })
+  const { createHash } = await import('node:crypto')
+  expect(createHash('md5').update(Buffer.from(file.data)).digest('hex')).toBe(detail.hash.md5)
+  expect(file.headers['content-disposition']).toContain(dataset.originalFile.name)
+
+  // reads follow the readIntegrityRevisions permission (same as the list endpoint)
+  await expect(anonymousAx.get(`/api/v1/datasets/${dataset.id}/_integrity/revisions/0`)).rejects.toMatchObject({ status: 403 })
+})
+
 test('owner transfer is refused while integrity is active', async () => {
   const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
   const dataset = await sendDataset('datasets/dataset1.csv', admin)

--- a/tests/features/integrity/admin.api.spec.ts
+++ b/tests/features/integrity/admin.api.spec.ts
@@ -393,6 +393,32 @@ test('restore heals a tampered metadata field synchronously and appends a restor
   expect(latest.context.reason).toBe('undo tamper')
 })
 
+test('restore re-ingests a tampered file through the pipeline and anchors with restore context', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  const prefix = revisionsPrefix(dataset)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+  const originalMd5 = dataset.originalFile.md5
+
+  await admin.post(`${apiUrl}/api/v1/test-env/tamper-dataset-file/${dataset.id}`, { content: 'a,b\n1,tampered' })
+  expect((await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data.status).toBe('breach')
+
+  const res = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_restore`, { i: 0, reason: 'undo file tamper' })).data
+  expect(res.status).toBe('restoring')
+
+  // the pipeline reprocesses the restored bytes; finalize re-anchors with the restore context
+  const keys = await waitForIntegrityRevisions(prefix, 4) // rev 0 + .file, plus the new pair
+  const raw = await waitForFlagCleared(dataset.id)
+  expect(raw.originalFile.md5).toBe(originalMd5)
+
+  const revKeys = keys.filter(k => !k.endsWith('.file')).sort()
+  const latest = await integrityTestStore.getRevision(revKeys.at(-1)!)
+  expect(latest.context.operation).toBe('restore')
+  expect(latest.context.origin).toBe('superadmin')
+
+  expect((await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data.status).toBe('ok')
+})
+
 test('restore guards: inactive, unknown index, payload-less revision, non-admin', async () => {
   const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
   const user = await axiosAuth('test_superadmin@test.com', undefined, false)

--- a/tests/features/integrity/admin.api.spec.ts
+++ b/tests/features/integrity/admin.api.spec.ts
@@ -22,7 +22,8 @@ test('superadmin enable writes the initial anchor; non-admin is forbidden', asyn
 
   // enable is synchronous: the anchor exists as soon as the PUT returns, no wait needed
   await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
-  expect((await listIntegrityKeys(prefix)).length).toBe(1)
+  // 2 raw keys: the revision JSON + its .file payload sibling (level-2 joint anchor)
+  expect((await listIntegrityKeys(prefix)).filter(k => !k.endsWith('.file')).length).toBe(1)
 
   const status = (await admin.get(`/api/v1/datasets/${dataset.id}/_integrity`)).data
   expect(status.active).toBe(true)
@@ -42,11 +43,11 @@ test('_fix on an unchanged state dedupes (no spurious revision)', async () => {
   const dataset = await sendDataset('datasets/dataset1.csv', admin)
   const prefix = revisionsPrefix(dataset)
   await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
-  expect((await listIntegrityKeys(prefix)).length).toBe(1)
+  expect((await listIntegrityKeys(prefix)).filter(k => !k.endsWith('.file')).length).toBe(1)
   // _fix is synchronous too
   await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_fix`)
   // unchanged state → dedupe → still exactly one revision
-  expect((await listIntegrityKeys(prefix)).length).toBe(1)
+  expect((await listIntegrityKeys(prefix)).filter(k => !k.endsWith('.file')).length).toBe(1)
 })
 
 test('revisions endpoint lists revisions newest-first and is readable by the owner admin', async () => {
@@ -60,7 +61,8 @@ test('revisions endpoint lists revisions newest-first and is readable by the own
   await admin.post(`${apiUrl}/api/v1/test-env/tamper-dataset-file/${dataset.id}`, { content: 'corrupted bytes' })
   await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_fix`) // revision 1
 
-  expect((await listIntegrityKeys(prefix)).length).toBe(2)
+  // raw store has 4 keys (2 revisions × JSON + .file); the revisions endpoint filters payloads out
+  expect((await listIntegrityKeys(prefix)).filter(k => !k.endsWith('.file')).length).toBe(2)
   const res = (await admin.get(`/api/v1/datasets/${dataset.id}/_integrity/revisions`)).data
   expect(res.count).toBe(2)
   expect(res.results.length).toBe(2)
@@ -89,7 +91,7 @@ test('integrity reads are allowed to the owner admin, writes stay superadmin-onl
   const dataset = await sendDataset('datasets/dataset1.csv', admin)
   const prefix = revisionsPrefix(dataset)
   await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
-  expect((await listIntegrityKeys(prefix)).length).toBe(1)
+  expect((await listIntegrityKeys(prefix)).filter(k => !k.endsWith('.file')).length).toBe(1)
 
   // owner (admin of the owner account) can read status and revisions
   expect((await owner.get(`/api/v1/datasets/${dataset.id}/_integrity`)).data.active).toBe(true)
@@ -158,7 +160,7 @@ test('disable then re-enable with unchanged content restores lastRevision', asyn
   // dedupe wrote no new revision
   const revisions = (await admin.get(`/api/v1/datasets/${dataset.id}/_integrity/revisions`)).data
   expect(revisions.count).toBe(1)
-  expect((await listIntegrityKeys(prefix)).length).toBe(1)
+  expect((await listIntegrityKeys(prefix)).filter(k => !k.endsWith('.file')).length).toBe(1)
 })
 
 test('internal historize fields are stripped from API responses', async () => {
@@ -233,7 +235,7 @@ test('an out-of-band write to an EXCLUDED field neither breaches nor creates a r
 
   const check = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data
   expect(check.status).toBe('ok')
-  expect((await listIntegrityKeys(prefix)).length).toBe(1)
+  expect((await listIntegrityKeys(prefix)).filter(k => !k.endsWith('.file')).length).toBe(1)
 })
 
 test('a legitimate metadata PATCH historizes a new revision', async () => {
@@ -244,8 +246,9 @@ test('a legitimate metadata PATCH historizes a new revision', async () => {
 
   await admin.patch(`/api/v1/datasets/${dataset.id}`, { description: 'legitimate new description' })
 
-  const keys = await waitForIntegrityRevisions(prefix, 2)
-  expect(keys.length).toBe(2)
+  // 4 raw keys: 2 revisions × (JSON + .file payload)
+  const keys = await waitForIntegrityRevisions(prefix, 4)
+  expect(keys.filter(k => !k.endsWith('.file')).length).toBe(2)
   await waitForFlagCleared(dataset.id)
   const check = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data
   expect(check.status).toBe('ok')
@@ -265,7 +268,7 @@ test('a permissions change historizes a new revision', async () => {
 
   await admin.put(`/api/v1/datasets/${dataset.id}/permissions`, [{ classes: ['list', 'read'] }])
 
-  expect((await waitForIntegrityRevisions(prefix, 2)).length).toBe(2)
+  expect((await waitForIntegrityRevisions(prefix, 4)).filter(k => !k.endsWith('.file')).length).toBe(2)
   await waitForFlagCleared(dataset.id)
   const check = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data
   expect(check.status).toBe('ok')
@@ -287,7 +290,7 @@ test('a topic removed from owner settings historizes a new revision', async () =
 
   // topics is a covered field: assigning it to the dataset is itself a legitimate PATCH that historizes
   await admin.patch(`/api/v1/datasets/${dataset.id}`, { topics: [{ id: topicId, title: 'Integrity topic' }] })
-  expect((await waitForIntegrityRevisions(prefix, 2)).length).toBe(2)
+  expect((await waitForIntegrityRevisions(prefix, 4)).filter(k => !k.endsWith('.file')).length).toBe(2)
   await waitForFlagCleared(dataset.id)
 
   // renaming the topic in settings propagates the display name, but topics are hashed as ids only
@@ -297,15 +300,15 @@ test('a topic removed from owner settings historizes a new revision', async () =
     topics: beforeRename.map((t: any) => t.id === topicId ? { ...t, title: 'Renamed integrity topic' } : t)
   })
   await waitForFlagCleared(dataset.id)
-  expect((await listIntegrityKeys(prefix)).length).toBe(2) // unchanged: rename is not covered
+  expect((await listIntegrityKeys(prefix)).filter(k => !k.endsWith('.file')).length).toBe(2) // unchanged: rename is not covered
 
   // now remove the topic from the owner settings — this fires the propagation $pull on the dataset
   const settingsBeforeRemoval = (await admin.get('/api/v1/settings/user/test_superadmin')).data.topics ?? []
   await admin.patch('/api/v1/settings/user/test_superadmin', { topics: settingsBeforeRemoval.filter((t: any) => t.id !== topicId) })
 
   await waitForFlagCleared(dataset.id)
-  const keys = await waitForIntegrityRevisions(prefix, 3)
-  expect(keys.length).toBe(3)
+  const keys = await waitForIntegrityRevisions(prefix, 6)
+  expect(keys.filter(k => !k.endsWith('.file')).length).toBe(3)
   const check = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data
   expect(check.status).toBe('ok')
 })
@@ -323,15 +326,15 @@ test('deleting a publication site historizes a new revision', async () => {
 
   // publicationSites is a covered field: assigning it to the dataset is itself a legitimate PATCH
   await admin.patch(`/api/v1/datasets/${dataset.id}`, { publicationSites: [`data-fair-portals:${siteId}`] })
-  expect((await waitForIntegrityRevisions(prefix, 2)).length).toBe(2)
+  expect((await waitForIntegrityRevisions(prefix, 4)).filter(k => !k.endsWith('.file')).length).toBe(2)
   await waitForFlagCleared(dataset.id)
 
   // deleting the publication site fires the propagation $pull on the dataset
   await admin.delete(`/api/v1/settings/user/test_superadmin/publication-sites/data-fair-portals/${siteId}`)
 
   await waitForFlagCleared(dataset.id)
-  const keys = await waitForIntegrityRevisions(prefix, 3)
-  expect(keys.length).toBe(3)
+  const keys = await waitForIntegrityRevisions(prefix, 6)
+  expect(keys.filter(k => !k.endsWith('.file')).length).toBe(3)
   const check = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data
   expect(check.status).toBe('ok')
 })
@@ -349,7 +352,7 @@ test('a settings write with unchanged topics does not re-anchor tagged datasets'
   const existingTopics = (await admin.get('/api/v1/settings/user/test_superadmin')).data.topics ?? []
   await admin.patch('/api/v1/settings/user/test_superadmin', { topics: [...existingTopics, { id: topicId, title: 'Unchanged topic' }] })
   await admin.patch(`/api/v1/datasets/${dataset.id}`, { topics: [{ id: topicId, title: 'Unchanged topic' }] })
-  await waitForIntegrityRevisions(prefix, 2)
+  await waitForIntegrityRevisions(prefix, 4)
   await waitForFlagCleared(dataset.id)
 
   // tamper out-of-band, then save settings with the SAME topics: the propagation must NOT
@@ -359,7 +362,7 @@ test('a settings write with unchanged topics does not re-anchor tagged datasets'
   await admin.patch('/api/v1/settings/user/test_superadmin', { topics: settingsTopics })
   await new Promise(resolve => setTimeout(resolve, 2000)) // settle: give a wrongly-stamped relay time to run
   expect((await getRawDataset(dataset.id))._needsHistorizing).toBeUndefined()
-  expect((await listIntegrityKeys(prefix)).length).toBe(2)
+  expect((await listIntegrityKeys(prefix)).filter(k => !k.endsWith('.file')).length).toBe(2)
   // and the tamper is still detectable
   const check = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data
   expect(check.status).toBe('breach')

--- a/tests/features/integrity/admin.api.spec.ts
+++ b/tests/features/integrity/admin.api.spec.ts
@@ -367,3 +367,17 @@ test('a settings write with unchanged topics does not re-anchor tagged datasets'
   const check = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data
   expect(check.status).toBe('breach')
 })
+
+test('owner transfer is refused while integrity is active', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+
+  await expect(admin.put(`/api/v1/datasets/${dataset.id}/owner`, { type: 'organization', id: 'test_org1', name: 'Test Org 1' }))
+    .rejects.toMatchObject({ status: 400 })
+
+  // disabling integrity unblocks the transfer
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: false })
+  const res = await admin.put(`/api/v1/datasets/${dataset.id}/owner`, { type: 'organization', id: 'test_org1', name: 'Test Org 1' })
+  expect(res.status).toBe(200)
+})

--- a/tests/features/integrity/core.api.spec.ts
+++ b/tests/features/integrity/core.api.spec.ts
@@ -281,6 +281,84 @@ test('a file replacement writes a new (second) revision', async () => {
 })
 
 // ---------------------------------------------------------------------------------------------
+// payload reference dedupe: one locked file copy per distinct file version (§3.1 amendment)
+// ---------------------------------------------------------------------------------------------
+
+test('a metadata-only edit references the file-owning revision; a file change owns a fresh payload', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  const prefix = revisionsPrefix(dataset)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+
+  // rev 0 owns its own bytes: no reference index
+  const rev0 = await integrityTestStore.getRevision(`${prefix}000000000`)
+  expect(rev0.payload?.file?.i).toBeUndefined() // absent i = own index
+  const ownSize = rev0.payload!.file!.size
+
+  // metadata-only edit → rev 1 references rev 0's payload, and writes NO new .file key
+  await admin.patch(`/api/v1/datasets/${dataset.id}`, { description: 'metadata only change' })
+  const afterMeta = await waitForIntegrityRevisions(prefix, 3)
+  await waitForFlagCleared(dataset.id)
+  expect(afterMeta.filter(k => !k.endsWith('.file')).length).toBe(2) // rev 0 + rev 1
+  expect(afterMeta.filter(k => k.endsWith('.file')).length).toBe(1) // still only rev 0's payload
+  expect(afterMeta).not.toContain(`${prefix}000000001.file`)
+  const rev1 = await integrityTestStore.getRevision(`${prefix}000000001`)
+  expect(rev1.payload?.file?.i).toBe(0) // references the bytes-owning revision
+  expect(rev1.payload?.file?.size).toBe(ownSize)
+  expect(rev1.hash.md5).toBe(rev0.hash.md5) // file bytes unchanged
+
+  // a subsequent FILE change → rev 2 owns a fresh payload at its own index (no i)
+  await doAndWaitForFinalize(admin, dataset.id, async () => {
+    const FormData = (await import('form-data')).default
+    const fs = (await import('fs-extra')).default
+    const path = (await import('node:path')).default
+    const form = new FormData()
+    form.append('file', fs.readFileSync(path.resolve('./tests/resources/datasets/dataset2.csv')), 'dataset1.csv')
+    await admin.post(`/api/v1/datasets/${dataset.id}`, form, { headers: form.getHeaders() })
+  })
+  // 5 keys: rev0, rev0.file, rev1 (reference, no .file), rev2, rev2.file
+  const afterFile = await waitForIntegrityRevisions(prefix, 5)
+  expect(afterFile).toContain(`${prefix}000000002.file`)
+  const rev2 = await integrityTestStore.getRevision(`${prefix}000000002`)
+  expect(rev2.payload?.file?.i).toBeUndefined() // owns its own bytes
+  expect(rev2.hash.md5).not.toBe(rev0.hash.md5)
+})
+
+test('a referencing revision extends the owning payload at write time; renewal on a reference anchor slides the referenced payload', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  const prefix = revisionsPrefix(dataset)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+  const ownPayloadKey = `${prefix}000000000.file`
+  const beforeRef = await integrityTestStore.getRetention(ownPayloadKey)
+
+  // metadata-only edit → rev 1 references rev 0's payload
+  await admin.patch(`/api/v1/datasets/${dataset.id}`, { description: 'metadata only' })
+  await waitForIntegrityRevisions(prefix, 3)
+  await waitForFlagCleared(dataset.id)
+  expect((await integrityTestStore.getRevision(`${prefix}000000001`)).payload?.file?.i).toBe(0)
+
+  // reference-time extension: writing the referencing revision pushed the owning payload's
+  // retain-until forward, so a superseded payload outlives every revision that references it
+  const afterRef = await integrityTestStore.getRetention(ownPayloadKey)
+  expect(afterRef!.getTime()).toBeGreaterThan(beforeRef!.getTime())
+
+  // make the latest (a reference) anchor look due, then check → renewal must slide the REFERENCED
+  // payload (rev 0's .file), since rev 1 has no .file object of its own
+  const revBefore = await integrityTestStore.getRetention(`${prefix}000000001`)
+  const payloadBefore = await integrityTestStore.getRetention(ownPayloadKey)
+  await admin.post(`${apiUrl}/api/v1/test-env/patch-dataset/${dataset.id}`, { 'integrity.lastRevision.retainUntil': new Date(Date.now() + 3600 * 1000).toISOString() })
+  const check = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data
+  expect(check.status).toBe('ok')
+  const state = (await admin.get(`/api/v1/datasets/${dataset.id}/_integrity`)).data
+  expect(state.lastRenewal?.status).toBe('ok')
+  const revAfter = await integrityTestStore.getRetention(`${prefix}000000001`)
+  const payloadAfter = await integrityTestStore.getRetention(ownPayloadKey)
+  expect(revAfter!.getTime()).toBeGreaterThan(revBefore!.getTime())
+  expect(payloadAfter!.getTime()).toBeGreaterThan(payloadBefore!.getTime())
+})
+
+// ---------------------------------------------------------------------------------------------
 // checker: breach detection + fix, on top of a synchronously-enabled dataset
 // ---------------------------------------------------------------------------------------------
 

--- a/tests/features/integrity/core.api.spec.ts
+++ b/tests/features/integrity/core.api.spec.ts
@@ -124,6 +124,39 @@ test('extendRetention cannot shorten a compliance lock', async () => {
   await expect(store.extendRetention(key, new Date(Date.now() + 24 * 3600 * 1000))).rejects.toThrow()
 })
 
+test('writePayload stores a compliance-locked binary sibling object', async () => {
+  const store = integrityTestStore
+  const base = `data-fair/test-store-payload/${Date.now()}/000000000`
+  const retainUntil = new Date(Date.now() + 24 * 3600 * 1000)
+  const { Readable } = await import('node:stream')
+  await store.writePayload(base + '.file', Readable.from(Buffer.from('payload-bytes')), retainUntil)
+
+  const { body, size } = await store.readPayload(base + '.file')
+  const chunks: Buffer[] = []
+  for await (const c of body) chunks.push(c as Buffer)
+  expect(Buffer.concat(chunks).toString()).toBe('payload-bytes')
+  expect(size).toBe('payload-bytes'.length)
+
+  // WORM: the locked payload version cannot be destroyed within retention
+  const versionId = await originalVersionId(base + '.file')
+  await expect(integrityTestClient.send(new DeleteObjectCommand({ Bucket: store.bucket, Key: base + '.file', VersionId: versionId })))
+    .rejects.toThrow()
+})
+
+test('a revision body can carry an inline metadata payload', async () => {
+  const store = integrityTestStore
+  const key = `data-fair/test-store-meta/${Date.now()}/000000000`
+  await store.writeRevision(key, {
+    hash: { md5: 'abc', sha256: 'def' },
+    context: { operation: 'create', origin: 'worker', date: new Date().toISOString() },
+    dataset: { id: 'ds-meta' },
+    payload: { metadata: { title: 'snap' }, file: { size: 13 } }
+  }, new Date(Date.now() + 24 * 3600 * 1000))
+  const back = await store.getRevision(key)
+  expect(back.payload?.metadata.title).toBe('snap')
+  expect(back.payload?.file?.size).toBe(13)
+})
+
 // ---------------------------------------------------------------------------------------------
 // relay: the async historize worker, driven by the _needsHistorizing outbox flag
 // ---------------------------------------------------------------------------------------------

--- a/tests/features/integrity/core.api.spec.ts
+++ b/tests/features/integrity/core.api.spec.ts
@@ -444,3 +444,34 @@ test('a failed lock extension is recorded as lastRenewal.failed and does not fai
   const got = await integrityTestStore.getRetention(latestKey)
   expect((got!.getTime() - Date.now()) / (24 * 3600000)).toBeGreaterThan(9)
 })
+
+test('lock renewal extends the payload object too', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const { dataset, latestKey } = await enabledDataset(admin)
+  const payloadKey = latestKey + '.file'
+
+  // snapshot both real S3 locks right after the anchor write, before any renewal — dev retention
+  // is only 1 day (see development.cjs), so comparing against an absolute far-future threshold
+  // would not discriminate "renewed" from "just-created": both land ~1 day out. Comparing the
+  // before/after timestamps directly does discriminate, regardless of the configured retention length
+  const revBefore = await integrityTestStore.getRetention(latestKey)
+  const payloadBefore = await integrityTestStore.getRetention(payloadKey)
+
+  // force the persisted anchor to look old (due): retain-until ~1h out (< 22h) — same trick as
+  // 'a due anchor is renewed on check'
+  const soon = new Date(Date.now() + 3600 * 1000).toISOString()
+  await admin.post(`${apiUrl}/api/v1/test-env/patch-dataset/${dataset.id}`, { 'integrity.lastRevision.retainUntil': soon })
+
+  const check = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data
+  expect(check.status).toBe('ok')
+
+  const state = (await admin.get(`/api/v1/datasets/${dataset.id}/_integrity`)).data
+  expect(state.lastRenewal?.status).toBe('ok')
+
+  // both the revision JSON and its .file sibling must have slid forward — the payload's lock
+  // must not be left behind on its original, now-stale, retain-until
+  const revAfter = await integrityTestStore.getRetention(latestKey)
+  const payloadAfter = await integrityTestStore.getRetention(payloadKey)
+  expect(revAfter!.getTime()).toBeGreaterThan(revBefore!.getTime())
+  expect(payloadAfter!.getTime()).toBeGreaterThan(payloadBefore!.getTime())
+})

--- a/tests/features/integrity/core.api.spec.ts
+++ b/tests/features/integrity/core.api.spec.ts
@@ -161,6 +161,53 @@ test('a revision body can carry an inline metadata payload', async () => {
 // relay: the async historize worker, driven by the _needsHistorizing outbox flag
 // ---------------------------------------------------------------------------------------------
 
+test('anchor carries the level-2 payload: inline metadata snapshot + locked .file sibling', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  const prefix = revisionsPrefix(dataset)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+
+  const keys = await listIntegrityKeys(prefix)
+  expect(keys).toContain(`${prefix}000000000`)
+  expect(keys).toContain(`${prefix}000000000.file`)
+
+  const rev = await integrityTestStore.getRevision(`${prefix}000000000`)
+  expect(rev.payload?.metadata.title).toBe(dataset.title)
+  expect(rev.payload?.metadata.createdBy).toBeUndefined() // covered projection only
+  expect(rev.payload?.file?.size).toBeGreaterThan(0)
+
+  const { body } = await integrityTestStore.readPayload(`${prefix}000000000.file`)
+  const chunks: Buffer[] = []
+  for await (const c of body) chunks.push(c as Buffer)
+  const { createHash } = await import('node:crypto')
+  expect(createHash('md5').update(Buffer.concat(chunks)).digest('hex')).toBe(rev.hash.md5)
+})
+
+test('dedupe is payload-aware: an L1-era anchor self-heals to level 2', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  const prefix = revisionsPrefix(dataset)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+  expect((await listIntegrityKeys(prefix)).filter(k => !k.endsWith('.file')).length).toBe(1)
+
+  // unchanged state and a payload-bearing latest anchor → dedupe, no new revision
+  await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_fix`)
+  expect((await listIntegrityKeys(prefix)).filter(k => !k.endsWith('.file')).length).toBe(1)
+
+  // simulate an L1-era anchor: write a payload-less revision as index 1 directly to the store
+  const rev0 = await integrityTestStore.getRevision(`${prefix}000000000`)
+  await integrityTestStore.writeRevision(`${prefix}000000001`, {
+    hash: rev0.hash, context: { operation: 'update', origin: 'worker', date: new Date().toISOString() }, dataset: { id: dataset.id }
+  }, new Date(Date.now() + 24 * 3600 * 1000))
+
+  // hashes match but the latest anchor has no payload → a fresh payload-bearing revision is written
+  await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_fix`)
+  const keys = await listIntegrityKeys(prefix)
+  expect(keys).toContain(`${prefix}000000002`)
+  expect(keys).toContain(`${prefix}000000002.file`)
+  expect((await integrityTestStore.getRevision(`${prefix}000000002`)).payload?.metadata).toBeTruthy()
+})
+
 test('relay writes a locked revision when _needsHistorizing is set, then dedupes', async () => {
   const ax = await axiosAuth('test_superadmin@test.com', undefined, true)
   const dataset = await sendDataset('datasets/dataset1.csv', ax)
@@ -172,8 +219,9 @@ test('relay writes a locked revision when _needsHistorizing is set, then dedupes
     _needsHistorizing: { context: { operation: 'enable', origin: 'superadmin' } }
   })
 
-  const keys = await waitForIntegrityRevisions(prefix, 1)
-  expect(keys.length).toBe(1)
+  // 2 keys: the revision JSON + its .file payload sibling (level-2 joint anchor)
+  const keys = await waitForIntegrityRevisions(prefix, 2)
+  expect(keys.filter(k => !k.endsWith('.file')).length).toBe(1)
   const raw = await getRawDataset(dataset.id)
   expect(raw._needsHistorizing).toBeUndefined()
   expect(raw.integrity.lastRevision.hash.md5).toBe(dataset.originalFile.md5)
@@ -181,7 +229,7 @@ test('relay writes a locked revision when _needsHistorizing is set, then dedupes
   // flag again without a change → relay must dedupe (clears flag, writes no new revision)
   await ax.post(`${apiUrl}/api/v1/test-env/patch-dataset/${dataset.id}`, { _needsHistorizing: {} })
   await waitForFlagCleared(dataset.id)
-  expect((await listIntegrityKeys(prefix)).length).toBe(1)
+  expect((await listIntegrityKeys(prefix)).filter(k => !k.endsWith('.file')).length).toBe(1)
 })
 
 test('flagging a REST dataset (no file) anchors metadata only: sha256 present, no md5', async () => {
@@ -212,7 +260,8 @@ test('a file replacement writes a new (second) revision', async () => {
     integrity: { active: true },
     _needsHistorizing: {}
   })
-  expect((await waitForIntegrityRevisions(prefix, 1)).length).toBe(1)
+  // 2 keys: the revision JSON + its .file payload sibling (level-2 joint anchor)
+  expect((await waitForIntegrityRevisions(prefix, 2)).filter(k => !k.endsWith('.file')).length).toBe(1)
 
   // replace the file; the finalize hook sets _needsHistorizing because integrity.active is true,
   // and the new md5 (dataset2.csv) differs from the anchor → relay writes revision 1. The joint
@@ -226,8 +275,9 @@ test('a file replacement writes a new (second) revision', async () => {
     await ax.post(`/api/v1/datasets/${dataset.id}`, form, { headers: form.getHeaders() })
   })
 
-  const keys = await waitForIntegrityRevisions(prefix, 2)
-  expect(keys.length).toBe(2)
+  // 4 keys: 2 revisions × (JSON + .file payload)
+  const keys = await waitForIntegrityRevisions(prefix, 4)
+  expect(keys.filter(k => !k.endsWith('.file')).length).toBe(2)
 })
 
 // ---------------------------------------------------------------------------------------------
@@ -275,8 +325,8 @@ test('a check during a pending legitimate update never reports a breach', async 
   const check = (await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data
   expect(['unknown', 'ok']).toContain(check.status)
 
-  // once the relay has anchored the new content the check is 'ok'
-  await waitForIntegrityRevisions(prefix, 2)
+  // once the relay has anchored the new content the check is 'ok' (4 keys: 2 revisions × JSON + .file)
+  await waitForIntegrityRevisions(prefix, 4)
   expect((await admin.post(`/api/v1/datasets/${dataset.id}/_integrity/_check`)).data.status).toBe('ok')
 
   await new Promise(resolve => setTimeout(resolve, 1500)) // settle: allow a stray event to arrive

--- a/tests/features/integrity/operations.unit.spec.ts
+++ b/tests/features/integrity/operations.unit.spec.ts
@@ -188,3 +188,19 @@ test('coveredMetadata strips readApiKey renewal churn but keeps active/interval'
   const disabled = { id: 'ds1', readApiKey: { ...base.readApiKey, active: false } }
   expect(ops.metadataHash(base)).not.toBe(ops.metadataHash(disabled))
 })
+
+test('payloadKey appends the .file suffix to the revision key', () => {
+  expect(ops.payloadKey(owner, 'ds1', 7)).toBe('data-fair/organization-acme/ds1/000000007.file')
+  expect(ops.isPayloadKey('data-fair/organization-acme/ds1/000000007.file')).toBe(true)
+  expect(ops.isPayloadKey('data-fair/organization-acme/ds1/000000007')).toBe(false)
+})
+
+test('latestKey and nextIndex ignore payload keys', () => {
+  const keys = [
+    'data-fair/organization-acme/ds1/000000000',
+    'data-fair/organization-acme/ds1/000000001',
+    'data-fair/organization-acme/ds1/000000001.file'
+  ]
+  expect(ops.latestKey(keys)).toBe('data-fair/organization-acme/ds1/000000001')
+  expect(ops.nextIndex(keys)).toBe(2)
+})

--- a/tests/features/integrity/operations.unit.spec.ts
+++ b/tests/features/integrity/operations.unit.spec.ts
@@ -204,3 +204,29 @@ test('latestKey and nextIndex ignore payload keys', () => {
   expect(ops.latestKey(keys)).toBe('data-fair/organization-acme/ds1/000000001')
   expect(ops.nextIndex(keys)).toBe(2)
 })
+
+test('restoreUpdate writes only diverging covered keys and unsets extra ones', () => {
+  const snapshot = { title: 'legit', description: 'legit desc', owner: { type: 'organization', id: 'acme' } }
+  const hot = {
+    title: 'tampered',
+    description: 'legit desc',
+    injected: 'evil',
+    status: 'finalized', // denylisted: must never be touched
+    owner: { type: 'organization', id: 'acme', name: 'Acme Corp' } // normalizes to snapshot → untouched
+  }
+  const { $set, $unset } = ops.restoreUpdate(hot, snapshot)
+  expect($set).toEqual({ title: 'legit' }) // description equal → skipped; owner equal after normalization → skipped
+  expect($unset).toEqual({ injected: '' })
+})
+
+test('restoreUpdate restores a tampered owner as its normalized form', () => {
+  const snapshot = { owner: { type: 'organization', id: 'acme' } }
+  const hot = { owner: { type: 'organization', id: 'evil', name: 'Evil' } }
+  expect(ops.restoreUpdate(hot, snapshot).$set.owner).toEqual({ type: 'organization', id: 'acme' })
+})
+
+test('rehydrateTopics fills titles back from settings, keeps unknown ids bare', () => {
+  const settingsTopics = [{ id: 't1', title: 'Topic 1', color: '#f00' }]
+  expect(ops.rehydrateTopics([{ id: 't1' }, { id: 'gone' }], settingsTopics))
+    .toEqual([{ id: 't1', title: 'Topic 1', color: '#f00' }, { id: 'gone' }])
+})

--- a/ui/src/components/dataset/dataset-integrity.vue
+++ b/ui/src/components/dataset/dataset-integrity.vue
@@ -121,8 +121,9 @@
                 :icon="mdiFileCompare"
                 variant="text"
                 size="x-small"
+                :loading="openDiff.loading.value"
                 :title="t('viewDiff')"
-                @click="openDiff(item.i)"
+                @click="openDiff.execute(item.i)"
               />
               <v-btn
                 v-if="item.fileSize"
@@ -130,6 +131,7 @@
                 variant="text"
                 size="x-small"
                 :title="t('downloadPayload')"
+                download
                 :href="`${$apiPath}/datasets/${dataset!.id}/_integrity/revisions/${item.i}/file`"
               />
               <v-btn
@@ -415,10 +417,10 @@ const diffKeys = computed(() => {
   return [...new Set([...Object.keys(snapshot), ...Object.keys(current)])]
     .filter(k => JSON.stringify(snapshot[k]) !== JSON.stringify(current[k])).sort()
 })
-const openDiff = async (i: number) => {
+const openDiff = useAsyncAction(async (i: number) => {
   diffData.value = await $fetch<RevisionDetail>(`datasets/${dataset.value!.id}/_integrity/revisions/${i}`)
   diffOpen.value = true
-}
+})
 
 const restoreTarget = ref<number | null>(null)
 const restoreReason = ref('')

--- a/ui/src/components/dataset/dataset-integrity.vue
+++ b/ui/src/components/dataset/dataset-integrity.vue
@@ -115,6 +115,38 @@
           <template #item.origin="{ item }">
             {{ t('origin_' + item.origin) }}
           </template>
+          <template #item.actions="{ item }">
+            <template v-if="item.hasPayload">
+              <v-btn
+                :icon="mdiFileCompare"
+                variant="text"
+                size="x-small"
+                :title="t('viewDiff')"
+                @click="openDiff(item.i)"
+              />
+              <v-btn
+                v-if="item.fileSize"
+                :icon="mdiDownload"
+                variant="text"
+                size="x-small"
+                :title="t('downloadPayload')"
+                :href="`${$apiPath}/datasets/${dataset!.id}/_integrity/revisions/${item.i}/file`"
+              />
+              <v-btn
+                v-if="adminMode"
+                :icon="mdiBackupRestore"
+                variant="text"
+                size="x-small"
+                color="warning"
+                :title="t('restore')"
+                @click="restoreTarget = item.i; restoreReason = ''"
+              />
+            </template>
+            <span
+              v-else
+              class="text-caption text-disabled"
+            >{{ t('noPayload') }}</span>
+          </template>
         </v-data-table-server>
       </template>
     </template>
@@ -128,6 +160,76 @@
       variant="tonal"
       :text="t('loadError')"
     />
+
+    <v-dialog
+      v-model="diffOpen"
+      max-width="1100"
+    >
+      <v-card :title="t('diffTitle', { i: diffData?.i })">
+        <v-card-text v-if="diffData">
+          <p
+            v-if="!diffKeys.length"
+            class="text-caption"
+          >
+            {{ t('noDiff') }}
+          </p>
+          <template
+            v-for="key of diffKeys"
+            :key="key"
+          >
+            <h4 class="text-subtitle-2 mt-2">
+              {{ key }}
+            </h4>
+            <v-row dense>
+              <v-col cols="6">
+                <div class="text-caption">
+                  {{ t('diffRevision') }}
+                </div>
+                <pre class="text-caption bg-surface-light pa-2 overflow-auto">{{ pretty(diffData.payload.metadata[key]) }}</pre>
+              </v-col>
+              <v-col cols="6">
+                <div class="text-caption">
+                  {{ t('diffCurrent') }}
+                </div>
+                <pre class="text-caption bg-surface-light pa-2 overflow-auto">{{ pretty(diffData.current?.[key]) }}</pre>
+              </v-col>
+            </v-row>
+          </template>
+        </v-card-text>
+      </v-card>
+    </v-dialog>
+
+    <v-dialog
+      :model-value="restoreTarget !== null"
+      max-width="500"
+      @update:model-value="(v) => { if (!v) restoreTarget = null }"
+    >
+      <v-card :title="t('restoreTitle', { i: restoreTarget })">
+        <v-card-text>
+          <p class="mb-2">
+            {{ t('restoreWarning') }}
+          </p>
+          <v-text-field
+            v-model="restoreReason"
+            :label="t('restoreReason')"
+            density="compact"
+          />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn @click="restoreTarget = null">
+            {{ t('cancel') }}
+          </v-btn>
+          <v-btn
+            color="warning"
+            :loading="restore.loading.value"
+            @click="restore.execute()"
+          >
+            {{ t('restore') }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </div>
 </template>
 
@@ -161,11 +263,25 @@ fr:
   op_update: Mise à jour
   op_enable: Activation
   op_fixIntegrity: Réconciliation
+  op_restore: Restauration
   origin_user: Utilisateur
   origin_superadmin: Superadmin
   origin_worker: Traitement interne
   origin_propagation: Propagation
   origin_upgrade: Script de migration
+  viewDiff: Voir les différences
+  downloadPayload: Télécharger le fichier historisé
+  restore: Restaurer
+  noPayload: non restaurable
+  diffTitle: "Révision {i} — différences avec l'état courant"
+  noDiff: Aucune différence de métadonnées avec l'état courant.
+  diffRevision: Révision
+  diffCurrent: État courant
+  restoreTitle: "Restaurer la révision {i}"
+  restoreWarning: Les métadonnées couvertes et le fichier de données seront restaurés à l'état de cette révision. Un fichier différent déclenche un retraitement complet du jeu de données.
+  restoreReason: Raison (optionnelle, tracée dans l'historique)
+  cancel: Annuler
+  restoreOk: Restauration lancée
 en:
   disabledInfo: Integrity checking is not enabled for this dataset.
   part_file: Data file
@@ -195,15 +311,29 @@ en:
   op_update: Update
   op_enable: Enable
   op_fixIntegrity: Reconcile
+  op_restore: Restore
   origin_user: User
   origin_superadmin: Superadmin
   origin_worker: Internal worker
   origin_propagation: Propagation
   origin_upgrade: Upgrade script
+  viewDiff: View diff
+  downloadPayload: Download historized file
+  restore: Restore
+  noPayload: not restorable
+  diffTitle: "Revision {i} — diff with current state"
+  noDiff: No metadata difference with the current state.
+  diffRevision: Revision
+  diffCurrent: Current state
+  restoreTitle: "Restore revision {i}"
+  restoreWarning: Covered metadata and the data file will be restored to this revision's state. A differing file triggers a full reprocessing of the dataset.
+  restoreReason: Reason (optional, recorded in the history)
+  cancel: Cancel
+  restoreOk: Restore started
 </i18n>
 
 <script setup lang="ts">
-import { mdiShieldRefresh, mdiWrench } from '@mdi/js'
+import { mdiShieldRefresh, mdiWrench, mdiFileCompare, mdiDownload, mdiBackupRestore } from '@mdi/js'
 import type { Dataset } from '#api/types'
 
 const { t, locale } = useI18n()
@@ -215,7 +345,8 @@ const session = useSession()
 const adminMode = computed(() => !!session.state.user?.adminMode)
 
 type IntegrityState = NonNullable<Dataset['integrity']>
-type RevisionEntry = { i: number, hash: { md5?: string, sha256?: string }, date: string, operation: string, origin: string, reason?: string }
+type RevisionEntry = { i: number, hash: { md5?: string, sha256?: string }, date: string, operation: string, origin: string, reason?: string, hasPayload?: boolean, fileSize?: number }
+type RevisionDetail = { i: number, hash: { md5?: string, sha256?: string }, context: any, payload: { metadata: Record<string, any>, file?: { size: number } }, current?: Record<string, any> }
 
 const state = ref<IntegrityState | null>(null)
 
@@ -231,7 +362,8 @@ const headers = computed(() => [
   { title: t('colOperation'), key: 'operation', sortable: false },
   { title: t('colDate'), key: 'date', sortable: false },
   { title: t('colOriginator'), key: 'origin', sortable: false },
-  { title: t('colHash'), key: 'hash', sortable: false }
+  { title: t('colHash'), key: 'hash', sortable: false },
+  { title: '', key: 'actions', sortable: false, align: 'end' as const }
 ])
 
 const loadRevisions = useAsyncAction(async () => {
@@ -272,6 +404,33 @@ const toggle = useAsyncAction(async (active: boolean) => {
 }, { success: t('toggleOk') })
 
 const formatDate = (dateStr: string) => new Date(dateStr).toLocaleString(locale.value)
+
+const diffOpen = ref(false)
+const diffData = ref<RevisionDetail | null>(null)
+const pretty = (v: any) => v === undefined ? '—' : JSON.stringify(v, null, 2)
+const diffKeys = computed(() => {
+  if (!diffData.value) return []
+  const snapshot = diffData.value.payload.metadata
+  const current = diffData.value.current ?? {}
+  return [...new Set([...Object.keys(snapshot), ...Object.keys(current)])]
+    .filter(k => JSON.stringify(snapshot[k]) !== JSON.stringify(current[k])).sort()
+})
+const openDiff = async (i: number) => {
+  diffData.value = await $fetch<RevisionDetail>(`datasets/${dataset.value!.id}/_integrity/revisions/${i}`)
+  diffOpen.value = true
+}
+
+const restoreTarget = ref<number | null>(null)
+const restoreReason = ref('')
+const restore = useAsyncAction(async () => {
+  const body: any = { i: restoreTarget.value }
+  if (restoreReason.value) body.reason = restoreReason.value
+  const res = await $fetch<{ status: string }>(`datasets/${dataset.value!.id}/_integrity/_restore`, { method: 'POST', body })
+  restoreTarget.value = null
+  await load.execute()
+  datasetStore.datasetFetch.refresh() // the breach badge and tab color derive from the dataset doc
+  return res
+}, { success: t('restoreOk') })
 
 defineExpose({ load })
 </script>


### PR DESCRIPTION
Deliver integrity **level 2 (repair)** for file datasets, on top of the level-1 joint anchor (#504): every anchor revision now stores the full payload, unlocking metadata diff, audit download, and restore from any stored revision.

- Payload storage: covered-metadata snapshot inline in the revision JSON + file copy as a sibling compliance-locked `{i}.file` object (written payload-first); dedupe is payload-aware and self-heals L1-era anchors. Always-on, no size gate — cost is metered into the owner's storage consumption.
- **Payload reference dedupe**: one locked file copy per distinct file *version* — a revision whose file is unchanged records `payload.file = { size, i }` referencing the bytes-owning revision instead of re-uploading. Lock renewal slides the latest revision JSON + its *referenced* payload, and each referencing revision extends the referenced payload's retention at write time, so bytes always outlive every revision that needs them.
- `POST _integrity/_restore { i, reason? }` (superadmin): metadata-only restores are synchronous and respond with the fresh verdict; file restores re-ingest the payload through the standard draft pipeline. Restore always appends a forced `restore` trail revision.
- Read surface: revision detail (snapshot + current covered projection for diffing), file payload download, `hasPayload`/`fileSize` on the revisions list; UI revision-row actions (diff dialog, download, admin-mode restore with reason).
- Owner transfer now returns 400 while integrity is active (replaces the transfer re-anchor machinery).

**Why:** clients' integrity requirement level 2 — restore a resource to its last verified state (architecture doc §2/§10); file and metadata shipped as one unit since they share the payload machinery.

**Heads-up:**
- `finalize` now preserves a pre-set `_needsHistorizing` context instead of overwriting it — this touches every finalize path, not just restores (reviewed safe: absent flag ⇒ unchanged worker default).
- Enable/anchor streams the full file synchronously into the locked store — long requests for multi-GB files (accepted; rare superadmin action).
- The file md5 is now storage-load-bearing (an md5 collision would collapse two file versions onto one payload) — noted as future work to consider sha256 for the file hash.
- Documented accepted window: a check during an in-flight file restore can record a transient breach until the finalize anchor lands (§3.3).
- Fast-follow test debt (recorded in the plan ledger): combined file+metadata tamper e2e; 409-refusal-writes-no-metadata regression.
