### PR TITLE
fix(files-storage): exact file-existence check on S3, opaque "UnknownError" in journal

### DIFF
--- a/api/src/datasets/routes/files.ts
+++ b/api/src/datasets/routes/files.ts
@@ -179,7 +179,7 @@ export const registerFilesRoutes = (router: Router) => {
   router.get('/:datasetId/full', readDataset({ noCache: true }), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('downloadFullData', 'read', 'readDataFiles'), cacheHeaders.noCache, async (req, res, next) => {
     const dataset = reqDataset(req)
     if (!dataset.file) return res.status(404).send('Ce jeu de données ne contient pas de fichier de données')
-    if (await filesStorage.pathExists(datasetUtils.fullFilePath(dataset))) {
+    if (await filesStorage.fileExists(datasetUtils.fullFilePath(dataset))) {
       await downloadFileFromStorage(datasetUtils.fullFilePath(dataset), req, res)
     } else {
       await downloadFileFromStorage(datasetUtils.filePath(dataset), req, res)
@@ -191,7 +191,7 @@ export const registerFilesRoutes = (router: Router) => {
   router.get('/:datasetId/validation-diagnostic.csv', readDataset({ acceptInitialDraft: true, noCache: true }), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('readJournal', 'readAdvanced'), cacheHeaders.noCache, async (req, res, next) => {
     const dataset = reqDataset(req)
     const filePath = validationDiagnosticFilePath(dataset)
-    if (!await filesStorage.pathExists(filePath)) {
+    if (!await filesStorage.fileExists(filePath)) {
       return res.status(404).type('text/plain').send('Aucun fichier de diagnostic disponible')
     }
     res.setHeader('content-disposition', contentDisposition(`${dataset.slug}-validation-diagnostic.csv`))
@@ -205,7 +205,7 @@ export const registerFilesRoutes = (router: Router) => {
   router.get('/:datasetId/cancelled-draft-diagnostic.csv', readDataset({ acceptInitialDraft: true, noCache: true }), apiKeyMiddlewareRead, rateLimiting.middleware, permissions.middleware('readJournal', 'readAdvanced'), cacheHeaders.noCache, async (req, res, next) => {
     const dataset = reqDataset(req)
     const filePath = cancelledDraftDiagnosticFilePath(dataset)
-    if (!await filesStorage.pathExists(filePath)) {
+    if (!await filesStorage.fileExists(filePath)) {
       return res.status(404).type('text/plain').send('Aucun fichier de diagnostic disponible')
     }
     res.setHeader('content-disposition', contentDisposition(`${dataset.slug}-cancelled-draft-diagnostic.csv`))

--- a/api/src/datasets/service.ts
+++ b/api/src/datasets/service.ts
@@ -668,7 +668,7 @@ export const validateDraft = async (dataset: any, datasetFull: any, patch: any) 
   const draftFullFilePath = fullFilePath(datasetDraft)
   const newFullFilePath = fullFilePath(patchedDataset)
   const oldFullFilePath = datasetFull.file && fullFilePath(datasetFull)
-  const hasFullFile = await filesStorage.pathExists(draftFullFilePath)
+  const hasFullFile = await filesStorage.fileExists(draftFullFilePath)
   if (hasFullFile) {
     await filesStorage.moveFile(draftFullFilePath, newFullFilePath)
   }
@@ -688,7 +688,7 @@ export const validateDraft = async (dataset: any, datasetFull: any, patch: any) 
   // a previous contribution to this dataset may have left a cancelled-draft
   // diagnostic; now that a contribution succeeded it is stale, remove it
   const staleCancelledDiagnostic = cancelledDraftDiagnosticFilePath(patchedDataset)
-  if (await filesStorage.pathExists(staleCancelledDiagnostic)) {
+  if (await filesStorage.fileExists(staleCancelledDiagnostic)) {
     await filesStorage.removeFile(staleCancelledDiagnostic)
     // the now-removed file was referenced by a past draft-cancelled event; clear
     // its hasDiagnosticFile flag so the UI stops offering a download that 404s

--- a/api/src/datasets/utils/attachment-content.ts
+++ b/api/src/datasets/utils/attachment-content.ts
@@ -1,0 +1,42 @@
+import type { FileBackend } from '../../files-storage/types.ts'
+import { arrayBuffer } from 'stream/consumers'
+
+export type AttachmentStorage = Pick<FileBackend, 'fileExists' | 'fileStats' | 'readStream'>
+
+// On S3 the existence check and the subsequent stats/read are separate requests on a
+// shared-nothing store, so the file can be reported present and still 404 on read
+// (eventual consistency, concurrent deletion). Not caught here, such a 404 fails the
+// whole indexing task and the raw AWS-SDK error — whose message is the literal
+// "UnknownError" for body-less HEAD responses — ends up verbatim in the dataset journal.
+const is404 = (err: any) =>
+  err?.status === 404 ||
+  err?.statusCode === 404 ||
+  err?.$metadata?.httpStatusCode === 404 ||
+  err?.name === 'NotFound' ||
+  err?.name === 'NoSuchKey' ||
+  err?.code === 'ENOENT'
+
+/**
+ * Load the content of a line's attached file for full-text indexing.
+ * A missing attachment degrades to a per-line warning (or a silent skip when it never
+ * existed), it must never fail the indexing task. attachmentIndexedLimit uses the
+ * config.defaultLimits convention: -1 means unlimited.
+ */
+export const readAttachmentContent = async (
+  storage: AttachmentStorage,
+  filePath: string,
+  attachmentIndexedLimit: number
+): Promise<{ raw?: string, warning?: string }> => {
+  try {
+    if (!await storage.fileExists(filePath)) return {}
+    const stats = await storage.fileStats(filePath)
+    if (attachmentIndexedLimit !== -1 && stats.size > attachmentIndexedLimit) {
+      return { warning: 'Pièce jointe trop volumineuse pour être analysée' }
+    }
+    const buf = await arrayBuffer((await storage.readStream(filePath)).body)
+    return { raw: Buffer.from(buf).toString('base64') }
+  } catch (err: any) {
+    if (is404(err)) return { warning: 'Pièce jointe introuvable' }
+    throw err
+  }
+}

--- a/api/src/datasets/utils/data-streams.ts
+++ b/api/src/datasets/utils/data-streams.ts
@@ -258,7 +258,7 @@ export const readStreams = async (dataset: Dataset, raw = false, full = false, i
   if (dataset.isRest) return restDatasetsUtils.readStreams(dataset)
   const p = full ? fullFilePath(dataset) : filePath(dataset)
 
-  if (!await filesStorage.pathExists(p)) {
+  if (!await filesStorage.fileExists(p)) {
     // we should not have to do this
     // this is a weird thing, maybe an unsolved race condition ?
     // let's wait a bit and try again to mask this problem temporarily

--- a/api/src/datasets/utils/diagnostic-file.ts
+++ b/api/src/datasets/utils/diagnostic-file.ts
@@ -111,7 +111,7 @@ export class DiagnosticWriter {
       await this.closeStream().catch(() => {})
     }
     await fs.remove(this.tmpPath).catch(() => {})
-    if (await filesStorage.pathExists(this.targetPath)) {
+    if (await filesStorage.fileExists(this.targetPath)) {
       await filesStorage.removeFile(this.targetPath)
     }
     await this.clearStaleJournalFlags()

--- a/api/src/datasets/utils/extensions.ts
+++ b/api/src/datasets/utils/extensions.ts
@@ -28,7 +28,7 @@ import type { Dataset, DatasetLine } from '#types'
 import type { AnyBulkWriteOperation, Document, Filter, WithId } from 'mongodb'
 import { isRestDataset } from '#types/dataset/index.ts'
 import filesStorage from '#files-storage'
-import { arrayBuffer } from 'stream/consumers'
+import { readAttachmentContent } from './attachment-content.ts'
 import testEvents from '../../misc/utils/test-events.ts'
 
 export { getExtensionKey } from '@data-fair/data-fair-shared/utils/extensions.js'
@@ -686,19 +686,10 @@ export const prepareCalculations = (dataset: Dataset) => {
       const isURL = !!parseURL(attachmentValue).host
       if (!isURL) {
         item._attachment_url = `${config.publicUrl}/api/v1/datasets/${dataset.id}/attachments/${attachmentValue}`
-        const filePath = attachmentPath(dataset, attachmentValue)
-        if (await filesStorage.pathExists(filePath)) {
-          const stats = await filesStorage.fileStats(filePath)
-
-          if (!attachmentField['x-capabilities'] || attachmentField['x-capabilities'].indexAttachment !== false) {
-            // -1 is the "unlimited" sentinel used across config.defaultLimits (see storage.ts)
-            if (config.defaultLimits.attachmentIndexed !== -1 && stats.size > config.defaultLimits.attachmentIndexed) {
-              warning = 'Pièce jointe trop volumineuse pour être analysée'
-            } else {
-              const buf = await arrayBuffer((await filesStorage.readStream(filePath)).body)
-              item._file_raw = Buffer.from(buf).toString('base64')
-            }
-          }
+        if (!attachmentField['x-capabilities'] || attachmentField['x-capabilities'].indexAttachment !== false) {
+          const result = await readAttachmentContent(filesStorage, attachmentPath(dataset, attachmentValue), config.defaultLimits.attachmentIndexed)
+          if (result.raw) item._file_raw = result.raw
+          if (result.warning) warning = result.warning
         }
       }
     }

--- a/api/src/datasets/utils/files.ts
+++ b/api/src/datasets/utils/files.ts
@@ -164,11 +164,7 @@ export const dataFiles = async (dataset: any, publicBaseUrl = config.publicUrl) 
 /**
  * @param {string} p
  */
-export const fsyncFile = async (p: string) => {
-  const fd = await fs.open(p, 'r')
-  await fs.fsync(fd)
-  await fs.close(fd)
-}
+export { fsyncFile } from '../../files-storage/operations.ts'
 
 export const cleanTmp = async () => {
   debugCleanTmp('check tmp dir for old files')

--- a/api/src/datasets/utils/rest.ts
+++ b/api/src/datasets/utils/rest.ts
@@ -993,7 +993,7 @@ const rollbackUploadedAttachment = async (uploadedAttachmentPath?: string) => {
   const p = uploadedAttachmentPath
   if (!p) return
   try {
-    if (await filesStorage.pathExists(p)) await filesStorage.removeFile(p)
+    if (await filesStorage.fileExists(p)) await filesStorage.removeFile(p)
   } catch (err) {
     console.warn('failed to rollback uploaded attachment', p, err)
   }

--- a/api/src/files-storage/fs.ts
+++ b/api/src/files-storage/fs.ts
@@ -3,16 +3,22 @@ import { join as joinPath, relative as relativePath } from 'path'
 import fs from 'fs-extra'
 import type { FileStats, FileBackend } from './types.ts'
 import { httpError } from '@data-fair/lib-express'
-import { fsyncFile } from '../datasets/utils/files.ts'
+import { fsyncFile } from './operations.ts'
 import parseRange from 'range-parser'
 import { pipeline } from 'node:stream/promises'
 import nodeDir from 'node-dir'
 import unzipper from 'unzipper'
-import config from '#config'
 
 export class FsBackend implements FileBackend {
+  private dataDir: string
+
+  // explicit dataDir instead of #config so the backend can be constructed in the test process
+  constructor (dataDir: string) {
+    this.dataDir = dataDir
+  }
+
   async checkAccess () {
-    await fs.writeFile(`${config.dataDir}/check-access.txt`, 'ok')
+    await fs.writeFile(`${this.dataDir}/check-access.txt`, 'ok')
   }
 
   async lsr (path: string): Promise<string[]> {
@@ -122,6 +128,15 @@ export class FsBackend implements FileBackend {
 
   async pathExists (path: string) {
     return fs.pathExists(path)
+  }
+
+  async fileExists (path: string) {
+    try {
+      return (await fs.stat(path)).isFile()
+    } catch (err: any) {
+      if (err.code === 'ENOENT' || err.code === 'ENOTDIR') return false
+      throw err
+    }
   }
 
   async zipDirectory (path: string) {

--- a/api/src/files-storage/index.ts
+++ b/api/src/files-storage/index.ts
@@ -3,5 +3,12 @@ import { FsBackend } from './fs.ts'
 import { S3Backend } from './s3.ts'
 import type { FileBackend } from './types.ts'
 
-export const filesStorage: FileBackend = config.filesStorage === 's3' ? new S3Backend() : new FsBackend()
+const buildBackend = (): FileBackend => {
+  if (config.filesStorage === 's3') {
+    if (!config.s3.bucket) throw new Error('files storage is configured as s3 but s3.bucket is missing')
+    return new S3Backend({ ...config.s3, bucket: config.s3.bucket, dataDir: config.dataDir })
+  }
+  return new FsBackend(config.dataDir)
+}
+export const filesStorage: FileBackend = buildBackend()
 export default filesStorage

--- a/api/src/files-storage/operations.ts
+++ b/api/src/files-storage/operations.ts
@@ -1,4 +1,13 @@
 import type { ApiConfig } from '../../config/type/index.ts'
+import fs from 'fs-extra'
+
+// durably flush a file that was just written; here (config-free module) rather than in
+// datasets/utils/files.ts so the fs backend can be imported without loading #config
+export const fsyncFile = async (p: string) => {
+  const fd = await fs.open(p, 'r')
+  await fs.fsync(fd)
+  await fs.close(fd)
+}
 
 /**
  * Prepare the S3 config for logging. The debug logs of a production API are routinely

--- a/api/src/files-storage/s3.ts
+++ b/api/src/files-storage/s3.ts
@@ -1,4 +1,4 @@
-import config from '#config'
+import type { ApiConfig } from '../../config/type/index.ts'
 import { relative as relativePath, resolve as resolvePath, join as joinPath } from 'node:path'
 import { S3Client, ListObjectsV2Command, DeleteObjectCommand, HeadObjectCommand, GetObjectCommand, CopyObjectCommand, paginateListObjectsV2, PutObjectCommand, CreateMultipartUploadCommand, UploadPartCopyCommand, CompleteMultipartUploadCommand, AbortMultipartUploadCommand, type S3ClientConfig } from '@aws-sdk/client-s3'
 import { Upload } from '@aws-sdk/lib-storage'
@@ -17,31 +17,34 @@ import { redactS3Config } from './operations.ts'
 
 const debug = debugModule('s3')
 
-export const dataDir = resolvePath(config.dataDir)
-
-const bucketPath = (path: string) => {
-  if (path === dataDir) return ''
-  return path.replace(dataDir + '/', '')
-}
+// explicit options instead of #config so the backend can be constructed in the test
+// process against MinIO (same pattern as IntegrityStore)
+export type S3BackendOptions = ApiConfig['s3'] & { bucket: string, dataDir: string }
 
 export class S3Backend implements FileBackend {
   private dataClient: S3Client
   private metadataClient: S3Client
+  private options: S3BackendOptions
+  private bucket: string
+  private dataDir: string
 
-  constructor () {
-    debug('create client', redactS3Config(config.s3))
+  constructor (options: S3BackendOptions) {
+    debug('create client', redactS3Config(options))
+    this.options = options
+    this.bucket = options.bucket
+    this.dataDir = resolvePath(options.dataDir)
     // Customizing the handler for high throughput
     // and splitting data and metadata client so that long running queries do not block short metadata queries
     // TODO: monitor the sockets like we do in @data-fair/lib-node/http-agents ?
     this.dataClient = new S3Client({
-      ...config.s3 as S3ClientConfig,
+      ...options as S3ClientConfig,
       requestHandler: new NodeHttpHandler({
         httpAgent: new HttpAgent({ keepAlive: true, maxSockets: 50, maxFreeSockets: 50, timeout: 60000 }),
         httpsAgent: new HttpsAgent({ keepAlive: true, maxSockets: 50, maxFreeSockets: 50, timeout: 60000 }),
       }),
     })
     this.metadataClient = new S3Client({
-      ...config.s3 as S3ClientConfig,
+      ...options as S3ClientConfig,
       // Customizing the handler for high throughput
       requestHandler: new NodeHttpHandler({
         httpAgent: new HttpAgent({ keepAlive: true, maxSockets: 50, maxFreeSockets: 50 }),
@@ -50,9 +53,14 @@ export class S3Backend implements FileBackend {
     })
   }
 
+  private bucketPath (path: string) {
+    if (path === this.dataDir) return ''
+    return path.replace(this.dataDir + '/', '')
+  }
+
   async checkAccess () {
     debug('check access')
-    const command = new PutObjectCommand({ Bucket: config.s3.bucket, Key: 'check-access.txt', Body: 'ok' })
+    const command = new PutObjectCommand({ Bucket: this.bucket, Key: 'check-access.txt', Body: 'ok' })
     debug('access ok')
     await this.metadataClient.send(command, { requestTimeout: 10000 })
   }
@@ -65,11 +73,11 @@ export class S3Backend implements FileBackend {
   }
 
   async lsrWithStats (targetPath: string): Promise<FileStats[]> {
-    debug('lrsWithStats', targetPath, bucketPath(targetPath))
-    const command = new ListObjectsV2Command({ Bucket: config.s3.bucket, Prefix: bucketPath(targetPath) })
+    debug('lrsWithStats', targetPath, this.bucketPath(targetPath))
+    const command = new ListObjectsV2Command({ Bucket: this.bucket, Prefix: this.bucketPath(targetPath) })
     const response = await this.metadataClient.send(command)
     const filesStats = (response.Contents || []).map((obj) => ({
-      path: relativePath(targetPath, joinPath(dataDir, obj.Key!)),
+      path: relativePath(targetPath, joinPath(this.dataDir, obj.Key!)),
       size: obj.Size!,
       lastModified: obj.LastModified!,
     }))
@@ -78,13 +86,20 @@ export class S3Backend implements FileBackend {
   }
 
   async fileStats (path: string) {
-    const command = new HeadObjectCommand({ Bucket: config.s3.bucket, Key: bucketPath(path) })
-    const response = await this.metadataClient.send(command)
-    return { size: response.ContentLength!, lastModified: response.LastModified! }
+    const command = new HeadObjectCommand({ Bucket: this.bucket, Key: this.bucketPath(path) })
+    try {
+      const response = await this.metadataClient.send(command)
+      return { size: response.ContentLength!, lastModified: response.LastModified! }
+    } catch (err: any) {
+      // a HEAD 404 response has no body for the SDK to parse, so the raw error carries the
+      // meaningless message "UnknownError"; map it before it can reach a journal or a client
+      if (err.$metadata?.httpStatusCode === 404) throw httpError(404, 'file not found')
+      throw err
+    }
   }
 
   async removeFile (path: string): Promise<void> {
-    const command = new DeleteObjectCommand({ Bucket: config.s3.bucket, Key: bucketPath(path) })
+    const command = new DeleteObjectCommand({ Bucket: this.bucket, Key: this.bucketPath(path) })
     await this.metadataClient.send(command)
   }
 
@@ -92,7 +107,7 @@ export class S3Backend implements FileBackend {
     // the page size cannot be too large as it is also the number of parallel deletes
     const pages = paginateListObjectsV2(
       { client: this.metadataClient, pageSize: 100 },
-      { Bucket: config.s3.bucket, Prefix: bucketPath(path) }
+      { Bucket: this.bucket, Prefix: this.bucketPath(path) }
     )
 
     for await (const page of pages) {
@@ -100,7 +115,7 @@ export class S3Backend implements FileBackend {
 
       // Map each object in the current page to a Delete promise
       const deletePromises = page.Contents.map((obj) => {
-        const deleteParams = { Bucket: config.s3.bucket, Key: obj.Key, }
+        const deleteParams = { Bucket: this.bucket, Key: obj.Key, }
         return this.metadataClient.send(new DeleteObjectCommand(deleteParams))
       })
 
@@ -113,7 +128,7 @@ export class S3Backend implements FileBackend {
     debug('readStream', path)
     const ifModifiedSinceDate = ifModifiedSince ? new Date(ifModifiedSince) : undefined
 
-    const bucketParams = { Bucket: config.s3.bucket, Key: bucketPath(path), IfModifiedSince: ifModifiedSinceDate, }
+    const bucketParams = { Bucket: this.bucket, Key: this.bucketPath(path), IfModifiedSince: ifModifiedSinceDate, }
     try {
       // retryMissing is set by callers that just wrote the file and so expect it to exist;
       // it absorbs read-after-write inconsistency on some S3 providers. It must stay off for
@@ -181,7 +196,7 @@ export class S3Backend implements FileBackend {
     // upload time instead. retryOnMissing absorbs the transient cross-connection
     // inconsistency (we write on dataClient and HEAD on metadataClient) so only a persistent
     // miss — the durable loss we actually want to catch — fails the upload.
-    await retryOnMissing(() => this.metadataClient.send(new HeadObjectCommand({ Bucket: config.s3.bucket, Key: bucketPath(path) })))
+    await retryOnMissing(() => this.metadataClient.send(new HeadObjectCommand({ Bucket: this.bucket, Key: this.bucketPath(path) })))
     await unlink(tmpPath)
   }
 
@@ -189,8 +204,8 @@ export class S3Backend implements FileBackend {
     const upload = new Upload({
       client: this.dataClient,
       params: {
-        Bucket: config.s3.bucket,
-        Key: bucketPath(path),
+        Bucket: this.bucket,
+        Key: this.bucketPath(path),
         Body: readStream
       }
     })
@@ -198,33 +213,33 @@ export class S3Backend implements FileBackend {
   }
 
   async writeString (path: string, content: string) {
-    const command = new PutObjectCommand({ Bucket: config.s3.bucket, Key: bucketPath(path), Body: content })
+    const command = new PutObjectCommand({ Bucket: this.bucket, Key: this.bucketPath(path), Body: content })
     await this.dataClient.send(command)
   }
 
   async copyFile (srcPath: string, dstPath: string) {
-    const srcKey = bucketPath(srcPath)
-    const dstKey = bucketPath(dstPath)
+    const srcKey = this.bucketPath(srcPath)
+    const dstKey = this.bucketPath(dstPath)
 
-    const headResp = await this.metadataClient.send(new HeadObjectCommand({ Bucket: config.s3.bucket, Key: srcKey }))
+    const headResp = await this.metadataClient.send(new HeadObjectCommand({ Bucket: this.bucket, Key: srcKey }))
     const fileSize = headResp.ContentLength!
 
-    const maxSingleCopySize = config.s3.maxSingleCopySize || 5 * 1024 * 1024 * 1024
+    const maxSingleCopySize = this.options.maxSingleCopySize || 5 * 1024 * 1024 * 1024
 
     if (fileSize < maxSingleCopySize) {
       await this.dataClient.send(new CopyObjectCommand({
-        Bucket: config.s3.bucket,
-        CopySource: `${config.s3.bucket}/${encodeURI(srcKey)}`,
+        Bucket: this.bucket,
+        CopySource: `${this.bucket}/${encodeURI(srcKey)}`,
         Key: dstKey,
       }))
       return
     }
 
-    const multipartChunkSize = config.s3.multipartChunkSize || 100 * 1024 * 1024
+    const multipartChunkSize = this.options.multipartChunkSize || 100 * 1024 * 1024
     const totalParts = Math.ceil(fileSize / multipartChunkSize)
 
     const createResp = await this.dataClient.send(new CreateMultipartUploadCommand({
-      Bucket: config.s3.bucket,
+      Bucket: this.bucket,
       Key: dstKey,
     }))
     const uploadId = createResp.UploadId!
@@ -236,9 +251,9 @@ export class S3Backend implements FileBackend {
         const end = Math.min(partNumber * multipartChunkSize, fileSize) - 1
 
         const copyPart = this.dataClient.send(new UploadPartCopyCommand({
-          Bucket: config.s3.bucket,
+          Bucket: this.bucket,
           Key: dstKey,
-          CopySource: `${config.s3.bucket}/${encodeURI(srcKey)}`,
+          CopySource: `${this.bucket}/${encodeURI(srcKey)}`,
           CopySourceRange: `bytes=${start}-${end}`,
           UploadId: uploadId,
           PartNumber: partNumber,
@@ -249,7 +264,7 @@ export class S3Backend implements FileBackend {
       const responses = await Promise.all(copyParts)
 
       await this.dataClient.send(new CompleteMultipartUploadCommand({
-        Bucket: config.s3.bucket,
+        Bucket: this.bucket,
         Key: dstKey,
         UploadId: uploadId,
         MultipartUpload: {
@@ -261,7 +276,7 @@ export class S3Backend implements FileBackend {
       }))
     } catch (err) {
       await this.dataClient.send(new AbortMultipartUploadCommand({
-        Bucket: config.s3.bucket,
+        Bucket: this.bucket,
         Key: dstKey,
         UploadId: uploadId,
       }))
@@ -278,7 +293,7 @@ export class S3Backend implements FileBackend {
     // the page size cannot be too large as it is also the number of parallel copies
     const pages = paginateListObjectsV2(
       { client: this.dataClient, pageSize: 100 },
-      { Bucket: config.s3.bucket, Prefix: bucketPath(srcPath) }
+      { Bucket: this.bucket, Prefix: this.bucketPath(srcPath) }
     )
 
     for await (const page of pages) {
@@ -287,10 +302,10 @@ export class S3Backend implements FileBackend {
       // Map each object in the current page to a Copy promise
       const copyPromises = page.Contents.map((obj) => {
         const sourceKey = obj.Key!
-        const destKey = sourceKey.replace(bucketPath(srcPath), bucketPath(dstPath))
+        const destKey = sourceKey.replace(this.bucketPath(srcPath), this.bucketPath(dstPath))
         return this.copyFile(
-          joinPath(dataDir, sourceKey),
-          joinPath(dataDir, destKey)
+          joinPath(this.dataDir, sourceKey),
+          joinPath(this.dataDir, destKey)
         )
       })
 
@@ -305,23 +320,35 @@ export class S3Backend implements FileBackend {
   }
 
   async pathExists (path: string) {
+    // prefix semantics: matches a "directory" (S3 has none, only key prefixes) as well as a
+    // file — use fileExists for files, a strict prefix of an existing key would match here
     const params = {
-      Bucket: config.s3.bucket,
-      Prefix: bucketPath(path),
+      Bucket: this.bucket,
+      Prefix: this.bucketPath(path),
       MaxKeys: 1, // We only need to know if at least one exists
     }
     const response = await this.metadataClient.send(new ListObjectsV2Command(params))
     return !!(response.Contents && response.Contents.length > 0)
   }
 
+  async fileExists (path: string) {
+    try {
+      await this.metadataClient.send(new HeadObjectCommand({ Bucket: this.bucket, Key: this.bucketPath(path) }))
+      return true
+    } catch (err: any) {
+      if (err.$metadata?.httpStatusCode === 404) return false
+      throw err
+    }
+  }
+
   async zipDirectory (path: string) {
-    return unzipper.Open.s3_v3(this.dataClient, { Bucket: config.s3.bucket, Key: bucketPath(path) })
+    return unzipper.Open.s3_v3(this.dataClient, { Bucket: this.bucket, Key: this.bucketPath(path) })
   }
 
   async fileSample (path: string) {
     const command = new GetObjectCommand({
-      Bucket: config.s3.bucket,
-      Key: bucketPath(path),
+      Bucket: this.bucket,
+      Key: this.bucketPath(path),
       Range: 'bytes=0-' + (1024 * 1024)
     })
     // fileSample is only ever called right after the file was written (storer / csv analysis),

--- a/api/src/files-storage/types.ts
+++ b/api/src/files-storage/types.ts
@@ -21,7 +21,10 @@ export type FileBackend = {
   moveFile(srcPath: string, dstPath: string): Promise<void>
   copyDir(srcPath: string, dstPath: string): Promise<void>
   moveDir(srcPath: string, dstPath: string): Promise<void>
+  // file OR directory, with prefix semantics on S3 (a strict prefix of an existing key matches)
   pathExists(path: string): Promise<boolean>
+  // exact match of a file, the only correct existence check before reading one
+  fileExists(path: string): Promise<boolean>
   zipDirectory(path: string): Promise<CentralDirectory>
   fileSample(path: string): Promise<Buffer>
   checkAccess(): Promise<void>

--- a/api/src/misc/utils/capture.ts
+++ b/api/src/misc/utils/capture.ts
@@ -128,7 +128,7 @@ export const screenshot = async (req: RequestWithResource, res: Response) => {
   const reqOpts = screenshotRequestOpts(req, isDefaultThumbnail)
 
   if (isDefaultThumbnail) {
-    if (await filesStorage.pathExists(capturePath)) {
+    if (await filesStorage.fileExists(capturePath)) {
       const stats = await filesStorage.fileStats(capturePath)
       if (resource.updatedAt && Math.floor(stats.lastModified.getTime() / 1000) >= Math.floor(new Date(resource.updatedAt).getTime() / 1000)) {
         res.set('x-capture-cache-status', 'HIT')

--- a/api/src/workers/batch-processor/index-lines.ts
+++ b/api/src/workers/batch-processor/index-lines.ts
@@ -54,7 +54,7 @@ export default async function (dataset: DatasetInternal) {
     for (const a of newRestAttachments) {
       let newAttachments
       const filePath = join(dataDir, 'shared-tmp', a.startsWith('drop:') ? a.replace('drop:', '') : a)
-      if (!await filesStorage.pathExists(filePath)) {
+      if (!await filesStorage.fileExists(filePath)) {
         console.warn(`newRestAttachments of dataset ${dataset.id} references missing attachments file`, a)
       } else {
         if (a.startsWith('drop:')) {
@@ -93,7 +93,7 @@ export default async function (dataset: DatasetInternal) {
   const indexStream = getIndexStream({ indexName, dataset, attachments: !!attachmentsProperty, reemit: isRestDataset(dataset) })
 
   if (!dataset.extensions || dataset.extensions.filter(e => e.active).length === 0) {
-    if (dataset.file && await filesStorage.pathExists(datasetUtils.fullFilePath(dataset))) {
+    if (dataset.file && await filesStorage.fileExists(datasetUtils.fullFilePath(dataset))) {
       debug('Delete previously extended file')
       await filesStorage.removeFile(datasetUtils.fullFilePath(dataset))
       if (!dataset.draftReason) await updateStorage(dataset, false, true)
@@ -186,7 +186,7 @@ export default async function (dataset: DatasetInternal) {
         // including the temp one built by this run)
         if (dataset.draftReason?.validationMode === 'compatibleOrCancel') {
           const srcDiagnostic = validationDiagnosticFilePath(dataset)
-          if (await filesStorage.pathExists(srcDiagnostic)) {
+          if (await filesStorage.fileExists(srcDiagnostic)) {
             await filesStorage.moveFile(srcDiagnostic, cancelledDraftDiagnosticFilePath(dataset))
           }
           await journals.log('datasets', dataset, {

--- a/api/src/workers/batch-processor/process-file.ts
+++ b/api/src/workers/batch-processor/process-file.ts
@@ -215,7 +215,7 @@ export default async function (dataset: DatasetInternal) {
       // wipes the draft dir — so the contributor keeps a downloadable report.
       const fileResult = await writer.finalize()
       const srcDiagnostic = validationDiagnosticFilePath(dataset)
-      if (await filesStorage.pathExists(srcDiagnostic)) {
+      if (await filesStorage.fileExists(srcDiagnostic)) {
         await filesStorage.moveFile(srcDiagnostic, cancelledDraftDiagnosticFilePath(dataset))
       }
       delete patch.validateDraft

--- a/api/src/workers/files-manager/store-file.ts
+++ b/api/src/workers/files-manager/store-file.ts
@@ -33,7 +33,7 @@ export default async function (dataset: DatasetInternal) {
     // storage (a NoSuchKey on S3 when reading it below). Until the root cause is fixed, log what
     // the loading dir actually contains so a wrong/absent key can be told apart from a read delay.
     // Remove this block once the root cause is identified and fixed.
-    if (!await filesStorage.pathExists(loadedFilePath)) {
+    if (!await filesStorage.fileExists(loadedFilePath)) {
       const existing = await filesStorage.lsrWithStats(loadingDir).catch(() => [])
       internalError('storer-missing-file', `loaded file missing when storer started: expected ${loadedFilePath} — loading dir contents: ${JSON.stringify(existing)}`)
     }
@@ -109,7 +109,7 @@ export default async function (dataset: DatasetInternal) {
         await filesStorage.removeFile(oldFilePath)
       }
     }
-  } else if (draft && !await filesStorage.pathExists(datasetUtils.originalFilePath(dataset))) {
+  } else if (draft && !await filesStorage.fileExists(datasetUtils.originalFilePath(dataset))) {
     // this happens if we upload only the attachments, not the data file itself
     // in this case copy the one from prod
     await filesStorage.copyFile(datasetUtils.originalFilePath(datasetFull), datasetUtils.originalFilePath(dataset))

--- a/api/src/workers/files-processor/normalize.ts
+++ b/api/src/workers/files-processor/normalize.ts
@@ -47,7 +47,7 @@ export default async function (dataset: FileDataset) {
   const tmpDir = (await tmp.dir({ tmpdir: mainTmpDir, unsafeCleanup: true, prefix: 'normalizer-' })).path
 
   try {
-    if (!await filesStorage.pathExists(originalFilePath)) {
+    if (!await filesStorage.fileExists(originalFilePath)) {
       // we should not have to do this
       // this is a weird thing, maybe an unsolved race condition ?
       // let's wait a bit and try again to mask this problem temporarily

--- a/tests/features/datasets/upload/attachment-content.unit.spec.ts
+++ b/tests/features/datasets/upload/attachment-content.unit.spec.ts
@@ -1,0 +1,89 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { Readable } from 'node:stream'
+
+// Per-line attachment content loading for indexing, extracted from prepareCalculations
+// (extensions.ts) with the storage backend injected so it can be unit-tested.
+//
+// Defense in depth for the "UnknownError" incident: on S3 the existence check and the
+// subsequent stats/read are separate requests on a shared-nothing store, so the file can
+// be reported present and still 404 on read (prefix-matching pathExists before the fix,
+// eventual consistency or concurrent deletion after it). A missing attachment must
+// degrade to a per-line warning — it must never fail the whole indexing task.
+
+const streamOf = (content: string) => ({ body: Readable.from([Buffer.from(content)]), size: content.length, lastModified: new Date() })
+
+const consistentStorage = (content: string) => ({
+  fileExists: async () => true,
+  fileStats: async () => ({ size: content.length, lastModified: new Date() }),
+  readStream: async () => streamOf(content)
+})
+
+test.describe('readAttachmentContent', () => {
+  let readAttachmentContent: (storage: any, filePath: string, attachmentIndexedLimit: number) => Promise<{ raw?: string, warning?: string }>
+
+  test.beforeAll(async () => {
+    // dynamic import: the module does not exist yet when this suite is first added (TDD),
+    // and a static import of a missing module would abort the whole test collection
+    ({ readAttachmentContent } = await import('../../../../api/src/datasets/utils/attachment-content.ts'))
+  })
+  test('returns the base64 content of an existing attachment', async () => {
+    const result = await readAttachmentContent(consistentStorage('fake jpg content') as any, '/data/attachments/03kp0009.jpg', -1)
+    assert.equal(result.raw, Buffer.from('fake jpg content').toString('base64'))
+    assert.equal(result.warning, undefined)
+  })
+
+  test('returns nothing when the attachment file is absent', async () => {
+    const storage = { ...consistentStorage('x'), fileExists: async () => false }
+    const result = await readAttachmentContent(storage as any, '/data/attachments/03kp0009', -1)
+    assert.deepEqual(result, {})
+  })
+
+  test('warns instead of indexing when the attachment exceeds the indexed-size limit', async () => {
+    const storage = consistentStorage('fake jpg content')
+    const result = await readAttachmentContent(storage as any, '/data/attachments/03kp0009.jpg', 4)
+    assert.equal(result.raw, undefined)
+    assert.match(result.warning!, /volumineuse/)
+  })
+
+  test('warns instead of throwing when the file 404s after the existence check', async () => {
+    // mapped backend error (fileStats after the boundary fix)
+    const storage = {
+      ...consistentStorage('x'),
+      fileStats: async () => { throw Object.assign(new Error('file not found'), { status: 404 }) }
+    }
+    const result = await readAttachmentContent(storage as any, '/data/attachments/03kp0009', -1)
+    assert.equal(result.raw, undefined)
+    assert.match(result.warning!, /introuvable/)
+  })
+
+  test('warns instead of throwing on a raw AWS-SDK NotFound whose message is "UnknownError"', async () => {
+    // the exact error shape of the incident: HeadObject 404 has no body, so the SDK
+    // throws name "NotFound" with the literal message "UnknownError"
+    const storage = {
+      ...consistentStorage('x'),
+      fileStats: async () => { throw Object.assign(new Error('UnknownError'), { name: 'NotFound', $metadata: { httpStatusCode: 404 } }) }
+    }
+    const result = await readAttachmentContent(storage as any, '/data/attachments/03kp0009', -1)
+    assert.equal(result.raw, undefined)
+    assert.match(result.warning!, /introuvable/)
+  })
+
+  test('warns when the read stream itself 404s', async () => {
+    const storage = {
+      ...consistentStorage('x'),
+      readStream: async () => { throw Object.assign(new Error('file not found'), { status: 404 }) }
+    }
+    const result = await readAttachmentContent(storage as any, '/data/attachments/03kp0009', -1)
+    assert.equal(result.raw, undefined)
+    assert.match(result.warning!, /introuvable/)
+  })
+
+  test('propagates non-404 storage errors', async () => {
+    const storage = {
+      ...consistentStorage('x'),
+      fileStats: async () => { throw Object.assign(new Error('service unavailable'), { status: 503 }) }
+    }
+    await assert.rejects(readAttachmentContent(storage as any, '/data/attachments/03kp0009.jpg', -1), /service unavailable/)
+  })
+})

--- a/tests/features/infra/files-storage-fs.unit.spec.ts
+++ b/tests/features/infra/files-storage-fs.unit.spec.ts
@@ -1,0 +1,34 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// Exact-match `fileExists` on the fs backend, mirroring the semantics pinned for the S3
+// backend in files-storage-s3.api.spec.ts. The fs backend must be importable without
+// loading #config in the test process (config is only needed by checkAccess).
+
+test.describe('fs files-storage backend', () => {
+  let backend: any
+  let dir: string
+
+  test.beforeAll(async () => {
+    const { FsBackend } = await import('../../../api/src/files-storage/fs.ts')
+    dir = await mkdtemp(join(tmpdir(), 'df-files-storage-fs-'))
+    backend = new FsBackend(dir)
+    await mkdir(join(dir, 'attachments'))
+    await writeFile(join(dir, 'attachments', '03kp0009.jpg'), 'fake jpg content')
+  })
+
+  test.afterAll(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+  })
+
+  test('fileExists requires an exact file match', async () => {
+    assert.equal(await backend.fileExists(join(dir, 'attachments', '03kp0009.jpg')), true)
+    // a strict prefix of an existing file is not an existing file
+    assert.equal(await backend.fileExists(join(dir, 'attachments', '03kp0009')), false)
+    // a directory is not a file
+    assert.equal(await backend.fileExists(join(dir, 'attachments')), false)
+  })
+})

--- a/tests/features/infra/files-storage-s3.api.spec.ts
+++ b/tests/features/infra/files-storage-s3.api.spec.ts
@@ -1,0 +1,85 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { resolve } from 'node:path'
+import { S3Client, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3'
+
+// The S3 files-storage backend, exercised against the dev MinIO (same convention as
+// s3-multipart-copy.api.spec.ts: skipped when no S3 service is reachable).
+//
+// Context: on S3, `pathExists` is a ListObjectsV2 Prefix match while the fs backend
+// checks the exact path. A dataset attachment value that is a strict prefix of a stored
+// file (e.g. `03kp0009` vs `03kp0009.jpg`) passes the existence check and then crashes
+// on the exact-key HeadObject of `fileStats` — whose 404 has no response body, so the
+// AWS SDK surfaces the literal message "UnknownError" all the way to the dataset journal.
+// These tests pin the intended semantics: a new exact-match `fileExists` for files,
+// prefix semantics kept on `pathExists` for directories, and S3 errors mapped to
+// meaningful http errors at the backend boundary.
+
+const s3Port = process.env.S3_PORT
+const s3Options = {
+  region: 'us-east-1',
+  endpoint: `http://localhost:${s3Port}`,
+  bucket: 'bucketdev',
+  credentials: {
+    accessKeyId: 'minioadmin',
+    secretAccessKey: 'minioadmin'
+  },
+  forcePathStyle: true
+}
+const dataDir = resolve('../data/development')
+const base = `${dataDir}/test-files-storage-s3`
+const storedKey = 'test-files-storage-s3/attachments/03kp0009.jpg'
+
+test.describe('S3 files-storage backend', () => {
+  let backend: any
+  let rawClient: S3Client
+
+  test.beforeAll(async () => {
+    if (!s3Port) {
+      test.skip()
+      return
+    }
+    rawClient = new S3Client({
+      region: s3Options.region,
+      endpoint: s3Options.endpoint,
+      credentials: s3Options.credentials,
+      forcePathStyle: s3Options.forcePathStyle
+    })
+    try {
+      await rawClient.send(new PutObjectCommand({ Bucket: s3Options.bucket, Key: storedKey, Body: 'fake jpg content' }))
+    } catch {
+      test.skip()
+      return
+    }
+    // the backend must be constructible with explicit options (IntegrityStore pattern),
+    // without loading #config in the test process
+    const { S3Backend } = await import('../../../api/src/files-storage/s3.ts')
+    backend = new S3Backend({ ...s3Options, dataDir })
+  })
+
+  test.afterAll(async () => {
+    if (!s3Port) return
+    await rawClient.send(new DeleteObjectCommand({ Bucket: s3Options.bucket, Key: storedKey }))
+  })
+
+  test('fileExists requires an exact key match', async () => {
+    assert.equal(await backend.fileExists(`${base}/attachments/03kp0009.jpg`), true)
+    // a strict prefix of an existing key is NOT an existing file
+    assert.equal(await backend.fileExists(`${base}/attachments/03kp0009`), false)
+    // a directory prefix is not a file either
+    assert.equal(await backend.fileExists(`${base}/attachments`), false)
+  })
+
+  test('pathExists keeps prefix semantics for directories', async () => {
+    assert.equal(await backend.pathExists(`${base}/attachments`), true)
+    assert.equal(await backend.pathExists(`${base}/nowhere`), false)
+  })
+
+  test('fileStats on a missing key throws a mapped 404, not "UnknownError"', async () => {
+    await assert.rejects(backend.fileStats(`${base}/attachments/03kp0009`), (err: any) => {
+      assert.equal(err.status, 404)
+      assert.match(err.message, /file not found/)
+      return true
+    })
+  })
+})


### PR DESCRIPTION
On S3, `pathExists` is a `ListObjectsV2` Prefix match: a dataset attachment value that is a strict prefix of a stored file (e.g. `03kp0009` vs `03kp0009.jpg`) passed the existence check, then crashed on the exact-key `HeadObject` of `fileStats` — whose 404 has no response body, so the AWS SDK surfaced the literal message `"UnknownError"` into the dataset journal and failed the whole indexing task. The fs backend checks exact paths, which is why this never reproduced outside S3 deployments.

- add `fileExists` to the storage backends (exact `HeadObject` on S3, `stat.isFile()` on fs) and switch the callers that test a single file to it; directory checks keep prefix-based `pathExists`
- map `fileStats` 404s to `httpError(404, 'file not found')` like `readStream` already does
- extract the per-line attachment content loading into `readAttachmentContent` (storage injected, unit-tested): a 404 between existence check and read now degrades to a per-line warning instead of killing the indexing of the dataset
- construct the backends with explicit options (IntegrityStore pattern) so they can be tested against MinIO without loading `#config`; the S3 spec pins the exact-match, dir-prefix and 404-mapping semantics on the real backend class

**Why:** a client dataset (CSV + attachments zip with extension-less references) ended in error with an unactionable `UnknownError` journal entry. Deliberately NOT accepting extension-less attachment paths — the data stays wrong, but the platform now reports it usefully instead of crashing opaquely.

**Heads-up:** `fileExists` returns false where prefix-matching `pathExists` returned true — the 16 switched call sites are the thing to review hardest. `filesStorage: s3` without `s3.bucket` now fails at startup instead of erroring later.
