### PR TITLE
fix(datasets): tolerate non-geo children in geo queries on virtual datasets

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -18,9 +18,9 @@
   "dependencies": {
     "@aws-sdk/lib-storage": "^3.995.0",
     "@data-fair/data-fair-shared": "*",
-    "@data-fair/lib-express": "^1.20.5",
+    "@data-fair/lib-express": "^1.24.0",
     "@data-fair/lib-node": "^2.11.0",
-    "@data-fair/lib-utils": "^1.6.1",
+    "@data-fair/lib-utils": "^1.12.0",
     "@data-fair/lib-validation": "^1.0.2",
     "@dsnp/parquetjs": "^1.8.7",
     "@e965/xlsx": "0.20.3",

--- a/api/src/datasets/es/commons.ts
+++ b/api/src/datasets/es/commons.ts
@@ -69,7 +69,9 @@ export const parseSort = (sortStr: string | undefined, fields: string[], dataset
     if (key.startsWith('_geo_distance:')) {
       if (!dataset.bbox) throw httpError(400, '"geo_distance" sorting cannot be used on this dataset. It is not geolocalized.')
       const [lon, lat] = key.replace('_geo_distance:', '').split(':')
-      result.push({ _geo_distance: { _geopoint: { lon, lat }, order } })
+      // ignore_unmapped lets a virtual dataset mix geo and non-geo children:
+      // rows from a child without geo mapping sort last instead of failing the query
+      result.push({ _geo_distance: { _geopoint: { lon, lat }, order, ignore_unmapped: true } })
       continue
     }
 
@@ -232,7 +234,7 @@ export const prepareQuery = (dataset: any, query: Record<string, any>, qFields?:
   if ((query.geo_distance ?? query._c_geo_distance)) {
     if (!esQuery.sort.some((s: any) => !!s._geo_distance)) {
       const [lon, lat] = (query.geo_distance ?? query._c_geo_distance).split(/[,:]/)
-      esQuery.sort.push({ _geo_distance: { _geopoint: { lon, lat }, order: 'asc' } })
+      esQuery.sort.push({ _geo_distance: { _geopoint: { lon, lat }, order: 'asc', ignore_unmapped: true } })
     }
     if (!esQuery._source.includes('_geopoint')) {
       esQuery._source.push('_geopoint')
@@ -475,7 +477,10 @@ export const prepareQuery = (dataset: any, query: Record<string, any>, qFields?:
             type: 'envelope',
             coordinates: [[esBoundingBox.left, esBoundingBox.top], [esBoundingBox.right, esBoundingBox.bottom]]
           }
-        }
+        },
+        // ignore_unmapped lets a virtual dataset mix geo and non-geo children:
+        // the non-geo child's index simply matches nothing instead of failing the query
+        ignore_unmapped: true
       }
     })
   }
@@ -501,7 +506,8 @@ export const prepareQuery = (dataset: any, query: Record<string, any>, qFields?:
                 type: 'point',
                 coordinates: [lon, lat]
               }
-            }
+            },
+            ignore_unmapped: true
           }
         })
       } else {
@@ -513,7 +519,8 @@ export const prepareQuery = (dataset: any, query: Record<string, any>, qFields?:
         filter.push({
           geo_distance: {
             distance,
-            _geopoint: { lat, lon }
+            _geopoint: { lat, lon },
+            ignore_unmapped: true
           }
         })
       }

--- a/api/src/datasets/utils/virtual.ts
+++ b/api/src/datasets/utils/virtual.ts
@@ -133,6 +133,12 @@ export const prepareSchema = async (dataset: VirtualDataset) => {
   return schema.filter((f: any) => !!f)
 }
 
+// "cannot be queried" errors are thrown both while serving requests (descendants are resolved
+// by readDataset with fillDescendants) and inside worker tasks (finalization of a virtual dataset).
+// expose sends the message as response body despite the 501 status being hidden by default,
+// noRetry tells the worker loop not to retry (structured equivalent of the [noretry] message prefix)
+const cannotQueryError = (message: string) => Object.assign(httpError(501, message, { expose: true }), { noRetry: true })
+
 const recurseDescendants = async (descendants: any[], dataset: Pick<VirtualDataset, 'id' | 'owner' | 'virtual'>, mongoOptions: any) => {
   const pseudoSessionState = getPseudoSessionState(dataset.owner, 'virtual-dataset', '_virtual-dataset', 'admin')
   const permissionsFilter = filterCan(pseudoSessionState, 'datasets', 'read')
@@ -163,14 +169,14 @@ const recurseDescendants = async (descendants: any[], dataset: Pick<VirtualDatas
         : `${owner.type === 'user' ? 'utilisateur' : 'organisation'} "${owner.name}"`
       return `le jeu de données "${child.title ?? id}" (${id}, propriété de ${ownerLabel}) n'est pas accessible en lecture par le compte propriétaire du jeu de données virtuel`
     })
-    throw httpError(501, `[noretry] Le jeu de données virtuel "${dataset.id}" ne peut pas être requêté : ${details.join(' ; ')}.`)
+    throw cannotQueryError(`Le jeu de données virtuel "${dataset.id}" ne peut pas être requêté : ${details.join(' ; ')}.`)
   }
   for (const child of children) {
     if (child.isVirtual && (child.virtual?.filters?.length || child.virtual?.filterActiveAccount)) {
       const filterKind = child.virtual?.filters?.length
         ? `des filtres (${child.virtual.filters.map((f: any) => f.key).filter(Boolean).join(', ')})`
         : 'un filtre sur le compte actif'
-      throw httpError(501, `[noretry] Le jeu de données virtuel "${dataset.id}" ne peut pas être requêté : il utilise le jeu de données virtuel enfant "${child.id}" qui définit ${filterKind}, ce qui n'est pas supporté.`)
+      throw cannotQueryError(`Le jeu de données virtuel "${dataset.id}" ne peut pas être requêté : il utilise le jeu de données virtuel enfant "${child.id}" qui définit ${filterKind}, ce qui n'est pas supporté.`)
     }
     if (child.isVirtual) {
       await recurseDescendants(descendants, child as VirtualDataset, mongoOptions)
@@ -197,7 +203,7 @@ export const descendants = async (dataset: VirtualDataset, extraProperties: stri
   const descendants: any[] = []
   await recurseDescendants(descendants, dataset, mongoOptions)
   if (descendants.length === 0 && throwEmpty) {
-    throw httpError(501, '[noretry] Le jeu de données virtuel ne peut pas être requêté, il n\'utilise aucun jeu de données requêtable.')
+    throw cannotQueryError('Le jeu de données virtuel ne peut pas être requêté, il n\'utilise aucun jeu de données requêtable.')
   }
   if (extraProperties) {
     for (const descendant of descendants) {

--- a/api/src/workers/index.ts
+++ b/api/src/workers/index.ts
@@ -196,7 +196,8 @@ export const processResourceTask = async (type: ResourceType, resource: any, tas
     console.warn(`failure in worker ${task.name} - ${type} / ${resource.slug} (${resource.id})`, errorMessage)
 
     // some error are caused by bad input, we should not retry these
-    let retry = !errorMessage.startsWith('[noretry] ')
+    // they are signalled either by a [noretry] message prefix or a noRetry property on the error
+    let retry = !errorMessage.startsWith('[noretry] ') && err?.noRetry !== true
     if (!retry) {
       debug('error message started by [noretry]')
       errorMessage = errorMessage.replace('[noretry] ', '')

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@commitlint/cli": "^17.5.0",
         "@commitlint/config-conventional": "^17.4.4",
         "@data-fair/lib-types-builder": "^1.7.0",
-        "@data-fair/lib-utils": "^1.6.1",
+        "@data-fair/lib-utils": "^1.12.0",
         "@playwright/test": "^1.52.0",
         "@reporters/bail": "^1.3.1",
         "@types/content-disposition": "^0.5.8",
@@ -66,9 +66,9 @@
       "dependencies": {
         "@aws-sdk/lib-storage": "^3.995.0",
         "@data-fair/data-fair-shared": "*",
-        "@data-fair/lib-express": "^1.20.5",
+        "@data-fair/lib-express": "^1.24.0",
         "@data-fair/lib-node": "^2.11.0",
-        "@data-fair/lib-utils": "^1.6.1",
+        "@data-fair/lib-utils": "^1.12.0",
         "@data-fair/lib-validation": "^1.0.2",
         "@dsnp/parquetjs": "^1.8.7",
         "@e965/xlsx": "0.20.3",
@@ -1630,7 +1630,7 @@
       "integrity": "sha512-LBppiR7ncYLIpDxZLmXHIDvGmUHjqwc3F+qXuVSS4vDpgvCL8RWhT6396DSXMpgbY0I3aKZ8T6LGpPxz8qB4/Q==",
       "license": "MIT",
       "dependencies": {
-        "@data-fair/lib-utils": "^1.6.1",
+        "@data-fair/lib-utils": "^1.12.0",
         "@data-fair/lib-validation": "^1.0.0",
         "ajv-formats": "3.0.1"
       },
@@ -1644,9 +1644,9 @@
       }
     },
     "node_modules/@data-fair/lib-express": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/@data-fair/lib-express/-/lib-express-1.23.1.tgz",
-      "integrity": "sha512-sYVyaRvtpVkS1vPLAm8VOlkSnizcdRFXGYKQuWl/6/mu0uvPPIA2YliU+wajfyZaWN9q1fIbJ9p9My5xvBDVUw==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@data-fair/lib-express/-/lib-express-1.24.0.tgz",
+      "integrity": "sha512-IyQXLsxdZKwElM55HJkhTOXNBuZWDOdoUqPN+nkvi6x/0iV95VqcVM2OH5cROSu1NnlNAdgW5OlJRhPxWTQL4A==",
       "license": "MIT",
       "dependencies": {
         "@data-fair/lib-common-types": "^1.7.1",
@@ -1749,9 +1749,9 @@
       }
     },
     "node_modules/@data-fair/lib-utils": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@data-fair/lib-utils/-/lib-utils-1.10.2.tgz",
-      "integrity": "sha512-/1pEeL2uAJSb+wwiDakgMs64Cr341a1fVGsANP6RUEbfs8w7/gm+vw3vDuSRGQ+7CfAMfqYI4AnAfHsCvt/+wg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@data-fair/lib-utils/-/lib-utils-1.12.0.tgz",
+      "integrity": "sha512-Ac7mtyJpNzQ2RhwzdzWqrqxodnytscmEfzw3MVFtpo18OArBE4oV0FDj5rZCMXFwfDKsLghw3UVjdlIE6HMnYQ==",
       "license": "MIT",
       "peerDependencies": {
         "dayjs": "1"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@commitlint/cli": "^17.5.0",
     "@commitlint/config-conventional": "^17.4.4",
     "@data-fair/lib-types-builder": "^1.7.0",
-    "@data-fair/lib-utils": "^1.6.1",
+    "@data-fair/lib-utils": "^1.12.0",
     "@playwright/test": "^1.52.0",
     "@reporters/bail": "^1.3.1",
     "@types/content-disposition": "^0.5.8",

--- a/tests/features/datasets/virtual/virtual-datasets-core.api.spec.ts
+++ b/tests/features/datasets/virtual/virtual-datasets-core.api.spec.ts
@@ -334,6 +334,8 @@ test.describe('virtual datasets core', () => {
 
     await assert.rejects(ax.get(`/api/v1/datasets/${res.data.id}/lines`), (err: any) => {
       assert.equal(err.status, 501)
+      // the body is the user-facing message, not empty and not a stack trace
+      assert.equal(err.data, 'Le jeu de données virtuel ne peut pas être requêté, il n\'utilise aucun jeu de données requêtable.')
       return true
     })
   })
@@ -367,10 +369,13 @@ test.describe('virtual datasets core', () => {
     const virtualDataset = res.data
     await waitForDatasetError(ax, virtualDataset.id)
 
-    await assert.rejects(
-      ax.get(`/api/v1/datasets/${virtualDataset.id}/lines`),
-      { status: 501 }
-    )
+    await assert.rejects(ax.get(`/api/v1/datasets/${virtualDataset.id}/lines`), (err: any) => {
+      assert.equal(err.status, 501)
+      // the body is the user-facing message, without the worker-only [noretry] prefix
+      assert.ok(err.data.startsWith(`Le jeu de données virtuel "${virtualDataset.id}" ne peut pas être requêté`), err.data)
+      assert.ok(err.data.includes('des filtres (id)'), err.data)
+      return true
+    })
   })
 
   test('A virtual dataset is updated after a child schema changes', async () => {
@@ -481,6 +486,8 @@ test.describe('virtual datasets core', () => {
       // the error now pinpoints the exact child dataset that is not readable
       assert.ok(err.data.includes(dataset.id))
       assert.ok(err.data.includes('n\'est pas accessible en lecture par le compte propriétaire du jeu de données virtuel'))
+      // the body is the user-facing message, not a stack trace with the worker-only [noretry] prefix
+      assert.ok(err.data.startsWith(`Le jeu de données virtuel "${res.data.id}" ne peut pas être requêté`), err.data)
       return true
     })
   })

--- a/tests/features/datasets/virtual/virtual-datasets-features.api.spec.ts
+++ b/tests/features/datasets/virtual/virtual-datasets-features.api.spec.ts
@@ -289,6 +289,43 @@ test.describe('virtual datasets features', () => {
     assert.equal(res.status, 200)
   })
 
+  test('A virtual dataset with geo and non-geo children supports geo queries', async () => {
+    const ax = testUser1
+    const geoChild = await sendDataset('datasets/dataset1.csv', ax)
+    const locProp = geoChild.schema.find((p: any) => p.key === 'loc')
+    locProp['x-refersTo'] = 'http://www.w3.org/2003/01/geo/wgs84_pos#lat_long'
+    await ax.patch('/api/v1/datasets/' + geoChild.id, { schema: geoChild.schema })
+    await waitForFinalize(ax, geoChild.id)
+    const plainChild = await sendDataset('datasets/dataset2.csv', ax)
+
+    const res = await ax.post('/api/v1/datasets', {
+      isVirtual: true,
+      title: 'a virtual dataset',
+      virtual: {
+        children: [geoChild.id, plainChild.id]
+      },
+      schema: [{ key: 'id' }, { key: 'loc' }]
+    })
+    const virtualDataset = await waitForFinalize(ax, res.data.id)
+    assert.ok(virtualDataset.bbox?.length, 'the virtual dataset should be geolocalized')
+
+    let lines = await ax.get(`/api/v1/datasets/${virtualDataset.id}/lines`)
+    assert.equal(lines.data.total, 8)
+    // geo filters must ignore the rows of the non-geo child instead of failing
+    // on its index that has no geo mapping (partial shards failure)
+    lines = await ax.get(`/api/v1/datasets/${virtualDataset.id}/lines?bbox=-2.5,40,3,47`)
+    assert.equal(lines.data.total, 1)
+    assert.equal(lines.data.results[0].id, 'bidule')
+    lines = await ax.get(`/api/v1/datasets/${virtualDataset.id}/lines?geo_distance=-2.75,47.7,10km`)
+    assert.equal(lines.data.total, 1)
+    assert.equal(lines.data.results[0].id, 'koumoul')
+    lines = await ax.get(`/api/v1/datasets/${virtualDataset.id}/lines?sort=_geo_distance:2.6:45.5`)
+    assert.equal(lines.data.total, 8)
+    assert.equal(lines.data.results[0].id, 'bidule')
+    const geoAgg = await ax.get(`/api/v1/datasets/${virtualDataset.id}/geo_agg?bbox=-3,45,3,48`)
+    assert.equal(geoAgg.data.aggs.length, 2)
+  })
+
   test('fails to upload file on virtual data', async () => {
     const ax = testUser1
     let res = await ax.post('/api/v1/datasets', {


### PR DESCRIPTION
Since #369 set `allow_partial_search_results: false` on all ES read paths, geo queries (`bbox`, `xyz`, `geo_distance`, `_geo_distance` sort) on a virtual dataset mixing geo and non-geo children failed whole-request with "Partial shards failure": the non-geo child's index has no `_geopoint`/`_geoshape` mapping and its shards raise `query_shard_exception`. Before #369 those shard failures were silently swallowed by ES defaults, so this used to work.

Restore the old semantics deliberately with `ignore_unmapped: true` on the `geo_shape` / `geo_distance` filters and `_geo_distance` sorts: the unmapped index matches nothing (its rows sort last) instead of failing the query, while `allow_partial_search_results: false` keeps doing its intended job on timeouts.

Adds the first geo coverage to the virtual dataset test suite: one geo child + one non-geo child, exercising `bbox`, `geo_distance`, `sort=_geo_distance` and `geo_agg`.

**Heads-up:** rows of a non-geo child are silently excluded from geo-filtered results (pre-#369 behavior, now explicit).
