### PR TITLE
fix(datasets): allow grouping enriched columns in the schema editor

### DIFF
--- a/api/src/datasets/utils/extensions.ts
+++ b/api/src/datasets/utils/extensions.ts
@@ -616,6 +616,7 @@ export const prepareExtensionsSchema = async (schema: any, extensions: any[]) =>
       if (newExtProp) {
         if (prop.title) newExtProp.title = prop.title
         if (prop.description) newExtProp.description = prop.description
+        if ('x-group' in prop) newExtProp['x-group'] = prop['x-group']
         newSchema.push(newExtProp)
       }
     } else {

--- a/tests/features/datasets/extensions/extensions-core.api.spec.ts
+++ b/tests/features/datasets/extensions/extensions-core.api.spec.ts
@@ -560,6 +560,29 @@ other,unknown address
     assert.equal(dataset.schema.length, 11)
   })
 
+  test('Preserve user metadata (x-group) on enriched columns when schema is saved', async () => {
+    const ax = testUser1
+    // Initial dataset with addresses, extended with the geocoder remote service
+    let dataset = await sendDataset('datasets/dataset-extensions.csv', ax)
+    await setupCoordsMock(10)
+    dataset.schema.find((field: any) => field.key === 'adr')['x-refersTo'] = 'http://schema.org/address'
+    const res = await ax.patch(`/api/v1/datasets/${dataset.id}`, {
+      schema: dataset.schema,
+      extensions: [{ active: true, type: 'remoteService', remoteService: 'geocoder-koumoul', action: 'postCoords' }]
+    })
+    assert.equal(res.status, 200)
+    dataset = await waitForFinalize(ax, dataset.id)
+    const extensionKey = dataset.extensions[0].propertyPrefix
+    const latKey = extensionKey + '.lat'
+    assert.ok(dataset.schema.find((field: any) => field.key === latKey))
+
+    // define a group on an enriched column and save the schema (innocuous change)
+    dataset.schema.find((field: any) => field.key === latKey)['x-group'] = 'coordinates'
+    dataset = await ax.patch(`/api/v1/datasets/${dataset.id}`, { schema: dataset.schema }).then(r => r.data)
+    const latProp = dataset.schema.find((field: any) => field.key === latKey)
+    assert.equal(latProp['x-group'], 'coordinates', 'x-group must be preserved on enriched columns')
+  })
+
   test('Extend geojson dataset', async () => {
     const ax = testUser1
     // Initial dataset with addresses

--- a/tests/features/datasets/virtual/virtual-datasets-core.api.spec.ts
+++ b/tests/features/datasets/virtual/virtual-datasets-core.api.spec.ts
@@ -49,6 +49,25 @@ test.describe('virtual datasets core', () => {
     assert.equal(res.data.total, 2)
   })
 
+  test('Preserve a group (x-group) set on a virtual dataset column', async () => {
+    const ax = testUser1
+    const dataset = await sendDataset('datasets/dataset1.csv', ax)
+    const res = await ax.post('/api/v1/datasets', {
+      isVirtual: true,
+      virtual: { children: [dataset.id] },
+      title: 'a virtual dataset with a group',
+      schema: [{ key: 'id' }, { key: 'loc' }]
+    })
+    let virtualDataset = await waitForFinalize(ax, res.data.id)
+    assert.ok(virtualDataset.schema.find((p: any) => p.key === 'id'))
+
+    // define a group on a column and save the schema (innocuous change)
+    virtualDataset.schema.find((p: any) => p.key === 'id')['x-group'] = 'my group'
+    virtualDataset = await ax.patch(`/api/v1/datasets/${virtualDataset.id}`, { schema: virtualDataset.schema }).then(r => r.data)
+    const groupedField = virtualDataset.schema.find((p: any) => p.key === 'id')
+    assert.equal(groupedField['x-group'], 'my group', 'x-group must be preserved on virtual dataset columns')
+  })
+
   test('Create a virtual dataset with initFrom', async () => {
     // Send basic dataset
     const ax = testUser1

--- a/ui/src/components/dataset/schema/dataset-column-editor.vue
+++ b/ui/src/components/dataset/schema/dataset-column-editor.vue
@@ -53,7 +53,7 @@
     >
       <!-- Action buttons row -->
       <div
-        v-if="editable && dataset && !dataset.isVirtual"
+        v-if="editable && dataset && !dataset.isVirtual && columnEditable"
         class="d-flex justify-end ga-1 mb-2"
       >
         <confirm-menu
@@ -130,7 +130,7 @@
         v-if="column"
         :model-value="column['x-refersTo'] ?? undefined"
         :label="t('concept')"
-        :disabled="!(editable ?? false) || (dataset?.isVirtual ?? false)"
+        :disabled="!(editable ?? false) || (dataset?.isVirtual ?? false) || !columnEditable"
         :items="filteredVocabularyItems"
         :custom-filter="conceptFilter"
         item-value="value"
@@ -157,7 +157,7 @@
         v-if="column && column.type === 'string'"
         :model-value="(column as any).separator ?? undefined"
         :label="t('sep')"
-        :disabled="!(editable ?? false) || (dataset?.isVirtual ?? false)"
+        :disabled="!(editable ?? false) || (dataset?.isVirtual ?? false) || !columnEditable"
         :items="[', ', '; ', ' - ', ' / ', ' | ']"
         density="comfortable"
         class="mb-2"
@@ -175,7 +175,7 @@
         v-if="column && showDisplayFormat"
         v-model="displayFormat"
         :label="t('xDisplay')"
-        :disabled="!editable"
+        :disabled="!editable || !columnEditable"
         :items="displayFormatItems"
         class="mb-2"
         density="comfortable"
@@ -286,6 +286,11 @@ const currentFileColumn = computed(() => {
   if (!props.column || !dataset.value?.file?.schema) return null
   const col = props.column
   return dataset.value.file.schema.find((c: any) => c.key === col.key)
+})
+
+const columnEditable = computed(() => {
+  const col = props.column as any
+  return !!col && !(col['x-extension'] && col['x-extension'] !== col.key)
 })
 
 type VocabSubheader = { type: 'subheader', title: string }


### PR DESCRIPTION
Enriched (remote-service extension) columns are rebuilt from the extension definition on every schema save, so a user-defined column group (`x-group`) set on such a column was silently dropped on save.

- **api:** preserve `x-group` on enriched columns in `prepareExtensionsSchema` — a consumer-side organization concern never emitted by the extension (same pass-through as `x-group` on virtual datasets).
- **ui:** on enriched columns only title, description and group stay editable; concept, separator, format and the technical-config / labels buttons are disabled or hidden to match what the API actually persists. Calculated (exprEval) and normal columns stay fully editable.
- **tests:** cover `x-group` preservation on enriched columns and on virtual dataset columns.

**Why:** setting a group on an enriched column got removed on save.

**Heads-up:** the schema column editor now disables/hides the concept, separator, format, capabilities and labels editors on remote-service enriched columns (`x-extension !== key`). Those edits never persisted there anyway, so no capability is lost — the UI just stops promising what the API doesn't keep. Worth confirming the `x-extension !== key` split keeps exprEval calculated columns fully editable.
