### PR TITLE
fix(datasets): nested virtual datasets over datasets with attachments

### DIFF
--- a/api/src/datasets/service.ts
+++ b/api/src/datasets/service.ts
@@ -569,9 +569,13 @@ export const applyPatch = async (dataset: any, patch: any, removedRestProps?: an
     for await (const virtualDataset of db.collection('datasets').find({ 'virtual.children': dataset.id })) {
       // prepareSchema mutates the stored field objects in place, snapshot them for the comparison
       const previousSchema = structuredClone(virtualDataset.schema)
+      const hadAttachmentsAsImage = virtualDataset.attachmentsAsImage ?? null
       const virtualDatasetSchema = await virtualDatasetsUtils.prepareSchema(virtualDataset as unknown as VirtualDataset)
-      if (!equal(virtualDatasetSchema, previousSchema)) {
-        await applyPatch(virtualDataset, { schema: virtualDatasetSchema, updatedAt: patch.updatedAt })
+      const attachmentsAsImage = virtualDataset.attachmentsAsImage ?? null
+      if (!equal(virtualDatasetSchema, previousSchema) || attachmentsAsImage !== hadAttachmentsAsImage) {
+        const virtualPatch: Record<string, any> = { schema: virtualDatasetSchema, updatedAt: patch.updatedAt }
+        if (attachmentsAsImage !== hadAttachmentsAsImage) virtualPatch.attachmentsAsImage = attachmentsAsImage
+        await applyPatch(virtualDataset, virtualPatch)
       }
     }
   }

--- a/api/src/datasets/service.ts
+++ b/api/src/datasets/service.ts
@@ -567,8 +567,10 @@ export const applyPatch = async (dataset: any, patch: any, removedRestProps?: an
   if (!dataset.draftReason && !patch.status && patch.schema) {
     // if the schema changed without triggering a worker we might need to actualize virtual datasets schemas too
     for await (const virtualDataset of db.collection('datasets').find({ 'virtual.children': dataset.id })) {
+      // prepareSchema mutates the stored field objects in place, snapshot them for the comparison
+      const previousSchema = structuredClone(virtualDataset.schema)
       const virtualDatasetSchema = await virtualDatasetsUtils.prepareSchema(virtualDataset as unknown as VirtualDataset)
-      if (!equal(virtualDatasetSchema, virtualDataset.schema)) {
+      if (!equal(virtualDatasetSchema, previousSchema)) {
         await applyPatch(virtualDataset, { schema: virtualDatasetSchema, updatedAt: patch.updatedAt })
       }
     }

--- a/api/src/datasets/service.ts
+++ b/api/src/datasets/service.ts
@@ -2,6 +2,7 @@ import config from '#config'
 import mongo from '#mongo'
 import debugLib from 'debug'
 import { httpError } from '@data-fair/lib-utils/http-errors.js'
+import { internalError } from '@data-fair/lib-node/observer.js'
 import memoize from 'memoizee'
 import equal from 'deep-equal'
 import * as findUtils from '../misc/utils/find.ts'
@@ -570,9 +571,16 @@ export const applyPatch = async (dataset: any, patch: any, removedRestProps?: an
   if (!dataset.draftReason && !patch.status && patch.schema) {
     // if the schema changed without triggering a worker we might need to actualize virtual datasets schemas too
     for await (const virtualDataset of db.collection('datasets').find({ 'virtual.children': dataset.id })) {
-      const virtualPatch = await virtualDatasetsUtils.prepareVirtualDatasetPatch(virtualDataset as unknown as VirtualDataset)
-      if ('attachmentsAsImage' in virtualPatch || !equal(virtualPatch.schema, virtualDataset.schema)) {
-        await applyPatch(virtualDataset, { ...virtualPatch, updatedAt: patch.updatedAt })
+      try {
+        const virtualPatch = await virtualDatasetsUtils.prepareVirtualDatasetPatch(virtualDataset as unknown as VirtualDataset)
+        if ('attachmentsAsImage' in virtualPatch || !equal(virtualPatch.schema, virtualDataset.schema)) {
+          await applyPatch(virtualDataset, { ...virtualPatch, updatedAt: patch.updatedAt })
+        }
+      } catch (err) {
+        // the parent virtual dataset may have become invalid (a conflict introduced by this very
+        // patch, another child deleted or not shared anymore...): don't fail this dataset's own
+        // patch for it, the parent will surface the error at its next finalization or query
+        internalError('virtual-schema-sync', err)
       }
     }
   }

--- a/api/src/datasets/service.ts
+++ b/api/src/datasets/service.ts
@@ -339,7 +339,10 @@ export const createDataset = async (db: Db, es: Client, locale: string, sessionS
     if (!body.title) throw httpError(400, 'Un jeu de données virtuel doit être créé avec un titre')
     if (attachmentsFile) throw httpError(400, 'Un jeu de données virtuel ne peut pas avoir de pièces jointes')
     dataset.virtual = dataset.virtual || { children: [] }
-    dataset.schema = await virtualDatasetsUtils.prepareSchema(dataset)
+    const virtualPatch = await virtualDatasetsUtils.prepareVirtualDatasetPatch(dataset)
+    dataset.schema = virtualPatch.schema
+    if (virtualPatch.attachmentsAsImage) dataset.attachmentsAsImage = true
+    else if (virtualPatch.attachmentsAsImage === null) delete dataset.attachmentsAsImage
     if (dataset.initFrom) {
       dataset.status = 'created'
     } else {
@@ -567,15 +570,9 @@ export const applyPatch = async (dataset: any, patch: any, removedRestProps?: an
   if (!dataset.draftReason && !patch.status && patch.schema) {
     // if the schema changed without triggering a worker we might need to actualize virtual datasets schemas too
     for await (const virtualDataset of db.collection('datasets').find({ 'virtual.children': dataset.id })) {
-      // prepareSchema mutates the stored field objects in place, snapshot them for the comparison
-      const previousSchema = structuredClone(virtualDataset.schema)
-      const hadAttachmentsAsImage = virtualDataset.attachmentsAsImage ?? null
-      const virtualDatasetSchema = await virtualDatasetsUtils.prepareSchema(virtualDataset as unknown as VirtualDataset)
-      const attachmentsAsImage = virtualDataset.attachmentsAsImage ?? null
-      if (!equal(virtualDatasetSchema, previousSchema) || attachmentsAsImage !== hadAttachmentsAsImage) {
-        const virtualPatch: Record<string, any> = { schema: virtualDatasetSchema, updatedAt: patch.updatedAt }
-        if (attachmentsAsImage !== hadAttachmentsAsImage) virtualPatch.attachmentsAsImage = attachmentsAsImage
-        await applyPatch(virtualDataset, virtualPatch)
+      const virtualPatch = await virtualDatasetsUtils.prepareVirtualDatasetPatch(virtualDataset as unknown as VirtualDataset)
+      if ('attachmentsAsImage' in virtualPatch || !equal(virtualPatch.schema, virtualDataset.schema)) {
+        await applyPatch(virtualDataset, { ...virtualPatch, updatedAt: patch.updatedAt })
       }
     }
   }

--- a/api/src/datasets/utils/patch.ts
+++ b/api/src/datasets/utils/patch.ts
@@ -200,7 +200,9 @@ export const preparePatch = async (app: any, patch: any, dataset: any, sessionSt
     patch.draftReason = { key: 'file-updated', message: 'Nouveau fichier chargé sur un jeu de données existant', validationMode: draftValidationMode }
   } else if (dataset.isVirtual) {
     if (patch.schema || patch.virtual) {
-      patch.schema = await virtualDatasetsUtils.prepareSchema({ ...dataset, ...patch })
+      const virtualPatch = await virtualDatasetsUtils.prepareVirtualDatasetPatch({ ...dataset, ...patch })
+      patch.schema = virtualPatch.schema
+      if ('attachmentsAsImage' in virtualPatch) patch.attachmentsAsImage = virtualPatch.attachmentsAsImage
       patch.status = 'indexed'
     }
   } else if (patch.extensions && !dataset.isRest) {

--- a/api/src/datasets/utils/virtual.ts
+++ b/api/src/datasets/utils/virtual.ts
@@ -133,6 +133,14 @@ export const prepareSchema = async (dataset: VirtualDataset) => {
     fieldsByConcept[f['x-refersTo']] = f.key
   }
 
+  // attachmentsAsImage is derived state on a virtual dataset, inherited from the children like
+  // the image concept of _attachment_url above: the thumbnail routines require the flag and the
+  // concept to be in lockstep, otherwise /lines?thumbnail=true builds ids that don't resolve.
+  // Callers persist this mutation (whole document at creation, patch at finalization and sync).
+  const attachmentUrlField = schema.find((f: any) => f?.key === '_attachment_url')
+  if (attachmentUrlField?.['x-refersTo'] === 'http://schema.org/image') dataset.attachmentsAsImage = true
+  else delete dataset.attachmentsAsImage
+
   return schema.filter((f: any) => !!f)
 }
 

--- a/api/src/datasets/utils/virtual.ts
+++ b/api/src/datasets/utils/virtual.ts
@@ -3,37 +3,59 @@ import config from '#config'
 import * as datasetUtils from '../../datasets/utils/index.ts'
 import capabilitiesSchema from '../../../contract/capabilities.js'
 import { httpError } from '@data-fair/lib-utils/http-errors.js'
-import type { AccountKeys } from '@data-fair/lib-express'
+import type { Account } from '@data-fair/lib-express'
 import type { VirtualDataset } from '#types'
 import { getPseudoSessionState } from '../../misc/utils/users.ts'
 import { filterCan } from '../../misc/utils/permissions.ts'
 import { type FindOptions } from 'mongodb'
 import { type VirtualFilter, type QueryableDescendant } from '../es/operations.ts'
 
+// distinguish "the dataset does not exist anymore" from "it exists but is not readable by the
+// account owning the virtual dataset" — and report exactly which child is at fault
+const missingChildrenDetails = async (missingIds: string[]) => {
+  const existingMissing = await mongo.datasets
+    .find({ id: { $in: missingIds } }, { projection: { id: 1, title: 1, owner: 1 } })
+    .toArray()
+  const existingMissingById = new Map(existingMissing.map(c => [c.id, c]))
+  return missingIds.map(id => {
+    const child = existingMissingById.get(id)
+    if (!child) return `le jeu de données "${id}" n'existe plus`
+    const owner = child.owner
+    const ownerLabel = owner.department
+      ? `${owner.type === 'user' ? 'utilisateur' : 'organisation'} "${owner.name}" / département "${owner.departmentName ?? owner.department}"`
+      : `${owner.type === 'user' ? 'utilisateur' : 'organisation'} "${owner.name}"`
+    return `le jeu de données "${child.title ?? id}" (${id}, propriété de ${ownerLabel}) n'est pas accessible en lecture par le compte propriétaire du jeu de données virtuel`
+  })
+}
+
 // blacklisted fields are fields that are present in a grandchild but not re-exposed
 // by the child.. it must not be possible to access those fields in the case
 // of another child having the same key
-async function childrenSchemas (owner: AccountKeys, children: string[], blackListedFields: Set<string>) {
+async function childrenSchemas (owner: Account, children: string[], blackListedFields: Set<string>) {
   const schemas: any[] = []
-  for (const childId of children) {
-    const child = await mongo.datasets
-      .findOne({
-        id: childId,
-        $or: [
-          // the virtual dataset can have children that are either from the same owner
-          // or completely public for the "read" operations classes
-          // we could try to manage intermediate cases, but it would be complicated
-          { 'owner.id': owner.id, 'owner.type': owner.type },
-          { permissions: { $elemMatch: { classes: 'read', type: null, id: null } } }
-        ]
-      }, { projection: { isVirtual: 1, virtual: 1, schema: 1 } })
-    if (!child) continue
+  // the children usable by a virtual dataset are those its owner account can read — the same
+  // permissions model applied when resolving the descendants of a query (see recurseDescendants)
+  const pseudoSessionState = getPseudoSessionState(owner, 'virtual-dataset', '_virtual-dataset', 'admin')
+  const permissionsFilter = filterCan(pseudoSessionState, 'datasets', 'read')
+  for (const childId of [...new Set(children)]) {
+    const child = await mongo.datasets.findOne(
+      { id: childId, $or: permissionsFilter },
+      { projection: { isVirtual: 1, virtual: 1, schema: 1, owner: 1 } })
+    if (!child) {
+      // fail fast at creation / patch / finalization time with the same detailed report the
+      // query path produces, instead of silently preparing an unreconciled schema
+      const details = await missingChildrenDetails([childId])
+      throw httpError(400, `[noretry] Le schéma du jeu de données virtuel ne peut pas être établi : ${details.join(' ; ')}.`)
+    }
     if (child.isVirtual && child.virtual) {
-      // recurse only to blacklist protected fields at every level; the returned schemas are
-      // not merged into the result: a virtual child's schema is already reconciled with its own
-      // children (level by level, kept in sync by re-finalization when a descendant changes),
-      // so only direct children participate in the compatibility checks of prepareVirtualDataset
-      const grandChildrenSchemas = await childrenSchemas(owner, child.virtual.children, blackListedFields)
+      // recurse only to blacklist protected fields at every level — readability is judged level
+      // by level from the owner of each intermediate virtual dataset, like at query time (an
+      // intermediate virtual dataset can expose a child its own owner can read to accounts that
+      // cannot read that child directly). The returned schemas are not merged into the result:
+      // a virtual child's schema is already reconciled with its own children (level by level,
+      // kept in sync by re-finalization when a descendant changes), so only direct children
+      // participate in the compatibility checks of prepareVirtualDataset
+      const grandChildrenSchemas = await childrenSchemas(child.owner, child.virtual.children, blackListedFields)
       for (const s of grandChildrenSchemas) {
         for (const field of s) {
           if (!child.schema?.find(f => f.key === field.key)) blackListedFields.add(field.key)
@@ -201,23 +223,7 @@ const recurseDescendants = async (descendants: any[], dataset: Pick<VirtualDatas
 
   if (children.length !== childrenIds.length) {
     const foundIds = new Set(children.map(c => c.id))
-    const missingIds = childrenIds.filter(id => !foundIds.has(id))
-    // re-query the missing children ignoring the permissions filter to tell apart
-    // "the dataset does not exist anymore" from "it exists but is not readable by the
-    // account owning the virtual dataset" — and report exactly which child is at fault
-    const existingMissing = await mongo.datasets
-      .find({ id: { $in: missingIds } }, { projection: { id: 1, title: 1, owner: 1 } })
-      .toArray()
-    const existingMissingById = new Map(existingMissing.map(c => [c.id, c]))
-    const details = missingIds.map(id => {
-      const child = existingMissingById.get(id)
-      if (!child) return `le jeu de données "${id}" n'existe plus`
-      const owner = child.owner
-      const ownerLabel = owner.department
-        ? `${owner.type === 'user' ? 'utilisateur' : 'organisation'} "${owner.name}" / département "${owner.departmentName ?? owner.department}"`
-        : `${owner.type === 'user' ? 'utilisateur' : 'organisation'} "${owner.name}"`
-      return `le jeu de données "${child.title ?? id}" (${id}, propriété de ${ownerLabel}) n'est pas accessible en lecture par le compte propriétaire du jeu de données virtuel`
-    })
+    const details = await missingChildrenDetails(childrenIds.filter(id => !foundIds.has(id)))
     throw cannotQueryError(`Le jeu de données virtuel "${dataset.id}" ne peut pas être requêté : ${details.join(' ; ')}.`)
   }
   for (const child of children) {

--- a/api/src/datasets/utils/virtual.ts
+++ b/api/src/datasets/utils/virtual.ts
@@ -90,8 +90,16 @@ export const prepareSchema = async (dataset: VirtualDataset) => {
     if (matchingFields[0]['x-display']) field['x-display'] = matchingFields[0]['x-display']
     else delete field['x-display']
 
-    // Some attributes of a field have to be homogeneous accross all children
+    // Some attributes of a field have to be homogeneous accross all children.
+    // Capability keys absent from the contract are generator-owned, not user config (e.g.
+    // nativeWildcard stamped on _attachment_url by extendedSchema to reflect its ES wildcard
+    // mapping): they describe the children indices too, preserve them through the merge below
+    const ownCapabilities: Record<string, any> = field['x-capabilities'] || {}
     field['x-capabilities'] = {}
+    for (const key in ownCapabilities) {
+      // @ts-ignore
+      if (!capabilitiesSchema.properties[key]) field['x-capabilities'][key] = ownCapabilities[key]
+    }
     const xLabels: Record<string, string> = {}
     for (const f of matchingFields) {
       if (f.type !== field.type) {

--- a/api/src/datasets/utils/virtual.ts
+++ b/api/src/datasets/utils/virtual.ts
@@ -14,7 +14,7 @@ import { type VirtualFilter, type QueryableDescendant } from '../es/operations.t
 // by the child.. it must not be possible to access those fields in the case
 // of another child having the same key
 async function childrenSchemas (owner: AccountKeys, children: string[], blackListedFields: Set<string>) {
-  let schemas: any[] = []
+  const schemas: any[] = []
   for (const childId of children) {
     const child = await mongo.datasets
       .findOne({
@@ -29,17 +29,18 @@ async function childrenSchemas (owner: AccountKeys, children: string[], blackLis
       }, { projection: { isVirtual: 1, virtual: 1, schema: 1 } })
     if (!child) continue
     if (child.isVirtual && child.virtual) {
+      // recurse only to blacklist protected fields at every level; the returned schemas are
+      // not merged into the result: a virtual child's schema is already reconciled with its own
+      // children (level by level, kept in sync by re-finalization when a descendant changes),
+      // so only direct children participate in the compatibility checks of prepareSchema
       const grandChildrenSchemas = await childrenSchemas(owner, child.virtual.children, blackListedFields)
       for (const s of grandChildrenSchemas) {
         for (const field of s) {
           if (!child.schema?.find(f => f.key === field.key)) blackListedFields.add(field.key)
         }
       }
-      schemas.push(child.schema)
-      schemas = schemas.concat(grandChildrenSchemas)
-    } else {
-      schemas.push(child.schema)
     }
+    schemas.push(child.schema)
   }
   return schemas
 }

--- a/api/src/datasets/utils/virtual.ts
+++ b/api/src/datasets/utils/virtual.ts
@@ -32,7 +32,7 @@ async function childrenSchemas (owner: AccountKeys, children: string[], blackLis
       // recurse only to blacklist protected fields at every level; the returned schemas are
       // not merged into the result: a virtual child's schema is already reconciled with its own
       // children (level by level, kept in sync by re-finalization when a descendant changes),
-      // so only direct children participate in the compatibility checks of prepareSchema
+      // so only direct children participate in the compatibility checks of prepareVirtualDataset
       const grandChildrenSchemas = await childrenSchemas(owner, child.virtual.children, blackListedFields)
       for (const s of grandChildrenSchemas) {
         for (const field of s) {
@@ -48,9 +48,16 @@ async function childrenSchemas (owner: AccountKeys, children: string[], blackLis
 // Validate and fill a virtual dataset schema based on its children
 // @ts-ignore
 const capabilitiesDefaultFalse = Object.keys(capabilitiesSchema.properties).filter((key: string) => capabilitiesSchema.properties[key]?.default === false)
-export const prepareSchema = async (dataset: VirtualDataset) => {
-  if (!dataset.virtual.children || !dataset.virtual.children.length) return []
-  dataset.schema = dataset.schema || []
+
+// Compute the derived state of a virtual dataset from its children: the reconciled schema and the
+// attachmentsAsImage flag (the thumbnail routines require the flag and the image concept of
+// _attachment_url to be in lockstep). Reads the children from mongo but never mutates its input:
+// it works on a deep copy of the dataset schema.
+const prepareVirtualDataset = async (dataset: VirtualDataset): Promise<{ schema: any[], attachmentsAsImage: boolean }> => {
+  if (!dataset.virtual.children || !dataset.virtual.children.length) return { schema: [], attachmentsAsImage: false }
+  // extendedSchema (cleanSchema, fixConcepts) and the reconciliation below mutate the dataset
+  // and its field objects in place
+  dataset = { ...dataset, schema: structuredClone(dataset.schema ?? []) }
   for (const field of dataset.schema) delete field['x-extension']
   const schema = await datasetUtils.extendedSchema(mongo.db, dataset)
   const blackListedFields = new Set<string>([])
@@ -141,15 +148,24 @@ export const prepareSchema = async (dataset: VirtualDataset) => {
     fieldsByConcept[f['x-refersTo']] = f.key
   }
 
-  // attachmentsAsImage is derived state on a virtual dataset, inherited from the children like
-  // the image concept of _attachment_url above: the thumbnail routines require the flag and the
-  // concept to be in lockstep, otherwise /lines?thumbnail=true builds ids that don't resolve.
-  // Callers persist this mutation (whole document at creation, patch at finalization and sync).
   const attachmentUrlField = schema.find((f: any) => f?.key === '_attachment_url')
-  if (attachmentUrlField?.['x-refersTo'] === 'http://schema.org/image') dataset.attachmentsAsImage = true
-  else delete dataset.attachmentsAsImage
+  return {
+    schema: schema.filter((f: any) => !!f),
+    attachmentsAsImage: attachmentUrlField?.['x-refersTo'] === 'http://schema.org/image'
+  }
+}
 
-  return schema.filter((f: any) => !!f)
+// The single persistence contract for the derived state of a virtual dataset: the reconciled
+// schema, plus the attachmentsAsImage flag only when it must change on the stored document
+// (true to set it, null to unset it — the patch appliers translate null to $unset). Used by
+// every write path: creation, finalization, metadata patch, and the sync performed when a child
+// schema changes without a worker run.
+export const prepareVirtualDatasetPatch = async (dataset: VirtualDataset): Promise<{ schema: any[], attachmentsAsImage?: true | null }> => {
+  const { schema, attachmentsAsImage } = await prepareVirtualDataset(dataset)
+  const patch: { schema: any[], attachmentsAsImage?: true | null } = { schema }
+  if (attachmentsAsImage && !dataset.attachmentsAsImage) patch.attachmentsAsImage = true
+  if (!attachmentsAsImage && dataset.attachmentsAsImage) patch.attachmentsAsImage = null
+  return patch
 }
 
 // "cannot be queried" errors are thrown both while serving requests (descendants are resolved

--- a/api/src/datasets/utils/virtual.ts
+++ b/api/src/datasets/utils/virtual.ts
@@ -96,6 +96,10 @@ const prepareVirtualDataset = async (dataset: VirtualDataset): Promise<{ schema:
     else delete field.separator
     if (matchingFields[0]['x-display']) field['x-display'] = matchingFields[0]['x-display']
     else delete field['x-display']
+    // timeZone drives the day boundaries of date filters and aggregations, which are applied to
+    // the children indices: it must reflect the children data, not the default timezone
+    if (matchingFields[0].timeZone) field.timeZone = matchingFields[0].timeZone
+    else delete field.timeZone
 
     // Some attributes of a field have to be homogeneous accross all children.
     // Capability keys absent from the contract are generator-owned, not user config (e.g.
@@ -120,7 +124,17 @@ const prepareVirtualDataset = async (dataset: VirtualDataset): Promise<{ schema:
       let format = f.format
       if (format === 'uri-reference') format = undefined
       if (format !== field.format) throw httpError(400, `[noretry] Le champ "${field.key}" a des formats contradictoires (${field.format || 'non défini'}, ${f.format || 'non défini'}).`)
-      if (f['x-refersTo'] !== field['x-refersTo']) throw httpError(400, `[noretry] Le champ "${field.key}" a des concepts contradictoires (${field['x-refersTo'] || 'non défini'}, ${f['x-refersTo'] || 'non défini'}).`)
+      if (f['x-refersTo'] !== field['x-refersTo']) {
+        if (field.key === '_attachment_url') {
+          // children disagree on attachmentsAsImage: degrade to plain attachment links (no image
+          // concept, so no derived attachmentsAsImage flag either) instead of failing on a
+          // calculated field the user cannot edit directly
+          delete field['x-refersTo']
+          delete field['x-concept']
+        } else {
+          throw httpError(400, `[noretry] Le champ "${field.key}" a des concepts contradictoires (${field['x-refersTo'] || 'non défini'}, ${f['x-refersTo'] || 'non défini'}).`)
+        }
+      }
       for (const key in f['x-capabilities'] || {}) {
         if (capabilitiesDefaultFalse.includes(key)) {
           if (f['x-capabilities'][key] === false || !(key in f['x-capabilities'])) field['x-capabilities'][key] = false

--- a/api/src/workers/short-processor/finalize.ts
+++ b/api/src/workers/short-processor/finalize.ts
@@ -42,14 +42,17 @@ export default async function (_dataset: DatasetInternal) {
   // default to the generic worker context otherwise
   if (dataset.integrity?.active) result._needsHistorizing = (dataset as any)._needsHistorizing ?? { context: { operation: 'update', origin: 'worker' } }
 
+  debug('prepare extended schema')
   if (isVirtualDataset(dataset)) {
     queryableDataset.descendants = await virtualDatasetsUtils.descendants(dataset)
+    // prepareSchema runs extendedSchema itself, then reconciles the calculated fields with the
+    // children schemas (e.g. _attachment_url inherits the image concept from a child with
+    // attachmentsAsImage) — a plain extendedSchema call would discard that reconciliation
     queryableDataset.schema = result.schema = await virtualDatasetsUtils.prepareSchema(dataset)
+  } else {
+    // Add the calculated fields to the schema
+    queryableDataset.schema = result.schema = await datasetUtils.extendedSchema(db, dataset)
   }
-
-  // Add the calculated fields to the schema
-  debug('prepare extended schema')
-  queryableDataset.schema = result.schema = await datasetUtils.extendedSchema(db, dataset)
   // record whether the freshly-built index carries the _search catch-all fields.
   // only when an index was actually (re)built: finalize also runs after a partial REST data
   // update (`_partialRestStatus` set, existing index reused) — don't recompute the flag then.

--- a/api/src/workers/short-processor/finalize.ts
+++ b/api/src/workers/short-processor/finalize.ts
@@ -48,7 +48,14 @@ export default async function (_dataset: DatasetInternal) {
     // prepareSchema runs extendedSchema itself, then reconciles the calculated fields with the
     // children schemas (e.g. _attachment_url inherits the image concept from a child with
     // attachmentsAsImage) — a plain extendedSchema call would discard that reconciliation
+    const hadAttachmentsAsImage = dataset.attachmentsAsImage ?? null
     queryableDataset.schema = result.schema = await virtualDatasetsUtils.prepareSchema(dataset)
+    // persist the attachmentsAsImage flag derived from the children by prepareSchema
+    const attachmentsAsImage = dataset.attachmentsAsImage ?? null
+    if (attachmentsAsImage !== hadAttachmentsAsImage) {
+      queryableDataset.attachmentsAsImage = dataset.attachmentsAsImage
+      result.attachmentsAsImage = attachmentsAsImage
+    }
   } else {
     // Add the calculated fields to the schema
     queryableDataset.schema = result.schema = await datasetUtils.extendedSchema(db, dataset)

--- a/api/src/workers/short-processor/finalize.ts
+++ b/api/src/workers/short-processor/finalize.ts
@@ -45,16 +45,21 @@ export default async function (_dataset: DatasetInternal) {
   debug('prepare extended schema')
   if (isVirtualDataset(dataset)) {
     queryableDataset.descendants = await virtualDatasetsUtils.descendants(dataset)
-    // prepareSchema runs extendedSchema itself, then reconciles the calculated fields with the
-    // children schemas (e.g. _attachment_url inherits the image concept from a child with
-    // attachmentsAsImage) — a plain extendedSchema call would discard that reconciliation
-    const hadAttachmentsAsImage = dataset.attachmentsAsImage ?? null
-    queryableDataset.schema = result.schema = await virtualDatasetsUtils.prepareSchema(dataset)
-    // persist the attachmentsAsImage flag derived from the children by prepareSchema
-    const attachmentsAsImage = dataset.attachmentsAsImage ?? null
-    if (attachmentsAsImage !== hadAttachmentsAsImage) {
-      queryableDataset.attachmentsAsImage = dataset.attachmentsAsImage
-      result.attachmentsAsImage = attachmentsAsImage
+    // the prepared schema runs extendedSchema itself, then reconciles the calculated fields with
+    // the children schemas (e.g. _attachment_url inherits the image concept from a child with
+    // attachmentsAsImage) — a plain extendedSchema call would discard that reconciliation.
+    // The preparation is pure (fresh field objects): dataset.schema must be reassigned too so
+    // the cardinality/enum stamping below (which walks dataset.schema) lands on the objects
+    // persisted through result.schema
+    const virtualPatch = await virtualDatasetsUtils.prepareVirtualDatasetPatch(dataset)
+    dataset.schema = queryableDataset.schema = result.schema = virtualPatch.schema
+    if ('attachmentsAsImage' in virtualPatch) {
+      result.attachmentsAsImage = virtualPatch.attachmentsAsImage
+      if (virtualPatch.attachmentsAsImage) dataset.attachmentsAsImage = queryableDataset.attachmentsAsImage = true
+      else {
+        delete dataset.attachmentsAsImage
+        delete queryableDataset.attachmentsAsImage
+      }
     }
   } else {
     // Add the calculated fields to the schema

--- a/tests/features/datasets/virtual/virtual-datasets-core.api.spec.ts
+++ b/tests/features/datasets/virtual/virtual-datasets-core.api.spec.ts
@@ -609,22 +609,52 @@ test.describe('virtual datasets core', () => {
     const ax = testUser1
     const dataset = await sendDataset('datasets/dataset1.csv', ax)
 
-    const res = await testUser3.post('/api/v1/datasets', {
+    // schema preparation applies the same permissions model as querying: the creation fails
+    // fast with the detailed message instead of leaving a dataset that errors at finalization
+    await assert.rejects(testUser3.post('/api/v1/datasets', {
       isVirtual: true,
       title: 'a virtual dataset',
       virtual: {
         children: [dataset.id]
       }
+    }), (err: any) => {
+      assert.equal(err.status, 400)
+      assert.ok(err.data.includes(dataset.id))
+      assert.ok(err.data.includes('n\'est pas accessible en lecture par le compte propriétaire du jeu de données virtuel'))
+      return true
     })
-    await waitForDatasetError(testUser3, res.data.id)
 
-    await assert.rejects(testUser3.get(`/api/v1/datasets/${res.data.id}/lines`), (err: any) => {
+    // the specific permission unlocks creation, and the schema is reconciled with the shared
+    // child instead of being silently skipped
+    await ax.put('/api/v1/datasets/' + dataset.id + '/permissions', [
+      { classes: ['read'], type: 'user', id: 'test_user3' }
+    ])
+    const res = await testUser3.post('/api/v1/datasets', {
+      isVirtual: true,
+      title: 'a virtual dataset',
+      virtual: {
+        children: [dataset.id]
+      },
+      schema: [{ key: 'id' }]
+    })
+    const virtualDataset = await waitForFinalize(testUser3, res.data.id)
+    const idField = virtualDataset.schema.find((f: any) => f.key === 'id')
+    assert.equal(idField.type, 'string')
+    const lines = (await testUser3.get(`/api/v1/datasets/${virtualDataset.id}/lines`)).data
+    assert.equal(lines.total, 2)
+
+    // revoking the permission breaks querying with the detailed error
+    await ax.put('/api/v1/datasets/' + dataset.id + '/permissions', [])
+    // bump the virtual dataset so its cached descendants resolution is revalidated (a permission
+    // change on a child does not touch the virtual doc, the cache may serve it for up to 30s)
+    await testUser3.patch(`/api/v1/datasets/${virtualDataset.id}`, { title: 'a virtual dataset 2' })
+    await assert.rejects(testUser3.get(`/api/v1/datasets/${virtualDataset.id}/lines`), (err: any) => {
       assert.equal(err.status, 501)
-      // the error now pinpoints the exact child dataset that is not readable
+      // the error pinpoints the exact child dataset that is not readable
       assert.ok(err.data.includes(dataset.id))
       assert.ok(err.data.includes('n\'est pas accessible en lecture par le compte propriétaire du jeu de données virtuel'))
       // the body is the user-facing message, not a stack trace with the worker-only [noretry] prefix
-      assert.ok(err.data.startsWith(`Le jeu de données virtuel "${res.data.id}" ne peut pas être requêté`), err.data)
+      assert.ok(err.data.startsWith(`Le jeu de données virtuel "${virtualDataset.id}" ne peut pas être requêté`), err.data)
       return true
     })
   })

--- a/tests/features/datasets/virtual/virtual-datasets-features.api.spec.ts
+++ b/tests/features/datasets/virtual/virtual-datasets-features.api.spec.ts
@@ -364,6 +364,28 @@ test.describe('virtual datasets features', () => {
     assert.equal(res.status, 200)
   })
 
+  test('a patch on a child is not blocked by an unrelated broken virtual parent', async () => {
+    const ax = testUser1
+    const child1 = await sendDataset('datasets/dataset1.csv', ax)
+    const child2 = await sendDataset('datasets/dataset2.csv', ax)
+    let res = await ax.post('/api/v1/datasets', {
+      isVirtual: true,
+      title: 'a virtual dataset',
+      virtual: { children: [child1.id, child2.id] },
+      schema: [{ key: 'id' }]
+    })
+    await waitForFinalize(ax, res.data.id)
+
+    // the virtual parent becomes broken: one of its children is deleted
+    await ax.delete('/api/v1/datasets/' + child2.id)
+
+    // an innocuous schema patch on the remaining child still works: the immediate sync of the
+    // broken parent is skipped, the parent will surface its own error at next finalization
+    child1.schema[0].title = 'a new title'
+    res = await ax.patch('/api/v1/datasets/' + child1.id, { schema: child1.schema })
+    assert.equal(res.status, 200)
+  })
+
   test('a virtual dataset over children disagreeing on attachmentsAsImage degrades to plain attachments', async () => {
     const ax = testUser1
     const children: any[] = []

--- a/tests/features/datasets/virtual/virtual-datasets-features.api.spec.ts
+++ b/tests/features/datasets/virtual/virtual-datasets-features.api.spec.ts
@@ -289,6 +289,70 @@ test.describe('virtual datasets features', () => {
     assert.equal(res.status, 200)
   })
 
+  test('a virtual dataset of a virtual dataset of a dataset with attachments re-expose those attachments', async () => {
+    const ax = testUser1
+    let res = await ax.post('/api/v1/datasets', {
+      isRest: true,
+      title: 'childattach',
+      attachmentsAsImage: true,
+      schema: [
+        { key: 'attr1', type: 'integer' },
+        { key: 'attachmentPath', type: 'string', 'x-refersTo': 'http://schema.org/DigitalDocument' }
+      ]
+    })
+    const child = res.data
+
+    const form = new FormData()
+    const attachmentContent = fs.readFileSync('./tests/resources/avatar.jpeg')
+    form.append('attachment', attachmentContent, 'dir1/avatar.jpeg')
+    form.append('attr1', '10')
+    res = await ax.post(`/api/v1/datasets/${child.id}/lines`, form, { headers: { 'Content-Length': form.getLengthSync(), ...form.getHeaders() } })
+    assert.equal(res.status, 201)
+    await waitForFinalize(ax, child.id)
+    const attachmentPath = (await ax.get(`/api/v1/datasets/${child.id}/lines`)).data.results[0].attachmentPath
+
+    // level 1 virtual, with a filter to check that filtered intermediate levels work too
+    res = await ax.post('/api/v1/datasets', {
+      isVirtual: true,
+      virtual: { children: [child.id], filters: [{ key: 'attr1', values: ['10'] }] },
+      title: 'virtual level 1',
+      schema: [
+        { key: 'attr1', type: 'integer' },
+        { key: 'attachmentPath', type: 'string', 'x-refersTo': 'http://schema.org/DigitalDocument' }
+      ]
+    })
+    const virtual1 = await waitForFinalize(ax, res.data.id)
+    assert.equal(virtual1.status, 'finalized')
+    // the finalized virtual schema keeps the concept reconciled from the child
+    // (it used to be overwritten by a plain extendedSchema at the end of finalization)
+    const v1AttachmentUrl = virtual1.schema.find((f: any) => f.key === '_attachment_url')
+    assert.equal(v1AttachmentUrl?.['x-refersTo'], 'http://schema.org/image')
+
+    // level 2 virtual (of the level 1 virtual)
+    res = await ax.post('/api/v1/datasets', {
+      isVirtual: true,
+      virtual: { children: [virtual1.id] },
+      title: 'virtual level 2',
+      schema: [
+        { key: 'attr1', type: 'integer' },
+        { key: 'attachmentPath', type: 'string', 'x-refersTo': 'http://schema.org/DigitalDocument' }
+      ]
+    })
+    const virtual2 = await waitForFinalize(ax, res.data.id)
+    assert.equal(virtual2.status, 'finalized')
+    const v2AttachmentUrl = virtual2.schema.find((f: any) => f.key === '_attachment_url')
+    assert.equal(v2AttachmentUrl?.['x-refersTo'], 'http://schema.org/image')
+
+    // lines are readable through the nested virtual and the attachment url is rewritten
+    res = await ax.get(`/api/v1/datasets/${virtual2.id}/lines`)
+    assert.equal(res.data.total, 1)
+    assert.equal(res.data.results[0]._attachment_url, `${config.publicUrl}/api/v1/datasets/${virtual2.id}/attachments/${child.id}/${attachmentPath}`)
+
+    // the attachment is downloadable through the nested virtual
+    res = await ax.get(`/api/v1/datasets/${virtual2.id}/attachments/${child.id}/${attachmentPath}`)
+    assert.equal(res.status, 200)
+  })
+
   test('A virtual dataset with geo and non-geo children supports geo queries', async () => {
     const ax = testUser1
     const geoChild = await sendDataset('datasets/dataset1.csv', ax)

--- a/tests/features/datasets/virtual/virtual-datasets-features.api.spec.ts
+++ b/tests/features/datasets/virtual/virtual-datasets-features.api.spec.ts
@@ -327,6 +327,8 @@ test.describe('virtual datasets features', () => {
     // (it used to be overwritten by a plain extendedSchema at the end of finalization)
     const v1AttachmentUrl = virtual1.schema.find((f: any) => f.key === '_attachment_url')
     assert.equal(v1AttachmentUrl?.['x-refersTo'], 'http://schema.org/image')
+    // attachmentsAsImage is derived from the children, it was not set at creation
+    assert.equal(virtual1.attachmentsAsImage, true)
 
     // level 2 virtual (of the level 1 virtual)
     res = await ax.post('/api/v1/datasets', {
@@ -342,6 +344,7 @@ test.describe('virtual datasets features', () => {
     assert.equal(virtual2.status, 'finalized')
     const v2AttachmentUrl = virtual2.schema.find((f: any) => f.key === '_attachment_url')
     assert.equal(v2AttachmentUrl?.['x-refersTo'], 'http://schema.org/image')
+    assert.equal(virtual2.attachmentsAsImage, true)
 
     // lines are readable through the nested virtual and the attachment url is rewritten
     res = await ax.get(`/api/v1/datasets/${virtual2.id}/lines`)
@@ -350,6 +353,12 @@ test.describe('virtual datasets features', () => {
 
     // the attachment is downloadable through the nested virtual
     res = await ax.get(`/api/v1/datasets/${virtual2.id}/attachments/${child.id}/${attachmentPath}`)
+    assert.equal(res.status, 200)
+
+    // thumbnails work through the nested virtual thanks to the derived attachmentsAsImage flag
+    res = await ax.get(`/api/v1/datasets/${virtual2.id}/lines?thumbnail=true`)
+    assert.ok(res.data.results[0]._thumbnail)
+    res = await ax.get(res.data.results[0]._thumbnail)
     assert.equal(res.status, 200)
   })
 

--- a/tests/features/datasets/virtual/virtual-datasets-features.api.spec.ts
+++ b/tests/features/datasets/virtual/virtual-datasets-features.api.spec.ts
@@ -364,6 +364,78 @@ test.describe('virtual datasets features', () => {
     assert.equal(res.status, 200)
   })
 
+  test('a virtual dataset over children disagreeing on attachmentsAsImage degrades to plain attachments', async () => {
+    const ax = testUser1
+    const children: any[] = []
+    for (const attachmentsAsImage of [true, false]) {
+      let res = await ax.post('/api/v1/datasets', {
+        isRest: true,
+        title: 'childattach ' + attachmentsAsImage,
+        attachmentsAsImage,
+        schema: [
+          { key: 'attr1', type: 'integer' },
+          { key: 'attachmentPath', type: 'string', 'x-refersTo': 'http://schema.org/DigitalDocument' }
+        ]
+      })
+      const child = res.data
+      const form = new FormData()
+      form.append('attachment', fs.readFileSync('./tests/resources/avatar.jpeg'), 'dir1/avatar.jpeg')
+      form.append('attr1', '10')
+      res = await ax.post(`/api/v1/datasets/${child.id}/lines`, form, { headers: { 'Content-Length': form.getLengthSync(), ...form.getHeaders() } })
+      assert.equal(res.status, 201)
+      await waitForFinalize(ax, child.id)
+      children.push(child)
+    }
+
+    const res = await ax.post('/api/v1/datasets', {
+      isVirtual: true,
+      virtual: { children: children.map(c => c.id) },
+      title: 'a virtual dataset',
+      schema: [
+        { key: 'attr1', type: 'integer' },
+        { key: 'attachmentPath', type: 'string', 'x-refersTo': 'http://schema.org/DigitalDocument' }
+      ]
+    })
+    const virtualDataset = await waitForFinalize(ax, res.data.id)
+    assert.equal(virtualDataset.status, 'finalized')
+    // the image concept and the derived attachmentsAsImage flag are dropped, not an error
+    const attachmentUrlField = virtualDataset.schema.find((f: any) => f.key === '_attachment_url')
+    assert.ok(attachmentUrlField)
+    assert.equal(attachmentUrlField['x-refersTo'], undefined)
+    assert.equal(virtualDataset.attachmentsAsImage, undefined)
+
+    // attachments are still re-exposed as plain links
+    const lines = (await ax.get(`/api/v1/datasets/${virtualDataset.id}/lines`)).data
+    assert.equal(lines.total, 2)
+    for (const line of lines.results) {
+      assert.ok(line._attachment_url.startsWith(`${config.publicUrl}/api/v1/datasets/${virtualDataset.id}/attachments/`))
+    }
+  })
+
+  test('a virtual dataset inherits the timeZone of date fields from its children', async () => {
+    const ax = testUser1
+    let res = await ax.post('/api/v1/datasets', {
+      isRest: true,
+      title: 'child with timezone',
+      schema: [
+        { key: 'd', type: 'string', format: 'date-time', timeZone: 'Europe/Athens' }
+      ]
+    })
+    const child = res.data
+    await ax.post(`/api/v1/datasets/${child.id}/lines`, { d: '2026-07-29T10:00:00+03:00' })
+    await waitForFinalize(ax, child.id)
+
+    res = await ax.post('/api/v1/datasets', {
+      isVirtual: true,
+      virtual: { children: [child.id] },
+      title: 'a virtual dataset',
+      schema: [{ key: 'd' }]
+    })
+    const virtualDataset = await waitForFinalize(ax, res.data.id)
+    const dField = virtualDataset.schema.find((f: any) => f.key === 'd')
+    assert.equal(dField.timeZone, 'Europe/Athens')
+  })
+
   test('A virtual dataset with geo and non-geo children supports geo queries', async () => {
     const ax = testUser1
     const geoChild = await sendDataset('datasets/dataset1.csv', ax)

--- a/tests/features/datasets/virtual/virtual-datasets-features.api.spec.ts
+++ b/tests/features/datasets/virtual/virtual-datasets-features.api.spec.ts
@@ -327,6 +327,8 @@ test.describe('virtual datasets features', () => {
     // (it used to be overwritten by a plain extendedSchema at the end of finalization)
     const v1AttachmentUrl = virtual1.schema.find((f: any) => f.key === '_attachment_url')
     assert.equal(v1AttachmentUrl?.['x-refersTo'], 'http://schema.org/image')
+    // the generator-owned capability marker survives the most-restrictive capabilities merge
+    assert.equal(v1AttachmentUrl?.['x-capabilities']?.nativeWildcard, true)
     // attachmentsAsImage is derived from the children, it was not set at creation
     assert.equal(virtual1.attachmentsAsImage, true)
 

--- a/ui/src/components/dataset/dataset-virtual-child-compat.vue
+++ b/ui/src/components/dataset/dataset-virtual-child-compat.vue
@@ -74,6 +74,9 @@ const messages = computed(() => {
 
   // Per-field checks
   for (const field of props.child.schema) {
+    // calculated fields are reconciled server-side (see prepareVirtualDataset), the user cannot
+    // act on a mismatch and any transient difference would show as a spurious conflict
+    if (field['x-calculated']) continue
     const parentField = props.parentSchema.find(pf => pf.key === field.key)
     if (!parentField) continue
 

--- a/ui/src/components/dataset/metadata/dataset-metadata-form.vue
+++ b/ui/src/components/dataset/metadata/dataset-metadata-form.vue
@@ -206,8 +206,9 @@
           @click:clear="dataset.modified = null"
         />
 
+        <!-- on virtual datasets attachmentsAsImage is derived from the children (see prepareSchema) -->
         <v-checkbox
-          v-if="dataset.schema?.some((prop: any) => prop['x-refersTo'] === 'http://schema.org/DigitalDocument')"
+          v-if="!dataset.isVirtual && dataset.schema?.some((prop: any) => prop['x-refersTo'] === 'http://schema.org/DigitalDocument')"
           v-model="dataset.attachmentsAsImage"
           :disabled="!can('writeDescriptionBreaking')"
           :label="t('attachmentsAsImage')"

--- a/ui/src/pages/new-dataset.vue
+++ b/ui/src/pages/new-dataset.vue
@@ -815,22 +815,18 @@ async function createVirtualDataset () {
     const { results: childDatasets } = await $fetch<{ results: any[] }>(`${$apiPath}/datasets`, {
       query: {
         id: virtualChildren.value.map(c => c.id).join(','),
-        select: 'id,schema,attachmentsAsImage'
+        select: 'id,schema'
       }
     })
-    let allChildrenHaveAttachmentsAsImage = true
+    // attachmentsAsImage is derived from the children by the server (see prepareSchema)
     for (const child of virtualChildren.value) {
       const childDataset = childDatasets.find(d => d.id === child.id)
-      if (!childDataset?.attachmentsAsImage) allChildrenHaveAttachmentsAsImage = false
       const schema = childDataset?.schema || []
       for (const property of schema) {
         if (!body.schema.find((p: any) => p.key === property.key)) {
           body.schema.push(property)
         }
       }
-    }
-    if (allChildrenHaveAttachmentsAsImage) {
-      body.attachmentsAsImage = true
     }
   }
 


### PR DESCRIPTION
Creating a virtual dataset of a virtual dataset of a dataset with attachments failed with a spurious `_attachment_url` "contradictory concepts" error. Root causes: the finalize worker overwrote the reconciled virtual schema with a plain `extendedSchema` call (losing the image concept inherited from the child), and compatibility checks compared fields against all transitive descendants instead of direct children only. Fixing this surfaced several adjacent hardenings, all included here:

- `attachmentsAsImage` is now derived from the children on virtual datasets (flag and `_attachment_url` image concept must be in lockstep or thumbnails 404); the metadata checkbox is hidden for virtuals and the wizard's manual copy removed
- virtual schema preparation is pure and centralized: `prepareVirtualDatasetPatch` is the single persistence contract used by creation, finalization, metadata patch and child-change sync (fixes a change-detection bug where the sync compared the schema to itself)
- generator-owned capability keys (`nativeWildcard`) survive the most-restrictive capabilities merge — without it, exact filters on long attachment URLs 400 through the virtual
- children disagreeing on `attachmentsAsImage` degrade to plain attachment links instead of failing on a calculated field the user cannot edit
- `timeZone` of date fields is inherited from children (day boundaries of date filters/aggregations)
- schema preparation applies the same permissions model as querying (#296 `filterCan` pseudo-session), judged level by level; a missing/unreadable child fails fast at creation with the same detailed report as the query path, and the child-change sync skips broken parents instead of failing the child's own patch

**Why:** nested virtual datasets over attachments should just work; each hardening closes a gap the investigation exposed.

**Heads-up:** creating a virtual with an unreadable child now 400s immediately instead of erroring at finalization; a manually set `attachmentsAsImage` on a virtual is normalized to the derived value at next finalization. No upgrade script: stored schemas heal as datasets re-finalize.
