### PR TITLE
feat(datasets): q_mode=adapt filters on the OR of retained words

### DIFF
--- a/api/contract/dataset-api-docs.ts
+++ b/api/contract/dataset-api-docs.ts
@@ -171,7 +171,7 @@ export default (
     description: `
   Ce paramètre permet d'altérer le comportement du paramètre "q". Le mode par défaut est "adapt".
 
-  Le mode "adapt" ignore automatiquement pour le filtrage les mots trop fréquents — juste assez pour que l'ensemble filtré reste au-dessus du seuil de comptage exact ; les mots ignorés comptent toujours pour le classement et sont signalés dans la réponse (\`meta.ignoredWords\`). Une recherche dont le total est sous le seuil, ou utilisant la syntaxe d'opérateurs, n'est pas modifiée.
+  Le mode "adapt" ignore automatiquement pour le filtrage les mots trop fréquents — juste assez pour que l'ensemble des résultats contenant au moins un des mots restants reste au-dessus du seuil de comptage exact ; les mots ignorés comptent toujours pour le classement et sont signalés dans la réponse (\`meta.ignoredWords\`). Une recherche dont le total est sous le seuil, ou utilisant la syntaxe d'opérateurs, n'est pas modifiée.
 
   Le mode "simple" (alias "or") expose directement la fonctionnalité [simple-query-string de Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html)
 
@@ -187,12 +187,12 @@ export default (
     }
   }, {
     in: 'query',
-    name: 'q_required',
+    name: 'q_ignored',
     description: `
-  Paramètre technique renseigné automatiquement par le mode "adapt" dans les liens de pagination (\`next\`) pour garantir des pages cohérentes : liste de mots de la recherche "q" (séparés par des virgules) exigés dans les résultats, en filtre non-scorant. Ne pas construire manuellement.
+  Paramètre technique renseigné automatiquement par le mode "adapt" dans les liens de pagination (\`next\`) pour garantir des pages cohérentes : liste de mots de la recherche "q" (séparés par des virgules) ignorés du filtrage — les résultats contiennent au moins un des autres mots de la recherche, les mots ignorés comptent toujours pour le classement. Ne pas construire manuellement.
     `,
     schema: {
-      title: 'Mots requis (pagination adapt)',
+      title: 'Mots ignorés (pagination adapt)',
       type: 'string'
     }
   }, {

--- a/api/src/datasets/es/adaptive-q.ts
+++ b/api/src/datasets/es/adaptive-q.ts
@@ -2,30 +2,32 @@ import config from '#config'
 import { httpError } from '@data-fair/lib-utils/http-errors.js'
 import { aliasName, prepareQuery } from './commons.ts'
 import { esSearchBody } from './approx-count.ts'
-import { type ApproxCountMode, extrapolateApproxTotal, estimateMarginPct, chooseStrictestCandidate, buildQClauses, ADAPT_FLOOR_SAFETY } from './operations.ts'
+import { type ApproxCountMode, extrapolateApproxTotal, estimateMarginPct, chooseStrictestCandidate, buildOrAdaptCandidates, type OrAdaptCandidate, buildQClauses, ADAPT_FLOOR_SAFETY, ADAPT_MIN_BITE } from './operations.ts'
 import { type Client } from '@elastic/elasticsearch'
 import { type EsAbortContext, timedEsCall } from './abort.ts'
 
 // q_mode=adapt: ignore the most frequent words of the search in filtering — just enough of
-// them that the filtered set stays above the exactness horizon (the track_total_hits cap) —
-// while every word keeps scoring (see buildQClauses' score-broad-match-strict shape).
+// them that the RETAINED-WORD UNION stays above the exactness horizon (the track_total_hits
+// cap) — while every word keeps scoring (see buildQClauses' score-broad-match-strict shape).
+// The match set is the plain OR search minus the docs that only matched ignored words.
 //
 // The decision is measured on the `_rand < randBound` sample slice, so every count in this
 // module is in SAMPLED DOCS (multiply by 1/probability for real counts). One size:0 search
 // returns the sampled count of the full OR search plus a per-word sampled count (filters
-// agg); when several words might be required together, one _msearch counts those
-// combinations. All probe requests are size:0 and deterministic → shard-request-cacheable.
+// agg); union-size bounds decide most candidates from those alone (buildOrAdaptCandidates),
+// and the few undecided unions are counted in one _msearch. All probe requests are size:0
+// and deterministic → shard-request-cacheable.
 //
 // Outcomes (THE INVARIANT: searches totalling under the cap run exactly as today):
-//   - OR search under the cap       → null (plain behaviour, exact total)
-//   - all words can be required     → nothing ignored (ignored: [])
-//   - some words must be ignored    → { required: the rarest, ignored: the most frequent }
-//   - even one word is too narrow   → unrestricted (required: [], plain capped OR)
+//   - OR search under the cap                → null (plain behaviour, exact total)
+//   - some words can be ignored              → { ignored: the most frequent }
+//   - nothing ignorable above the floor, or
+//     ignoring would not bite (co-occurring
+//     words: the union ≈ the full OR)        → { ignored: [] } (plain capped OR, sampled total)
 // The chosen candidate's sampled count also provides the response total, so the /lines
-// pipeline needs no separate count leg.
+// pipeline needs no separate count leg. Design evidence: benchmark/INVESTIGATIONS.md §14.
 
 export interface AdaptResult {
-  required: string[]
   ignored: string[]
   total: number
   /** margin of error in percent (~95 % confidence, rounded up) — becomes meta.totalMarginPct */
@@ -37,28 +39,21 @@ export interface AdaptResult {
 // ignoring a word the user explicitly required (+), negated (-), quoted or grouped.
 const SQS_SYNTAX = /[+\-|"*()~\\]/
 
-// Hard structural bound on the preflight fan-out: only the first MAX_ADAPT_WORDS words are
-// considered, so an adapt request costs AT MOST 3 ES round trips whatever the query — the
-// filters-agg probe (≤ MAX_ADAPT_WORDS buckets), one _msearch of ≤ MAX_ADAPT_WORDS-1
-// combination counts, and the main search.
+// Hard structural bound on the preflight fan-out: only the first MAX_ADAPT_WORDS distinct
+// words are considered, so an adapt request costs AT MOST 3 ES round trips whatever the
+// query — the filters-agg probe (≤ MAX_ADAPT_WORDS buckets), one _msearch of
+// ≤ MAX_ADAPT_WORDS-1 union counts, and the main search. Words beyond the bound can never
+// be ignored — they always stay retained, the safe (looser) direction.
 const MAX_ADAPT_WORDS = 8
-
-// A possible outcome: require the `required` words (a rarest-first prefix of the query's
-// words), ignore the rest. `sampledCount` is the size of that filtered set on the sample slice.
-interface Candidate {
-  required: string[]
-  ignored: string[]
-  sampledCount: number
-}
 
 export const runAdaptivePreflight = async (client: Client, dataset: any, query: Record<string, any>, mode: ApproxCountMode, abortContext?: EsAbortContext): Promise<AdaptResult | null> => {
   const q = String(query.q ?? '').trim()
   if (SQS_SYNTAX.test(q)) return null
-  const words = q.split(/\s+/).slice(0, MAX_ADAPT_WORDS)
+  const words = [...new Set(q.split(/\s+/))].slice(0, MAX_ADAPT_WORDS)
   if (words.length < 2) return null // nothing to relax on a single word
 
   // the full OR query (all other filters included) — the probes measure within that context
-  const orQuery = prepareQuery(dataset, { ...query, q_mode: 'simple', q_required: undefined }).query
+  const orQuery = prepareQuery(dataset, { ...query, q_mode: 'simple', q_ignored: undefined }).query
   const sampleSlice = { range: { _rand: { lt: mode.randBound } } }
   const wordMatchClauses: Record<string, any> = Object.fromEntries(words.map(word => [word, buildQClauses(dataset, word, undefined, 'simple')]))
 
@@ -80,31 +75,15 @@ export const runAdaptivePreflight = async (client: Client, dataset: any, query: 
   // under the cap the request must run exactly as today (exact total, full OR semantics)
   if (orSampledCount < sampledCap) return null
 
-  // candidates strictest-first: require the `requiredCount` rarest words, ignore the rest.
-  // A single required word is already counted by the agg; a multi-word combination can only
-  // qualify if its rarest member does (its count bounds the conjunction), so only those are
-  // worth counting — all in one _msearch. Two probes with two mechanisms on purpose: the
-  // combinations depend on the rarity order (unknown before the agg answers), and each shape
-  // matches its execution model — a filters agg amortizes the 8 unconditional per-word counts
-  // over ONE scan of the slice, while a conjunction as a top-level query leapfrogs on its
-  // rarest word (an agg bucket cannot skip, it tests every scanned doc).
-  const wordsByRarity = [...words].sort((a, b) => wordSampledCount[a] - wordSampledCount[b])
-  const candidates: Candidate[] = []
-  const needCounting: Candidate[] = []
-  for (let requiredCount = words.length; requiredCount >= 1; requiredCount--) {
-    const candidate: Candidate = {
-      required: wordsByRarity.slice(0, requiredCount),
-      ignored: wordsByRarity.slice(requiredCount),
-      sampledCount: 0
-    }
-    candidates.push(candidate)
-    if (requiredCount === 1) {
-      candidate.sampledCount = wordSampledCount[candidate.required[0]]
-    } else if (Math.min(...candidate.required.map(word => wordSampledCount[word])) >= floorSample) {
-      needCounting.push(candidate)
-    }
-  }
-  candidates.push({ required: [], ignored: [], sampledCount: orSampledCount }) // loosest: unrestricted
+  // candidates strictest-first: ignore the k most frequent words, keep the rest as an OR
+  // filter. Union-size bounds fill most sampled counts without ES (see the helper's doc);
+  // the undecided unions are counted in one _msearch. Two probes with two mechanisms on
+  // purpose: the candidates depend on the frequency order (unknown before the agg answers),
+  // and each shape matches its execution model — a filters agg amortizes the unconditional
+  // per-word counts over ONE scan of the slice, while a retained-OR union as a top-level
+  // filtered query iterates only its own posting lists.
+  const candidates = buildOrAdaptCandidates(words, wordSampledCount, orSampledCount, floorSample)
+  const needCounting = candidates.filter(candidate => candidate.sampledCount === null)
 
   if (needCounting.length) {
     const msearchBody = needCounting.flatMap(candidate => [
@@ -115,7 +94,15 @@ export const runAdaptivePreflight = async (client: Client, dataset: any, query: 
         // _msearch rejects a `timeout` querystring but accepts it per body — same ES-side
         // bound as every other search (the client requestTimeout stays the backstop)
         timeout: config.elasticsearch.searchTimeout,
-        query: { bool: { filter: [orQuery, ...candidate.required.map(word => wordMatchClauses[word]), sampleSlice] } }
+        query: {
+          bool: {
+            filter: [
+              orQuery,
+              { bool: { should: candidate.retained.map(word => wordMatchClauses[word]), minimum_should_match: 1 } },
+              sampleSlice
+            ]
+          }
+        }
       }
     ])
     const res = await timedEsCall(abortContext, () => client.transport.request({
@@ -130,9 +117,22 @@ export const runAdaptivePreflight = async (client: Client, dataset: any, query: 
     }
   }
 
-  const chosen = chooseStrictestCandidate(candidates, floorSample)
+  const chosen = chooseStrictestCandidate(candidates as Array<OrAdaptCandidate & { sampledCount: number }>, floorSample)
+
+  // an ignore-set must actually bite: when the query's words co-occur (phrase-like
+  // searches), the retained union covers (almost) the whole OR sample — filtering would
+  // exclude (almost) nothing and reporting "ignored" words would be pure noise. The two
+  // counts are nested on the same sample slice, so this comparison is exact, not
+  // statistical; and the union grows along looseness, so if the strictest candidate does
+  // not bite, no candidate does.
+  if (chosen.ignored.length && chosen.sampledCount >= orSampledCount * ADAPT_MIN_BITE) {
+    return {
+      ignored: [],
+      total: extrapolateApproxTotal(orSampledCount, mode),
+      marginPct: estimateMarginPct(orSampledCount)
+    }
+  }
   return {
-    required: chosen.required,
     ignored: chosen.ignored,
     total: extrapolateApproxTotal(chosen.sampledCount, mode),
     marginPct: estimateMarginPct(chosen.sampledCount)

--- a/api/src/datasets/es/commons.ts
+++ b/api/src/datasets/es/commons.ts
@@ -36,7 +36,7 @@ import {
   descendantsFilterClause,
   getCountMode,
   parseQMode,
-  parseQRequired,
+  parseQIgnored,
   DEFAULT_Q_MODE
 } from './operations.ts'
 
@@ -335,8 +335,8 @@ export const prepareQuery = (dataset: any, query: Record<string, any>, qFields?:
     }
     if (q) {
       const qMode = parseQMode(query.q_mode, DEFAULT_Q_MODE)
-      const requiredWords = query.q_required ? parseQRequired(q, query.q_required) : undefined
-      must.push(buildQClauses(dataset, q, qFields, qMode, sqsOptions, requiredWords))
+      const ignoredWords = query.q_ignored ? parseQIgnored(q, query.q_ignored) : undefined
+      must.push(buildQClauses(dataset, q, qFields, qMode, sqsOptions, ignoredWords))
     }
   }
   // pre-build schema lookup maps for O(1) field resolution

--- a/api/src/datasets/es/operations.ts
+++ b/api/src/datasets/es/operations.ts
@@ -487,7 +487,7 @@ export const buildQClauses = (
   qFields: string[] | undefined,
   qMode: string | undefined,
   sqsOptions: any = {},
-  requiredWords?: string[]
+  ignoredWords?: string[]
 ): any => {
   const { qSearchFields, qStandardFields, qWildcardFields, reduced } = getFilterableFields(dataset, q, qFields)
   const should: any[] = []
@@ -528,9 +528,11 @@ export const buildQClauses = (
   }
   const scored = { bool: { should, minimum_should_match: 1 } }
 
-  // "score broad, match strict": q_mode=and and q_required tighten the MATCH SET through a
+  // "score broad, match strict": q_mode=and and q_ignored tighten the MATCH SET through a
   // non-scoring filter while scores stay pure OR — the page is OR's page restricted to the
-  // tightened set, and the selective filter leads the iteration. Requirements must NEVER move
+  // tightened set, and the filter leads the iteration. For q_ignored the filter is the OR
+  // of the retained (non-ignored) words: the match set is the plain OR minus docs that
+  // only matched ignored words — ignored words keep scoring. Requirements must NEVER move
   // into scoring position (measured 2.5× slower on ES 7, see load-management.md §9).
   // Not composed with `complete` mode (its prefix/wildcard clauses carry their own semantics).
   if (qMode !== 'complete') {
@@ -538,8 +540,14 @@ export const buildQClauses = (
     if (qMode === 'and' && matchFields.length) {
       return { bool: { must: [scored], filter: [{ simple_query_string: { query: q, fields: matchFields, default_operator: 'and' } }] } }
     }
-    if (requiredWords?.length && matchFields.length) {
-      return { bool: { must: [scored], filter: requiredWords.map(word => ({ multi_match: { query: word, fields: matchFields } })) } }
+    if (ignoredWords?.length && matchFields.length) {
+      const retained = [...new Set(q.split(/\s+/))].filter(word => !ignoredWords.includes(word))
+      return {
+        bool: {
+          must: [scored],
+          filter: [{ bool: { should: retained.map(word => ({ multi_match: { query: word, fields: matchFields } })), minimum_should_match: 1 } }]
+        }
+      }
     }
   }
   return scored
@@ -874,20 +882,6 @@ export const parseQMode = (raw: string | undefined, dflt: string): QMode => {
   if (value === 'or' || value === 'simple') return 'simple'
   if (value === 'complete' || value === 'and' || value === 'adapt') return value
   throw httpError(400, `q_mode invalide "${value}" — valeurs acceptées : simple (ou or), complete, and, adapt`)
-}
-
-/**
- * Parse and validate q_required — the words a search must match (the non-scoring filter of
- * the score-broad-match-strict shape; pinned by q_mode=adapt in next links, or set
- * manually). Every word must be a whitespace token of q, else 400.
- */
-export const parseQRequired = (q: string, raw: string): string[] => {
-  const qWords = new Set(q.split(/\s+/))
-  const words = String(raw).split(',').map(word => word.trim()).filter(Boolean)
-  for (const word of words) {
-    if (!qWords.has(word)) throw httpError(400, `Le paramètre q_required contient "${word}" qui n'est pas un mot de la recherche q.`)
-  }
-  return words
 }
 
 /**

--- a/api/src/datasets/es/operations.ts
+++ b/api/src/datasets/es/operations.ts
@@ -890,11 +890,81 @@ export const parseQRequired = (q: string, raw: string): string[] => {
   return words
 }
 
+/**
+ * Parse and validate q_ignored — the words excluded from the non-scoring filter of the
+ * score-broad-match-strict shape (they keep scoring); pinned by q_mode=adapt in next
+ * links, or set manually. Every word must be a whitespace token of q, and at least one
+ * word of q must remain retained, else 400.
+ */
+export const parseQIgnored = (q: string, raw: string): string[] => {
+  const qWords = new Set(q.split(/\s+/))
+  const words = String(raw).split(',').map(word => word.trim()).filter(Boolean)
+  for (const word of words) {
+    if (!qWords.has(word)) throw httpError(400, `Le paramètre q_ignored contient "${word}" qui n'est pas un mot de la recherche q.`)
+  }
+  if (new Set(words).size >= qWords.size) throw httpError(400, 'Le paramètre q_ignored ne peut pas couvrir tous les mots de la recherche q.')
+  return words
+}
+
+export interface OrAdaptCandidate {
+  /** the words dropped from filtering, most frequent first */
+  ignored: string[]
+  /** the words whose OR forms the non-scoring filter */
+  retained: string[]
+  /** sampled size of the retained union; null = needs an ES count (bounds could not decide) */
+  sampledCount: number | null
+}
+
+/**
+ * Candidates for OR-of-retained adapt, ordered strictest-first: ignore the k most frequent
+ * words, k = words.length-1 … 0 (k=0 = nothing ignored, the plain OR — always last).
+ * Union-size bounds fill sampledCount without an ES count where they can: a single
+ * retained word IS its solo count; union ≤ sum(solo) < floor disqualifies; union ≥
+ * max(solo) ≥ floor qualifies outright — and since every stricter candidate already
+ * failed, that candidate will be chosen, so the walk stops there (its exact sampled count
+ * is still needed, for the display total). Measured to eliminate the second probe in most
+ * real queries — benchmark/INVESTIGATIONS.md §14 finding 3.
+ */
+export const buildOrAdaptCandidates = (
+  words: string[],
+  soloSampledCount: Record<string, number>,
+  orSampledCount: number,
+  floorSample: number
+): OrAdaptCandidate[] => {
+  const byFreq = [...words].sort((a, b) => soloSampledCount[b] - soloSampledCount[a])
+  const candidates: OrAdaptCandidate[] = []
+  for (let k = words.length - 1; k >= 1; k--) {
+    const candidate: OrAdaptCandidate = { ignored: byFreq.slice(0, k), retained: byFreq.slice(k), sampledCount: null }
+    candidates.push(candidate)
+    const solos = candidate.retained.map(word => soloSampledCount[word])
+    const max = Math.max(...solos)
+    const sum = solos.reduce((a, b) => a + b, 0)
+    if (candidate.retained.length === 1) {
+      candidate.sampledCount = solos[0]
+      if (solos[0] >= floorSample) break
+    } else if (sum < floorSample) {
+      candidate.sampledCount = sum // disqualified either way — the ≤-bound is enough
+    } else if (max >= floorSample) {
+      break // qualified outright: chosen; only its display total still needs counting
+    }
+  }
+  candidates.push({ ignored: [], retained: byFreq, sampledCount: orSampledCount })
+  return candidates
+}
+
 // Sampling-noise margin (~2σ at MIN_BOUNDARY_SAMPLES) protecting the never-below-cap
 // invariant: a candidate qualifies only when its estimate clears cap × this margin, so a
 // candidate whose TRUE total sits slightly below the cap cannot be chosen through sampling
 // noise. A statistical constant, deliberately not configuration.
 export const ADAPT_FLOOR_SAFETY = 1.2
+
+/**
+ * Minimum "bite" for an adapt ignore-set: the retained union must exclude at least 2 % of
+ * the sampled OR set, else filtering is pointless overhead (phrase-like queries whose
+ * words co-occur) and adapt reports nothing ignored. Both counts are nested on the same
+ * sample slice — the comparison is exact. A UX constant, deliberately not configuration.
+ */
+export const ADAPT_MIN_BITE = 0.98
 
 /**
  * Pick the strictest candidate whose sampled support clears floorSample — or the last

--- a/api/src/datasets/routes/read.ts
+++ b/api/src/datasets/routes/read.ts
@@ -89,19 +89,22 @@ const readLines: RequestHandler = async (req, res) => {
     ? () => approxTotal(req.app.get('es'), dataset, query, countMode, esAbortContext)
     : undefined
 
-  // q_mode=adapt: ignore over-common words in filtering (they keep scoring) so the match set
-  // stays above the cap — see es/adaptive-q.ts. The preflight rewrites the effective query to
-  // q_required BEFORE the main search; `next` links inherit it from the mutated query, so
-  // after= pages replay the exact same tightened query with no preflight (chain consistency).
+  // q_mode=adapt: ignore over-common words in filtering (they keep scoring) so the retained
+  // union stays above the cap — see es/adaptive-q.ts. The preflight rewrites the effective
+  // query to q_ignored BEFORE the main search; `next` links inherit it from the mutated
+  // query, so after= pages replay the exact same tightened query with no preflight (chain
+  // consistency).
   let ignoredWords: string[] | undefined
   const resolvedQMode = query.q ? parseQMode(query.q_mode, DEFAULT_Q_MODE) : undefined
-  if (countMode && query.count !== 'estimate' && resolvedQMode === 'adapt' && !query.q_required) {
+  if (countMode && query.count !== 'estimate' && resolvedQMode === 'adapt' && !query.q_ignored) {
     const adaptResult = await runAdaptivePreflight(req.app.get('es'), dataset, query, countMode, esAbortContext)
     observe.reqStep(req, 'adaptPreflight')
     if (adaptResult) {
-      if (adaptResult.required.length) query.q_required = adaptResult.required.join(',')
       // the transparency field only appears when adapt actually ignored at least one word
-      if (adaptResult.ignored.length) ignoredWords = adaptResult.ignored
+      if (adaptResult.ignored.length) {
+        query.q_ignored = adaptResult.ignored.join(',')
+        ignoredWords = adaptResult.ignored
+      }
       // the preflight already estimated the chosen candidate's total — no separate count leg needed
       approxTotalThunk = () => Promise.resolve({ total: adaptResult.total, marginPct: adaptResult.marginPct })
     }

--- a/api/src/misc/utils/query-advice.ts
+++ b/api/src/misc/utils/query-advice.ts
@@ -67,7 +67,7 @@ const RECOGNIZED_PARAMS = new Set([
   // pagination / output shaping
   'size', 'page', 'after', 'count', 'select', 'sort', 'truncate', 'thumbnail', 'html', 'format', 'hint', 'draft',
   // full-text search
-  'q', 'q_fields', 'q_mode', 'q_required', 'qs', 'highlight',
+  'q', 'q_fields', 'q_mode', 'q_ignored', 'qs', 'highlight',
   // ownership / account scoping
   'owner', 'account',
   // geo / temporal (+ their _c_ concept forms)

--- a/benchmark/INVESTIGATIONS.md
+++ b/benchmark/INVESTIGATIONS.md
@@ -534,6 +534,79 @@ margins at linear probe cost.
 
 ---
 
+## 14. `q_mode=adapt` filter semantics — AND-of-required vs OR-of-retained (2026-08-01)
+
+The shipped adapt (#528) tightens the match set to a *conjunction* of the rarest words
+("require the rarest, ignore the rest"), which is stronger than what we tell users ("some
+words were ignored") and stronger than the plan's own wording ("excludes from filtering the
+most common query words"). Re-evaluated against the natural reading — filter = **OR of the
+retained words**, i.e. the plain search minus the docs that match *only* ignored words —
+on the reloaded `bench-rna` corpus (3 289 936 docs, ES 8.19.9 + ES 7.17.28, shared
+`_rand`), implementation-faithful shapes, request cache cleared before every measured run
+(§13 methodology), shipped config on this corpus (p = 0.01, cap = 10 000,
+floorSample = 120). Tool: `rna-adapt-or.ts`. Variants:
+
+- **shipped-and** — faithful port of the merged design (filters-agg probe, conjunction
+  `_msearch` of rarest-prefix candidates, strictest above the cap floor).
+- **or-capfloor** — same strictest-first cap-floor rule transplanted to OR-land: ignore
+  the most frequent words, as many as possible while the *retained union* stays ≥ floor.
+  Union counts are needed only when bounds can't decide: union ≥ max(solo) qualifies a
+  candidate outright, sum(solo) < floor disqualifies — probe2 vanishes in most cases.
+- **or-noise2pct / or-noisecap** — fixed noise thresholds (solo count > 2 % of corpus /
+  > cap) instead of the cap-floor rule; retained union may fall below the cap.
+
+Decisions and end-to-end cost (probe1+probe2+main `took`, warm p50; cold runs and ES 8
+agree in ranking — full tables in the script output):
+
+| query | shipped-and | or-capfloor | e2e ES 7 (and → or) | e2e ES 8 (and → or) |
+|---|---|---|---|---|
+| rue baudelaire | unrestricted (~1.44 M) | nothing ignorable (~1.44 M) | 16 → 25 | 11.5 → 15 |
+| association sportive | require **both** (~140 k) | ignore `association` (~328 k) | 54 → 35 | 31 → 18.5 |
+| club de football marseille | require `football` (~44 k) | retain `football` (~44 k) | 32 → 22.5 | 15.5 → 11 |
+| comité des fêtes saint pierre | require `pierre` (~64 k) | retain `pierre` (~64 k) | 73.5 → 32 | 28 → 16 |
+| les amis de la bibliothèque | **unrestricted** (~3 M) | ignore `de,la,les` (~88 k) | 30 → 47 | 14.5 → 19.5 |
+
+Findings (decisions identical across ES versions in every case):
+
+1. **Fidelity: top-20 identical to or-exact in every cell, both designs, both versions.**
+   §12-C's rare-must degradation (14–18/20) came from putting requirements in scoring
+   position (`must`), not from the tightening itself — score-broad-match-strict restores
+   the full page. Page-1 fidelity therefore does NOT discriminate the two designs; the
+   difference is the *enumerable set* (pagination, exports, aggregations).
+2. **When the chosen candidate is a single word the two designs coincide exactly** (3 of
+   5 queries, incl. the no-op). They diverge in both remaining cases, both times in OR's
+   favour: on association-sportive AND silently intersects (140 k — excludes 188 k
+   single-word matches from the enumerable set, contradicting the "ignored" message)
+   where OR ignores the corpus's own noise word and keeps all `sportive` matches; on
+   les-amis AND finds **no qualifying conjunction and gives up** (unrestricted, ~3 M)
+   where OR's richer candidate lattice still shrinks the set 34× (~88 k).
+3. **Cost: OR is cheaper wherever the designs coincide or AND over-tightens** (73.5 → 32
+   on comité ES 7 — the conjunction `_msearch` alone cost 39 ms; the OR bounds shortcut
+   eliminated probe2 in 3 of 5 queries). OR pays more only where it works harder
+   (les-amis 30 → 47 but delivers ~88 k vs nothing; baudelaire 16 → 25 to *conclude*
+   no-op, bounded by one extra `_msearch`). Everything stays well under the or-exact
+   baselines (28–89 ms ES 7).
+4. **The OR filter is never slower than the AND filter in the main query** — association
+   sportive ES 7: 22–25 ms vs 36–38 ms. A short disjunction over mid-frequency postings
+   beats leapfrogging two ~1 M-doc iterators.
+5. **Fixed noise thresholds refuted.** solo > cap (0.3 % of this corpus) declares every
+   word noise on 4/5 queries → no relief at all; 2 %-of-corpus misses the
+   association-sportive relief and can tighten below the cap on sampling noise: les-amis
+   retained `bibliothèque` sampled 101 < floor while the TRUE count is 10 097 ≥ cap —
+   exactly the boundary noise ADAPT_FLOOR_SAFETY exists to absorb. The cap-floor
+   strictest-first rule transplants to OR unchanged and keeps the never-below-cap
+   invariant intact.
+
+**Consequence: reimplement `q_mode=adapt` with OR-of-retained filtering** — same probe1,
+bounds-guided union counts instead of conjunction counts, filter = single non-scoring
+`should` over the retained words, pagination pinned by a `q_ignored` param (the ignored
+words — the complement of today's `q_required`, whose name stops being accurate once
+nothing is conjunctively required). Semantics finally match the user-facing message: the
+result set is the plain OR search minus the docs that only matched ignored words, scores
+and page 1 unchanged.
+
+---
+
 ## Recording results
 
 Harness runs save JSON to `benchmark/results/` tagged with the git commit. When an

--- a/benchmark/src/rna-adapt-or.ts
+++ b/benchmark/src/rna-adapt-or.ts
@@ -1,0 +1,319 @@
+// Real-corpus (RNA) evaluation of the OR-of-retained redesign of q_mode=adapt vs the
+// shipped AND-of-required implementation (see INVESTIGATIONS.md §12-C / §13).
+//
+// Variants, all sharing the "score broad, match strict" shape (scores stay pure OR BM25):
+//   or-exact          today with count=exact — the fidelity baseline (top-20 reference)
+//   or-capped         plain capped OR — what adapt falls back to when it steps aside
+//   shipped-and       the merged design: require the rarest-prefix conjunction that keeps
+//                     the set above the cap floor (filters-agg probe + conjunction _msearch)
+//   or-capfloor       proposed: filter = OR of retained words; ignore the most frequent
+//                     words, as many as possible while the retained UNION stays above the
+//                     cap floor (probe: same filters agg; union counts only when the
+//                     max/sum solo bounds cannot decide)
+//   or-noise2pct      proposed: ignore words whose solo match count > 2 % of the corpus
+//                     (the §12-C rare-must threshold), keep the rest as an OR filter; the
+//                     retained union MAY fall below the cap → exact total (honest small page)
+//   or-noisecap       same, threshold = solo estimate > cap (10k) — expected to degenerate
+//                     on a 3.3M corpus (0.3 %): included as evidence for the threshold choice
+//
+// Metrics per variant: end-to-end ES cost (sum of `took` across probe legs + main query,
+// request cache cleared before every measured run — §13 methodology), top-20 overlap vs
+// or-exact, the ignore/require decision, and the display total.
+// Sampling matches shipped config on this corpus: p=0.01 (_rand < 10000), cap=10000,
+// ADAPT_FLOOR_SAFETY=1.2 → floorSample=120.
+// Usage: node --experimental-strip-types src/rna-adapt-or.ts --node=http://localhost:16395 [--index=bench-rna] [--runs=10] [--cold]
+
+import { parseArgs } from 'node:util'
+import { aggregate } from './metrics.ts'
+
+const { values } = parseArgs({
+  options: {
+    node: { type: 'string', default: 'http://localhost:16395' },
+    index: { type: 'string', default: 'bench-rna' },
+    runs: { type: 'string', default: '10' },
+    warmup: { type: 'string', default: '2' },
+    cold: { type: 'boolean', default: false }
+  }
+})
+const runs = parseInt(values.runs!)
+const warmup = parseInt(values.warmup!)
+
+const FIELDS = ['_search', '_search.text_standard']
+const SEARCH_FIELDS = ['_search']
+const STANDARD_FIELDS = ['_search.text_standard']
+
+// shipped config on a 3.29M-row corpus: p = clamp(sampleTarget/count) = 0.01
+const CAP = 10000
+const P = 0.01
+const RAND_BOUND = 10000 // p × 1e6
+const FLOOR_SAFETY = 1.2
+const sampledCap = CAP * P // 100
+const floorSample = Math.ceil(sampledCap * FLOOR_SAFETY) // 120
+const NOISE_2PCT = 0.02
+
+const QUERIES = [
+  'rue baudelaire',
+  'association sportive',
+  'club de football marseille',
+  'comité des fêtes saint pierre',
+  'les amis de la bibliothèque', // new: stopword-laden French, the pathological prod shape
+  'association'
+]
+
+async function es (method: string, path: string, body?: any, ndjson?: string): Promise<any> {
+  const res = await fetch(values.node! + path, {
+    method,
+    headers: { 'Content-Type': ndjson !== undefined ? 'application/x-ndjson' : 'application/json' },
+    body: ndjson !== undefined ? ndjson : (body === undefined ? undefined : JSON.stringify(body))
+  })
+  const data: any = await res.json()
+  if (!res.ok) throw new Error(`${method} ${path} -> ${res.status}: ${JSON.stringify(data.error?.root_cause?.[0] ?? data).slice(0, 200)}`)
+  return data
+}
+
+const sqs = (q: string, fields: string[]) => ({
+  simple_query_string: { query: q, fields, default_operator: 'or' }
+})
+// buildQClauses 'simple' shape: match on stemmed and raw inner fields
+const scoredClause = (q: string) => ({
+  bool: { should: [sqs(q, SEARCH_FIELDS), sqs(q, STANDARD_FIELDS)], minimum_should_match: 1 }
+})
+// the per-word clause used both by the probe agg and the main-query filters
+const wordClause = (w: string) => ({ multi_match: { query: w, fields: FIELDS } })
+
+const orFilter = (retained: string[]) => ({
+  bool: { should: retained.map(wordClause), minimum_should_match: 1 }
+})
+const sampleSlice = { range: { _rand: { lt: RAND_BOUND } } }
+
+interface Legs { probe1: number, probe2: number, main: number }
+interface RunResult {
+  legs: Legs
+  total: string
+  top: string[]
+  note: string
+}
+
+const fmtEst = (sampled: number) => '~' + Math.round(sampled / P).toLocaleString() + ' (est)'
+
+async function clearRequestCache () {
+  await es('POST', `/${values.index}/_cache/clear?request=true`)
+}
+async function clearAllCaches () {
+  await es('POST', `/${values.index}/_cache/clear`)
+}
+
+/** One measured execution of a variant; returns cost legs + page + decision note. */
+type Variant = () => Promise<RunResult>
+
+async function measure (name: string, variant: Variant): Promise<RunResult & { p50: number, min: number }> {
+  for (let w = 0; w < warmup; w++) await variant()
+  const costs: number[] = []
+  let last: RunResult
+  for (let r = 0; r < runs; r++) {
+    if (values.cold) await clearAllCaches()
+    else await clearRequestCache()
+    last = await variant()
+    costs.push(last.legs.probe1 + last.legs.probe2 + last.legs.main)
+  }
+  const agg = aggregate(costs)
+  return { ...last!, p50: agg.median, min: agg.min }
+}
+
+/** probe1, shared by all adapt variants: sampled OR total + per-word sampled counts. */
+async function probe1 (q: string, words: string[]) {
+  const res = await es('POST', `/${values.index}/_search`, {
+    size: 0,
+    track_total_hits: true,
+    query: { bool: { filter: [scoredClause(q), sampleSlice] } },
+    aggs: { perWord: { filters: { filters: Object.fromEntries(words.map(w => [w, wordClause(w)])) } } }
+  })
+  const solo: Record<string, number> = {}
+  for (const w of words) solo[w] = res.aggregations.perWord.buckets[w].doc_count
+  return { took: res.took as number, orSampled: res.hits.total.value as number, solo }
+}
+
+async function msearchCounts (q: string, filtersPerBody: any[][]): Promise<{ took: number, counts: number[] }> {
+  const body = filtersPerBody.flatMap(filters => [
+    {},
+    { size: 0, track_total_hits: true, query: { bool: { filter: [scoredClause(q), ...filters, sampleSlice] } } }
+  ])
+  const res = await es('POST', `/${values.index}/_msearch`, undefined, body.map(b => JSON.stringify(b)).join('\n') + '\n')
+  let took = 0
+  const counts: number[] = []
+  for (const r of res.responses) {
+    if (r.error) throw new Error('msearch: ' + JSON.stringify(r.error).slice(0, 200))
+    took += r.took
+    counts.push(r.hits.total.value)
+  }
+  return { took, counts }
+}
+
+async function mainSearch (q: string, filter: any[], trackTotal: number | boolean = CAP) {
+  const res = await es('POST', `/${values.index}/_search`, {
+    size: 20,
+    track_total_hits: trackTotal,
+    query: { bool: { must: [scoredClause(q)], filter } }
+  })
+  return { took: res.took as number, top: res.hits.hits.map((h: any) => h._id) as string[], total: res.hits.total }
+}
+
+// ---- the variants ----
+
+const orExact = (q: string): Variant => async () => {
+  const main = await mainSearch(q, [], true)
+  return { legs: { probe1: 0, probe2: 0, main: main.took }, total: `${main.total.value.toLocaleString()} (eq)`, top: main.top, note: '' }
+}
+
+const orCapped = (q: string): Variant => async () => {
+  const main = await mainSearch(q, [])
+  return { legs: { probe1: 0, probe2: 0, main: main.took }, total: `${main.total.value.toLocaleString()} (${main.total.relation})`, top: main.top, note: '' }
+}
+
+/** The merged implementation: rarest-prefix conjunctions, strictest above the floor. */
+const shippedAnd = (q: string, words: string[]): Variant => async () => {
+  const p1 = await probe1(q, words)
+  if (p1.orSampled < sampledCap) {
+    const main = await mainSearch(q, [], true)
+    return { legs: { probe1: p1.took, probe2: 0, main: main.took }, total: `${main.total.value.toLocaleString()} (eq)`, top: main.top, note: 'under cap → plain' }
+  }
+  const byRarity = [...words].sort((a, b) => p1.solo[a] - p1.solo[b])
+  interface Cand { required: string[], ignored: string[], sampledCount: number }
+  const candidates: Cand[] = []
+  const needCounting: Cand[] = []
+  for (let n = words.length; n >= 1; n--) {
+    const cand: Cand = { required: byRarity.slice(0, n), ignored: byRarity.slice(n), sampledCount: 0 }
+    candidates.push(cand)
+    if (n === 1) cand.sampledCount = p1.solo[cand.required[0]]
+    else if (Math.min(...cand.required.map(w => p1.solo[w])) >= floorSample) needCounting.push(cand)
+  }
+  candidates.push({ required: [], ignored: [], sampledCount: p1.orSampled })
+  let probe2Took = 0
+  if (needCounting.length) {
+    const { took, counts } = await msearchCounts(q, needCounting.map(c => c.required.map(wordClause)))
+    probe2Took = took
+    needCounting.forEach((c, i) => { c.sampledCount = counts[i] })
+  }
+  const chosen = candidates.find(c => c.sampledCount >= floorSample) ?? candidates[candidates.length - 1]
+  const main = await mainSearch(q, chosen.required.map(wordClause))
+  return {
+    legs: { probe1: p1.took, probe2: probe2Took, main: main.took },
+    total: fmtEst(chosen.sampledCount),
+    top: main.top,
+    note: chosen.required.length ? `require=[${chosen.required.join(',')}] ignore=[${chosen.ignored.join(',')}]` : 'unrestricted'
+  }
+}
+
+/** Proposed: OR of retained words, ignore as many frequent words as the cap floor allows.
+ *  Union counts requested only when the max/sum solo bounds cannot decide. */
+const orCapfloor = (q: string, words: string[]): Variant => async () => {
+  const p1 = await probe1(q, words)
+  if (p1.orSampled < sampledCap) {
+    const main = await mainSearch(q, [], true)
+    return { legs: { probe1: p1.took, probe2: 0, main: main.took }, total: `${main.total.value.toLocaleString()} (eq)`, top: main.top, note: 'under cap → plain' }
+  }
+  const byFreq = [...words].sort((a, b) => p1.solo[b] - p1.solo[a]) // most frequent first
+  interface Cand { retained: string[], ignored: string[], union: number | null }
+  // strictest first: ignore the k most frequent words, k = n-1 … 0
+  const candidates: Cand[] = []
+  for (let k = words.length - 1; k >= 0; k--) {
+    candidates.push({ ignored: byFreq.slice(0, k), retained: byFreq.slice(k), union: null })
+  }
+  // bounds: union ≥ max(solo), union ≤ sum(solo); count only the undecided + the chosen
+  const toCount: Cand[] = []
+  for (const cand of candidates) {
+    const max = Math.max(...cand.retained.map(w => p1.solo[w]))
+    const sum = cand.retained.reduce((a, w) => a + p1.solo[w], 0)
+    if (cand.retained.length === 1) {
+      cand.union = p1.solo[cand.retained[0]]
+      if (cand.union >= floorSample) break // strictest qualifies with a known total: done
+    } else if (sum < floorSample) {
+      cand.union = sum // disqualified, upper bound is enough
+    } else if (max >= floorSample) {
+      toCount.push(cand) // qualified: count for the total, then stop
+      break
+    } else {
+      toCount.push(cand) // undecided
+    }
+  }
+  let probe2Took = 0
+  if (toCount.length) {
+    const { took, counts } = await msearchCounts(q, toCount.map(c => [orFilter(c.retained)]))
+    probe2Took = took
+    toCount.forEach((c, i) => { c.union = counts[i] })
+  }
+  const chosen = candidates.find(c => (c.union ?? 0) >= floorSample) ?? candidates[candidates.length - 1]
+  const filter = chosen.ignored.length ? [orFilter(chosen.retained)] : []
+  const main = await mainSearch(q, filter)
+  return {
+    legs: { probe1: p1.took, probe2: probe2Took, main: main.took },
+    total: fmtEst(chosen.union ?? p1.orSampled),
+    top: main.top,
+    note: chosen.ignored.length ? `ignore=[${chosen.ignored.join(',')}] retain=[${chosen.retained.join(',')}]` : 'nothing ignorable'
+  }
+}
+
+/** Proposed: noise-threshold rule — ignore words whose solo count exceeds `pct` of the
+ *  corpus; the retained union may fall below the cap (exact total then). */
+const orNoise = (q: string, words: string[], pct: number, corpus: number): Variant => async () => {
+  const p1 = await probe1(q, words)
+  if (p1.orSampled < sampledCap) {
+    const main = await mainSearch(q, [], true)
+    return { legs: { probe1: p1.took, probe2: 0, main: main.took }, total: `${main.total.value.toLocaleString()} (eq)`, top: main.top, note: 'under cap → plain' }
+  }
+  const noiseSampled = corpus * pct * P
+  const ignored = words.filter(w => p1.solo[w] > noiseSampled)
+  const retained = words.filter(w => p1.solo[w] <= noiseSampled)
+  if (!ignored.length || !retained.length) {
+    const main = await mainSearch(q, [])
+    const why = retained.length ? 'no noise word' : 'all words are noise'
+    return { legs: { probe1: p1.took, probe2: 0, main: main.took }, total: fmtEst(p1.orSampled), top: main.top, note: `${why} → plain capped` }
+  }
+  let probe2Took = 0
+  let unionSampled: number
+  if (retained.length === 1) {
+    unionSampled = p1.solo[retained[0]]
+  } else {
+    const { took, counts } = await msearchCounts(q, [[orFilter(retained)]])
+    probe2Took = took
+    unionSampled = counts[0]
+  }
+  // below the floor the estimate is unreliable AND the set is selective → exact main query
+  const belowCap = unionSampled < floorSample
+  const main = await mainSearch(q, [orFilter(retained)], belowCap ? true : CAP)
+  return {
+    legs: { probe1: p1.took, probe2: probe2Took, main: main.took },
+    total: belowCap ? `${main.total.value.toLocaleString()} (eq)` : fmtEst(unionSampled),
+    top: main.top,
+    note: `ignore=[${ignored.join(',')}] retain=[${retained.join(',')}]${belowCap ? ' BELOW CAP' : ''}`
+  }
+}
+
+// ---- run ----
+
+const info = await es('GET', '/')
+const countRes = await es('GET', `/${values.index}/_count`)
+const corpus = countRes.count
+console.log(`\nES ${info.version.number} @ ${values.node} — ${values.index} (${corpus.toLocaleString()} docs), runs=${runs}, ${values.cold ? 'cold' : 'warm (request cache cleared)'}\n` +
+  `cap=${CAP} p=${P} floorSample=${floorSample} noise2pct=${Math.round(corpus * NOISE_2PCT).toLocaleString()} docs`)
+
+for (const q of QUERIES) {
+  const words = q.split(/\s+/)
+  console.log(`\n=== q="${q}"`)
+  const rows: Array<[string, RunResult & { p50: number, min: number }]> = []
+  rows.push(['or-exact (base)', await measure('or-exact', orExact(q))])
+  rows.push(['or-capped', await measure('or-capped', orCapped(q))])
+  if (words.length > 1) {
+    rows.push(['shipped-and', await measure('shipped-and', shippedAnd(q, words))])
+    rows.push(['or-capfloor', await measure('or-capfloor', orCapfloor(q, words))])
+    rows.push(['or-noise2pct', await measure('or-noise2pct', orNoise(q, words, NOISE_2PCT, corpus))])
+    rows.push(['or-noisecap', await measure('or-noisecap', orNoise(q, words, CAP / corpus, corpus))])
+  }
+  const baseTop = rows[0][1].top
+  console.log('variant'.padEnd(17) + '| e2e p50 | legs p1+p2+main | total            | top20 | note')
+  for (const [name, m] of rows) {
+    const overlap = `${m.top.filter(id => baseTop.includes(id)).length}/${baseTop.length}`
+    console.log(name.padEnd(17) +
+      `| ${String(m.p50).padStart(7)} | ${String(m.legs.probe1).padStart(4)}+${String(m.legs.probe2).padStart(3)}+${String(m.legs.main).padStart(4)}    | ${m.total.padEnd(16)} | ${overlap.padStart(5)} | ${m.note}`)
+  }
+}

--- a/docs/architecture/text-search-evaluation.md
+++ b/docs/architecture/text-search-evaluation.md
@@ -716,6 +716,16 @@ The real cost is not code but *tuning the decision rule* to make "same top page 
 true in the aggregate — measurable with `rna-check.ts` overlap metrics; a batch of real
 production query logs is the right calibration corpus.
 
+> **Amendment (2026-08-01).** The shipped `adapt` (#528) filtered on the *conjunction* of
+> the rarest words ("require the rarest, ignore the rest"). Re-benchmarked against the
+> OR-of-retained reading — filter = union of the non-ignored words, i.e. the plain search
+> minus docs that only matched ignored words — the OR form gives identical top-20 pages,
+> is cheaper wherever both designs act, adapts in cases the conjunction lattice cannot,
+> and matches the "some words were ignored" message users actually see. Filter semantics
+> were switched accordingly and the pinned pagination param renamed `q_required` →
+> `q_ignored` (a `min-bite` guard also keeps adapt a no-op on phrase-like queries whose
+> words co-occur). Evidence and decision rule: `benchmark/INVESTIGATIONS.md` §14.
+
 ## 8. Open questions
 
 - T4 boost-value calibration needs labelled relevance data — out of harness scope; flag for

--- a/docs/superpowers/plans/2026-08-01-adapt-or-of-retained.md
+++ b/docs/superpowers/plans/2026-08-01-adapt-or-of-retained.md
@@ -1,0 +1,609 @@
+# `q_mode=adapt` OR-of-retained Filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Change `q_mode=adapt` filter semantics from AND-of-required (conjunction of the rarest words) to OR-of-retained (the plain OR search minus documents that match *only* ignored words), replacing the `q_required` pagination param with `q_ignored`, so the behaviour finally matches the user-facing message "some words were ignored".
+
+**Architecture:** The preflight keeps its shape (one filters-agg probe on the `_rand` sample slice, one optional `_msearch`, strictest-first cap-floor selection) but candidates become "ignore the k most frequent words" with the retained words' **union** as the measured set; max/sum solo-count bounds eliminate most union counts. The main query keeps score-broad-match-strict: scores stay pure OR, the non-scoring filter becomes a single `bool`/`should` over the retained words. Evidence: `benchmark/INVESTIGATIONS.md` §14 (2026-08-01, RNA corpus, ES 7.17.28 + 8.19.9) — top-20 identical to plain OR everywhere, cheaper than the shipped design wherever both act, adapts in a case the conjunction lattice cannot, and the fixed-noise-threshold alternatives are refuted.
+
+**Tech Stack:** Node/TS API (`api/` workspace), Elasticsearch 7.17+ (plain `bool`/`multi_match` only), Playwright test projects (`unit` / `api`).
+
+## Global Constraints
+
+- **Production ES is 7.17.28** — the new filter uses only `bool`/`should`/`multi_match`, ES 7.0-compatible.
+- **THE INVARIANT is unchanged**: searches totalling under the cap run exactly as today; adapt never tightens a search below the exactness horizon (`floorSample = cap × probability × ADAPT_FLOOR_SAFETY`). §14 finding 5 re-validated the floor (a true-10 097 set sampled 101 < floor — boundary noise the safety margin exists to absorb).
+- **Scoring must never change**: requirements stay in non-scoring `filter` position (measured 2.5× slower otherwise, `load-management.md` §9); ignored words keep scoring (§14 finding 1 — this is what preserves 20/20 pages).
+- **`meta.ignoredWords` and `meta.totalMarginPct` keep their names and semantics** — UI (`ui/src/composables/dataset/lines.ts`, `dataset-nb-results.vue`, `dataset-table.vue`) reads them and needs no change.
+- **`q_required` is removed, not deprecated** (shipped yesterday in #528, unreleased to prod, documented "Ne pas construire manuellement"). Task 4 verifies unknown-param tolerance so stale links degrade gracefully.
+- TypeScript ratchet: pre-push runs `dev/check-types-ratchet.sh` — no net-new tsc errors.
+- Follow `docs/architecture/code-conventions.md`: pure logic in `operations.ts`, unit tests target pure functions only (never trick node config).
+- Run only related tests while iterating (`npx playwright test <file>`); the full suite runs on push.
+- Commits: `feat(datasets): …` style, one per task.
+- All work in the `chore-better-q-adapt` worktree (`/home/alban/data-fair/data-fair_chore-better-q-adapt`); its docker deps (ES 8.19.9, mongo, simple-directory) are already up. The bench `bench-rna` index coexists in that ES — tests `clean()` only their own aliases.
+
+---
+
+### Task 1: Pure layer — `parseQIgnored` + `buildOrAdaptCandidates`
+
+Additions only (nothing removed yet) so the tree stays green.
+
+**Files:**
+- Modify: `api/src/datasets/es/operations.ts` (append next to `parseQRequired` at ~880 and `chooseStrictestCandidate` at ~907)
+- Test: `tests/features/datasets/q-mode-operations.unit.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `parseQIgnored(q: string, raw: string): string[]` (400s on non-token or all-words-covered), `interface OrAdaptCandidate { ignored: string[], retained: string[], sampledCount: number | null }`, `buildOrAdaptCandidates(words: string[], soloSampledCount: Record<string, number>, orSampledCount: number, floorSample: number): OrAdaptCandidate[]` — ordered strictest-first, `sampledCount: null` marks candidates Task 3 must count via `_msearch`. `chooseStrictestCandidate` is reused as-is.
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Append to `tests/features/datasets/q-mode-operations.unit.spec.ts` (extend the import line with `parseQIgnored, buildOrAdaptCandidates`):
+
+```ts
+test('parseQIgnored accepts only whitespace tokens of q and must leave a word retained', () => {
+  assert.deepEqual(parseQIgnored('commun rare', 'commun'), ['commun'])
+  assert.deepEqual(parseQIgnored('commun alpha beta', ' commun , alpha '), ['commun', 'alpha'])
+  assert.throws(() => parseQIgnored('commun rare', 'absent'), { status: 400 })
+  assert.throws(() => parseQIgnored('commun rare', 'commu'), { status: 400 }) // partial words are not tokens
+  assert.throws(() => parseQIgnored('commun rare', 'commun,rare'), { status: 400 }) // nothing left to filter on
+  assert.throws(() => parseQIgnored('commun rare', 'commun,commun,rare'), { status: 400 }) // duplicates don't hide full coverage
+})
+
+test('buildOrAdaptCandidates orders strictest-first and lets bounds fill the counts', () => {
+  // rue-baudelaire shape: one rare pivot — the strictest candidate is decided by its solo count
+  const c1 = buildOrAdaptCandidates(['rue', 'baudelaire'], { rue: 14000, baudelaire: 7 }, 14119, 120)
+  assert.deepEqual(c1, [
+    { ignored: ['rue'], retained: ['baudelaire'], sampledCount: 7 }, // solo bound, disqualified
+    { ignored: [], retained: ['rue', 'baudelaire'], sampledCount: 14119 } // the plain-OR fallback
+  ])
+  // a qualifying single-word candidate stops the walk (nothing looser can be chosen)
+  const c2 = buildOrAdaptCandidates(['commun', 'rare'], { commun: 1030, rare: 100 }, 1100, 60)
+  assert.deepEqual(c2, [
+    { ignored: ['commun'], retained: ['rare'], sampledCount: 100 },
+    { ignored: [], retained: ['commun', 'rare'], sampledCount: 1100 }
+  ])
+  // sum-bound disqualifies without counting; max-bound qualifies and stops the walk with
+  // sampledCount null (Task 3 counts it for the display total)
+  const c3 = buildOrAdaptCandidates(
+    ['de', 'la', 'amis', 'bibliothèque'],
+    { de: 25000, la: 22000, amis: 750, bibliothèque: 101 },
+    30000, 120)
+  assert.deepEqual(c3, [
+    { ignored: ['de', 'la', 'amis'], retained: ['bibliothèque'], sampledCount: 101 }, // solo, disqualified
+    { ignored: ['de', 'la'], retained: ['amis', 'bibliothèque'], sampledCount: null }, // max 750 ≥ 120: chosen, needs its total
+    { ignored: [], retained: ['de', 'la', 'amis', 'bibliothèque'], sampledCount: 30000 }
+  ])
+  // sum-bound: two tiny words can be disqualified together without an ES count
+  const c4 = buildOrAdaptCandidates(['big', 'x', 'y'], { big: 5000, x: 20, y: 30 }, 5040, 120)
+  assert.equal(c4[1].sampledCount, 50) // {x,y} union ≤ 20+30 < 120 — no count needed
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd /home/alban/data-fair/data-fair_chore-better-q-adapt && npx playwright test tests/features/datasets/q-mode-operations.unit.spec.ts`
+Expected: FAIL — `parseQIgnored`/`buildOrAdaptCandidates` are not exported.
+
+- [ ] **Step 3: Implement the two pure functions**
+
+In `api/src/datasets/es/operations.ts`, after `parseQRequired`:
+
+```ts
+/**
+ * Parse and validate q_ignored — the words excluded from the non-scoring filter of the
+ * score-broad-match-strict shape (they keep scoring); pinned by q_mode=adapt in next
+ * links, or set manually. Every word must be a whitespace token of q, and at least one
+ * word of q must remain retained, else 400.
+ */
+export const parseQIgnored = (q: string, raw: string): string[] => {
+  const qWords = new Set(q.split(/\s+/))
+  const words = String(raw).split(',').map(word => word.trim()).filter(Boolean)
+  for (const word of words) {
+    if (!qWords.has(word)) throw httpError(400, `Le paramètre q_ignored contient "${word}" qui n'est pas un mot de la recherche q.`)
+  }
+  if (new Set(words).size >= qWords.size) throw httpError(400, 'Le paramètre q_ignored ne peut pas couvrir tous les mots de la recherche q.')
+  return words
+}
+
+export interface OrAdaptCandidate {
+  /** the words dropped from filtering, most frequent first */
+  ignored: string[]
+  /** the words whose OR forms the non-scoring filter */
+  retained: string[]
+  /** sampled size of the retained union; null = needs an ES count (bounds could not decide) */
+  sampledCount: number | null
+}
+
+/**
+ * Candidates for OR-of-retained adapt, ordered strictest-first: ignore the k most frequent
+ * words, k = words.length-1 … 0 (k=0 = nothing ignored, the plain OR — always last).
+ * Union-size bounds fill sampledCount without an ES count where they can: a single
+ * retained word IS its solo count; union ≤ sum(solo) < floor disqualifies; union ≥
+ * max(solo) ≥ floor qualifies outright — and since every stricter candidate already
+ * failed, that candidate will be chosen, so the walk stops there (its exact sampled count
+ * is still needed, for the display total). Measured to eliminate the second probe in most
+ * real queries — INVESTIGATIONS.md §14 finding 3.
+ */
+export const buildOrAdaptCandidates = (
+  words: string[],
+  soloSampledCount: Record<string, number>,
+  orSampledCount: number,
+  floorSample: number
+): OrAdaptCandidate[] => {
+  const byFreq = [...words].sort((a, b) => soloSampledCount[b] - soloSampledCount[a])
+  const candidates: OrAdaptCandidate[] = []
+  for (let k = words.length - 1; k >= 1; k--) {
+    const candidate: OrAdaptCandidate = { ignored: byFreq.slice(0, k), retained: byFreq.slice(k), sampledCount: null }
+    candidates.push(candidate)
+    const solos = candidate.retained.map(word => soloSampledCount[word])
+    const max = Math.max(...solos)
+    const sum = solos.reduce((a, b) => a + b, 0)
+    if (candidate.retained.length === 1) {
+      candidate.sampledCount = solos[0]
+      if (solos[0] >= floorSample) break
+    } else if (sum < floorSample) {
+      candidate.sampledCount = sum // disqualified either way — the ≤-bound is enough
+    } else if (max >= floorSample) {
+      break // qualified outright: chosen; only its display total still needs counting
+    }
+  }
+  candidates.push({ ignored: [], retained: byFreq, sampledCount: orSampledCount })
+  return candidates
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx playwright test tests/features/datasets/q-mode-operations.unit.spec.ts`
+Expected: PASS (including the pre-existing `parseQRequired`/`chooseStrictestCandidate` tests — nothing removed yet).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/src/datasets/es/operations.ts tests/features/datasets/q-mode-operations.unit.spec.ts
+git commit -m "feat(datasets): pure helpers for OR-of-retained adapt (parseQIgnored, candidate bounds)"
+```
+
+---
+
+### Task 2: Rewrite the API contract test to the OR semantics (red)
+
+The spec is rewritten *first* and must FAIL against the shipped AND implementation — that failure is the proof the new fixture discriminates the two designs.
+
+**Files:**
+- Modify: `tests/features/datasets/q-mode-adapt.api.spec.ts`
+
+**Interfaces:**
+- Consumes: the running worktree dev deps (ES + mongo + simple-directory docker services).
+- Produces: the executable contract Task 3 must turn green.
+
+- [ ] **Step 1: Extend the fixture with an OR-discriminating 3-word case**
+
+Replace the fixture block (lines 13–27). With 2-word queries, AND-of-one ≡ OR-of-one — only a 3-word query with *disjoint* rare-word rows separates the designs: under AND-of-retained `[alpha, beta]` the set would be empty, under OR it is both groups.
+
+```ts
+const id = 'qmodeadapt'
+// Deterministic word counts (test cap=100, dataset 2640 rows → probability clamps to 0.5,
+// floorSample = ceil(100 × 0.5 × 1.2) = 60 sampled docs = 120 true docs):
+//  - 60 rows   'commun rare …'      (count('rare') = 200 ≥ cap → "retain rare" qualifies; 'commun' ignored)
+//  - 140 rows  'rare autre …'
+//  - 2000 rows 'commun seulement …' (OR unions ≥ cap → adapt engages)
+//  - 200 rows  'grand ensemble …'   (phrase-like: the words co-occur, so ignoring one would
+//    exclude nothing — the min-bite guard must keep adapt a no-op, ignoredWords absent)
+//  - 40 rows   'petit exemple …'    (OR union 40 < cap → invariant: untouched)
+//  - 70 rows   'commun alpha …'  +  130 rows 'commun beta …'  (the OR proof: for
+//    q='commun alpha beta' adapt must ignore 'commun' and retain BOTH rare words —
+//    alpha-rows and beta-rows share no rare word, so a conjunction would return nothing;
+//    retained-union 200 ≥ 120 qualifies, keep-only-alpha 70 < 120 cannot, with safe
+//    sampling margins on both sides at p=0.5)
+const rows: Array<{ _id: string, str: string, n: number }> = []
+const push = (str: string) => rows.push({ _id: String(rows.length).padStart(5, '0'), str, n: rows.length })
+for (let i = 0; i < 60; i++) push('commun rare')
+for (let i = 0; i < 140; i++) push('rare autre')
+for (let i = 0; i < 2000; i++) push('commun seulement')
+for (let i = 0; i < 200; i++) push('grand ensemble')
+for (let i = 0; i < 40; i++) push('petit exemple')
+for (let i = 0; i < 70; i++) push('commun alpha')
+for (let i = 0; i < 130; i++) push('commun beta')
+```
+
+- [ ] **Step 2: Update the header comment and the tests to the OR contract**
+
+Header comment (lines 8–11):
+
+```ts
+// q_mode=or|and|adapt (see docs/superpowers/plans/2026-08-01-adapt-or-of-retained.md and
+// benchmark/INVESTIGATIONS.md §14). adapt = ignore the most common query words in filtering —
+// just enough that the RETAINED-WORD UNION stays above the cap — while every word keeps
+// scoring; the match set is the plain OR minus docs that only matched ignored words.
+// THE INVARIANT under test: searches totalling under the cap are untouched.
+```
+
+Test changes, in place:
+
+1. `'adapt drops the most common word …'` — unchanged assertions (`ignoredWords: ['commun']`, total 140–280, top result `'commun rare'`) — same outcome in both designs, keep as the continuity witness.
+
+2. Replace `'adapt keeps every word required when the strict set already clears the cap'` with the min-bite no-op test (the observable outcome for this fixture is unchanged — `ignoredWords` absent — but the mechanism is now the bite guard: ignoring `grand` would qualify yet exclude nothing, since the words co-occur):
+
+```ts
+  test('adapt ignores nothing when ignoring would not shrink the set (co-occurring words)', async () => {
+    const res = (await testUser1.get(`/api/v1/datasets/${id}/lines`, { params: { q: 'grand ensemble', q_mode: 'adapt' } })).data
+    assert.equal(res.meta.ignoredWords, undefined) // nothing was ignored → no field, just the estimate
+    assert.ok(Number.isInteger(res.meta.totalMarginPct))
+    assert.ok(res.total >= 140 && res.total < 280, `estimate ${res.total} implausible for true 200`)
+  })
+```
+
+3. NEW — the OR-semantics proof:
+
+```ts
+  test('retained words stay an OR: rows matching either rare word are all kept', async () => {
+    const res = (await testUser1.get(`/api/v1/datasets/${id}/lines`, { params: { q: 'commun alpha beta', q_mode: 'adapt', size: 100 } })).data
+    assert.deepEqual(res.meta.ignoredWords, ['commun'])
+    // the tightened set is the UNION of alpha-rows and beta-rows (70 + 130 = 200 — a
+    // conjunction of the retained words would be empty: no row contains both)
+    assert.ok(res.total >= 140 && res.total < 280, `estimate ${res.total} implausible for true 200`)
+    const strs = new Set(res.results.map((r: any) => r.str))
+    assert.ok(strs.has('commun alpha'), 'alpha-only rows must stay in the set')
+    assert.ok(strs.has('commun beta'), 'beta-only rows must stay in the set')
+  })
+```
+
+4. Replace the `q_required` direct test:
+
+```ts
+  test('q_ignored applies the filter directly, no preflight', async () => {
+    const res = (await testUser1.get(`/api/v1/datasets/${id}/lines`, { params: { q: 'commun rare', q_ignored: 'commun', count: 'exact' } })).data
+    assert.equal(res.total, 200) // docs matching the retained word 'rare'
+    assert.equal(res.meta, undefined)
+    const bad = await testUser1.get(`/api/v1/datasets/${id}/lines`, { params: { q: 'commun rare', q_ignored: 'absent' } }).catch((err: any) => err)
+    assert.equal(bad.status, 400) // q_ignored words must be tokens of q
+    const bad2 = await testUser1.get(`/api/v1/datasets/${id}/lines`, { params: { q: 'commun rare', q_ignored: 'commun,rare' } }).catch((err: any) => err)
+    assert.equal(bad2.status, 400) // at least one word must remain retained
+  })
+```
+
+5. `'adapt pins the exclusion in the next link'` — assert `res.next.includes('q_ignored=commun')` (the pinned param is now the ignored list — genuinely "the exclusion").
+
+6. `'a next-paginated chain enumerates exactly the tightened set'` — same 200-row expectations, pinned-param assert becomes `res.next.includes('q_ignored=commun')`.
+
+7. `'q_mode=or and count=exact keep the broad exact behaviour'` — the fixture grew: expected union for `'commun rare'` becomes `2200 + 70 + 130 = 2400` (`commun` now also matches the alpha/beta rows). Update `assert.equal(res.total, 2400)`.
+
+8. `'sqs syntax in q makes adapt step aside'` — `+commun rare` now truly matches `2060 + 200 = 2260` docs (commun required: 60+2000+70+130 = 2260). The existing `res.total >= 1600 && res.total < 2600` range still holds; update only the comment (`true 2260`).
+
+9. All other tests (`invariant`, `q_mode=and`, `numeric q_mode`, `default mode`, `hints`) — unchanged.
+
+- [ ] **Step 3: Run the spec to verify it fails against the shipped AND implementation**
+
+Run: `npx playwright test tests/features/datasets/q-mode-adapt.api.spec.ts`
+Expected: FAIL — at minimum the OR-proof test (shipped AND requires `[alpha, beta]`… which cannot qualify, so it degenerates differently — either way `ignoredWords`/results mismatch), the `q_ignored` tests (unknown param → no filter applied → totals wrong), and the next-link asserts (`q_required=` still pinned). The `'commun rare'` continuity test may still pass — that is expected and fine.
+
+- [ ] **Step 4: Commit the red spec**
+
+```bash
+git add tests/features/datasets/q-mode-adapt.api.spec.ts
+git commit -m "test(datasets): rewrite q_mode=adapt contract to OR-of-retained semantics (red)"
+```
+
+---
+
+### Task 3: The switchover — `buildQClauses`, `commons.ts`, `adaptive-q.ts`, `read.ts` (green)
+
+**Files:**
+- Modify: `api/src/datasets/es/operations.ts:484-546` (`buildQClauses`), `~880` (delete `parseQRequired`)
+- Modify: `api/src/datasets/es/commons.ts:338-339`
+- Modify: `api/src/datasets/es/adaptive-q.ts` (rewrite of the candidate/probe2 section + result shape)
+- Modify: `api/src/datasets/routes/read.ts:94-108`
+- Modify: `tests/features/datasets/q-mode-operations.unit.spec.ts` (drop the `parseQRequired` tests)
+
+**Interfaces:**
+- Consumes: `parseQIgnored`, `buildOrAdaptCandidates`, `OrAdaptCandidate`, `chooseStrictestCandidate` from Task 1.
+- Produces: `buildQClauses(dataset, q, qFields, qMode, sqsOptions?, ignoredWords?: string[])` (last param renamed and re-purposed), `AdaptResult { ignored: string[], total: number, marginPct: number }` from `runAdaptivePreflight` (the `required` field is gone).
+
+- [ ] **Step 1: `buildQClauses` — the filter becomes an OR over the retained words**
+
+Replace the tail of `buildQClauses` (operations.ts:530-546) — signature parameter `requiredWords?: string[]` becomes `ignoredWords?: string[]`:
+
+```ts
+  const scored = { bool: { should, minimum_should_match: 1 } }
+
+  // "score broad, match strict": q_mode=and and q_ignored tighten the MATCH SET through a
+  // non-scoring filter while scores stay pure OR — the page is OR's page restricted to the
+  // tightened set, and the filter leads the iteration. For q_ignored the filter is the OR
+  // of the retained (non-ignored) words: the match set is the plain OR minus docs that
+  // only matched ignored words — ignored words keep scoring. Requirements must NEVER move
+  // into scoring position (measured 2.5× slower on ES 7, see load-management.md §9).
+  // Not composed with `complete` mode (its prefix/wildcard clauses carry their own semantics).
+  if (qMode !== 'complete') {
+    const matchFields = reduced ? qSearchFields : [...qSearchFields, ...qStandardFields]
+    if (qMode === 'and' && matchFields.length) {
+      return { bool: { must: [scored], filter: [{ simple_query_string: { query: q, fields: matchFields, default_operator: 'and' } }] } }
+    }
+    if (ignoredWords?.length && matchFields.length) {
+      const retained = [...new Set(q.split(/\s+/))].filter(word => !ignoredWords.includes(word))
+      return {
+        bool: {
+          must: [scored],
+          filter: [{ bool: { should: retained.map(word => ({ multi_match: { query: word, fields: matchFields } })), minimum_should_match: 1 } }]
+        }
+      }
+    }
+  }
+  return scored
+```
+
+- [ ] **Step 2: `commons.ts` — parse `q_ignored` instead of `q_required`**
+
+At commons.ts:338-339 (and the matching import of `parseQRequired` at the top of the file):
+
+```ts
+      const ignoredWords = query.q_ignored ? parseQIgnored(q, query.q_ignored) : undefined
+      must.push(buildQClauses(dataset, q, qFields, qMode, sqsOptions, ignoredWords))
+```
+
+- [ ] **Step 3: Rewrite `adaptive-q.ts`**
+
+Replace the header comment, `AdaptResult`, and the candidate/probe2 section. The probe1 block (`orQuery`, `sampleSlice`, `wordMatchClauses`, the filters-agg search, `sampledCap`/`floorSample`, the `orSampledCount < sampledCap → null` early return) is unchanged except: `q_required: undefined` becomes `q_ignored: undefined` in the `prepareQuery` call, the word split gains a dedupe (`[...new Set(q.split(/\s+/))].slice(0, MAX_ADAPT_WORDS)`), and the import line pulls `buildOrAdaptCandidates, type OrAdaptCandidate` instead of nothing new.
+
+```ts
+// q_mode=adapt: ignore the most frequent words of the search in filtering — just enough of
+// them that the RETAINED-WORD UNION stays above the exactness horizon (the track_total_hits
+// cap) — while every word keeps scoring (see buildQClauses' score-broad-match-strict shape).
+// The match set is the plain OR search minus the docs that only matched ignored words.
+//
+// The decision is measured on the `_rand < randBound` sample slice, so every count in this
+// module is in SAMPLED DOCS (multiply by 1/probability for real counts). One size:0 search
+// returns the sampled count of the full OR search plus a per-word sampled count (filters
+// agg); union-size bounds decide most candidates from those alone (buildOrAdaptCandidates),
+// and the few undecided unions are counted in one _msearch.
+//
+// Outcomes (THE INVARIANT: searches totalling under the cap run exactly as today):
+//   - OR search under the cap                 → null (plain behaviour, exact total)
+//   - some words can be ignored               → { ignored: the most frequent }
+//   - nothing ignorable above the floor, or
+//     ignoring would not bite (co-occurring
+//     words: the union ≈ the full OR)        → { ignored: [] } (plain capped OR, sampled total)
+// The chosen candidate's sampled count also provides the response total, so the /lines
+// pipeline needs no separate count leg. Design evidence: benchmark/INVESTIGATIONS.md §14.
+
+export interface AdaptResult {
+  ignored: string[]
+  total: number
+  /** margin of error in percent (~95 % confidence, rounded up) — becomes meta.totalMarginPct */
+  marginPct: number
+}
+```
+
+The candidate/probe2/choose section (replacing lines 83–139 of the current file):
+
+```ts
+  // candidates strictest-first: ignore the k most frequent words, keep the rest as an OR
+  // filter. Union-size bounds fill most sampled counts without ES (see the helper's doc);
+  // the undecided unions are counted in one _msearch, each as a top-level filtered query
+  // (the retained-OR filter leads the iteration over its own posting lists).
+  const candidates = buildOrAdaptCandidates(words, wordSampledCount, orSampledCount, floorSample)
+  const needCounting = candidates.filter(candidate => candidate.sampledCount === null)
+
+  if (needCounting.length) {
+    const msearchBody = needCounting.flatMap(candidate => [
+      {},
+      {
+        size: 0,
+        track_total_hits: true,
+        // _msearch rejects a `timeout` querystring but accepts it per body — same ES-side
+        // bound as every other search (the client requestTimeout stays the backstop)
+        timeout: config.elasticsearch.searchTimeout,
+        query: {
+          bool: {
+            filter: [
+              orQuery,
+              { bool: { should: candidate.retained.map(word => wordMatchClauses[word]), minimum_should_match: 1 } },
+              sampleSlice
+            ]
+          }
+        }
+      }
+    ])
+    const res = await timedEsCall(abortContext, () => client.transport.request({
+      method: 'POST',
+      path: `/${aliasName(dataset)}/_msearch`,
+      bulkBody: msearchBody
+    }, { ...abortContext, meta: true }))
+    const responses: any[] = ((res as any).body).responses
+    for (const [i, candidate] of needCounting.entries()) {
+      if (responses[i].error) throw httpError(500, '[internal] adapt preflight msearch failed: ' + JSON.stringify(responses[i].error).slice(0, 200))
+      candidate.sampledCount = responses[i].hits.total.value
+    }
+  }
+
+  const chosen = chooseStrictestCandidate(candidates as Array<OrAdaptCandidate & { sampledCount: number }>, floorSample)
+
+  // an ignore-set must actually bite: when the query's words co-occur (phrase-like
+  // searches), the retained union covers (almost) the whole OR sample — filtering would
+  // exclude (almost) nothing and reporting "ignored" words would be pure noise. The two
+  // counts are nested on the same sample slice, so this comparison is exact, not
+  // statistical; and the union grows along looseness, so if the strictest candidate does
+  // not bite, no candidate does.
+  if (chosen.ignored.length && chosen.sampledCount >= orSampledCount * ADAPT_MIN_BITE) {
+    return {
+      ignored: [],
+      total: extrapolateApproxTotal(orSampledCount, mode),
+      marginPct: estimateMarginPct(orSampledCount)
+    }
+  }
+  return {
+    ignored: chosen.ignored,
+    total: extrapolateApproxTotal(chosen.sampledCount, mode),
+    marginPct: estimateMarginPct(chosen.sampledCount)
+  }
+```
+
+And in `operations.ts`, next to `ADAPT_FLOOR_SAFETY`:
+
+```ts
+/**
+ * Minimum "bite" for an adapt ignore-set: the retained union must exclude at least 2 % of
+ * the sampled OR set, else filtering is pointless overhead (phrase-like queries whose
+ * words co-occur) and adapt reports nothing ignored. Both counts are nested on the same
+ * sample slice — the comparison is exact. A UX constant, deliberately not configuration.
+ */
+export const ADAPT_MIN_BITE = 0.98
+```
+
+(`buildQClauses` stays imported for `wordMatchClauses`; the adaptive-q import line adds `buildOrAdaptCandidates`, `ADAPT_MIN_BITE` and `type OrAdaptCandidate`, and drops nothing else. The `Candidate` interface local to the old file is deleted — `OrAdaptCandidate` replaces it.)
+
+- [ ] **Step 4: `read.ts` — pin `q_ignored` in the mutated query**
+
+Replace read.ts:94-108:
+
+```ts
+  // q_mode=adapt: ignore over-common words in filtering (they keep scoring) so the retained
+  // union stays above the cap — see es/adaptive-q.ts. The preflight rewrites the effective
+  // query to q_ignored BEFORE the main search; `next` links inherit it from the mutated
+  // query, so after= pages replay the exact same tightened query with no preflight (chain
+  // consistency).
+  let ignoredWords: string[] | undefined
+  const resolvedQMode = query.q ? parseQMode(query.q_mode, DEFAULT_Q_MODE) : undefined
+  if (countMode && query.count !== 'estimate' && resolvedQMode === 'adapt' && !query.q_ignored) {
+    const adaptResult = await runAdaptivePreflight(req.app.get('es'), dataset, query, countMode, esAbortContext)
+    observe.reqStep(req, 'adaptPreflight')
+    if (adaptResult) {
+      // the transparency field only appears when adapt actually ignored at least one word
+      if (adaptResult.ignored.length) {
+        query.q_ignored = adaptResult.ignored.join(',')
+        ignoredWords = adaptResult.ignored
+      }
+      // the preflight already estimated the chosen candidate's total — no separate count leg needed
+      approxTotalThunk = () => Promise.resolve({ total: adaptResult.total, marginPct: adaptResult.marginPct })
+    }
+  }
+```
+
+- [ ] **Step 5: Delete `parseQRequired` and its unit tests**
+
+Remove `parseQRequired` from operations.ts and its test block from `q-mode-operations.unit.spec.ts` (keep the `parseQMode` and `chooseStrictestCandidate` tests — both functions survive).
+
+- [ ] **Step 6: Run unit + API specs to verify green**
+
+Run: `npx playwright test tests/features/datasets/q-mode-operations.unit.spec.ts tests/features/datasets/q-mode-adapt.api.spec.ts`
+Expected: PASS, all tests.
+
+- [ ] **Step 7: Ratchet + lint**
+
+Run: `bash dev/check-types-ratchet.sh && npm run lint`
+Expected: no net-new tsc errors, lint clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add api/src/datasets/es/operations.ts api/src/datasets/es/commons.ts api/src/datasets/es/adaptive-q.ts api/src/datasets/routes/read.ts tests/features/datasets/q-mode-operations.unit.spec.ts
+git commit -m "feat(datasets): q_mode=adapt filters on the OR of retained words (q_ignored replaces q_required)"
+```
+
+---
+
+### Task 4: Contract docs, param plumbing, stale-link tolerance, trace docs
+
+**Files:**
+- Modify: `api/contract/dataset-api-docs.ts:170-200` (q_mode + q_required→q_ignored param docs), `~723-726` (meta.ignoredWords description — verify, likely unchanged)
+- Modify: `api/src/misc/utils/query-advice.ts:70`
+- Modify: `docs/architecture/text-search-evaluation.md` §7 (amendment note)
+- Test: `tests/features/datasets/q-mode-adapt.api.spec.ts` (one added tolerance test)
+
+**Interfaces:**
+- Consumes: the Task 3 behaviour.
+- Produces: user-facing OpenAPI docs and the §7 design-trace amendment.
+
+- [ ] **Step 1: Verify unknown-param behaviour, then encode stale-`q_required`-link tolerance**
+
+Check what a stale #528-era next link does now: `GET /lines?q=commun rare&q_required=rare`. Read `query-advice.ts` around line 70 to see whether unlisted params 400 or merely produce a hint. Then add the test capturing the intended behaviour — a stale link must NOT 400; it re-runs the preflight and returns a coherent page:
+
+```ts
+  test('a stale q_required link (pre-rename #528) degrades gracefully', async () => {
+    const res = (await testUser1.get(`/api/v1/datasets/${id}/lines`, { params: { q: 'commun rare', q_required: 'rare' } })).data
+    assert.deepEqual(res.meta.ignoredWords, ['commun']) // the preflight re-ran; q_required is inert
+    assert.ok(res.total >= 140 && res.total < 280)
+  })
+```
+
+If the advice layer 400s on unknown params (or `query-advice.ts:70` gates them), keep `'q_required'` listed there alongside `'q_ignored'` with the comment `// tolerated pre-rename param (#528, never released) — remove after next release`; otherwise just rename the entry.
+
+- [ ] **Step 2: Update the OpenAPI param docs**
+
+In `api/contract/dataset-api-docs.ts`, the q_mode `adapt` paragraph becomes (only the first sentence's mechanics change — it now describes exactly what happens):
+
+```
+  Le mode "adapt" ignore automatiquement pour le filtrage les mots trop fréquents — juste assez pour que l'ensemble des résultats contenant au moins un des mots restants reste au-dessus du seuil de comptage exact ; les mots ignorés comptent toujours pour le classement et sont signalés dans la réponse (\`meta.ignoredWords\`). Une recherche dont le total est sous le seuil, ou utilisant la syntaxe d'opérateurs, n'est pas modifiée.
+```
+
+The `q_required` param block is replaced by:
+
+```ts
+  }, {
+    in: 'query',
+    name: 'q_ignored',
+    description: `
+  Paramètre technique renseigné automatiquement par le mode "adapt" dans les liens de pagination (\`next\`) pour garantir des pages cohérentes : liste de mots de la recherche "q" (séparés par des virgules) ignorés du filtrage — les résultats contiennent au moins un des autres mots de la recherche, les mots ignorés comptent toujours pour le classement. Ne pas construire manuellement.
+    `,
+    schema: {
+      title: 'Mots ignorés (pagination adapt)',
+      type: 'string'
+    }
+  }, {
+```
+
+Verify the `meta.ignoredWords` response-field description (~line 726) still reads correctly — it already says "ignoré des mots trop fréquents pour le filtrage (ils comptent toujours pour le classement)", which is now exactly true; leave it.
+
+- [ ] **Step 3: Amend `docs/architecture/text-search-evaluation.md` §7**
+
+Append at the end of §7:
+
+```markdown
+> **Amendment (2026-08-01).** The shipped `adapt` (#528) filtered on the *conjunction* of
+> the rarest words ("require the rarest, ignore the rest"). Re-benchmarked against the
+> OR-of-retained reading — filter = union of the non-ignored words, i.e. the plain search
+> minus docs that only matched ignored words — the OR form gives identical top-20 pages,
+> is cheaper wherever both designs act, adapts in cases the conjunction lattice cannot,
+> and matches the "some words were ignored" message users actually see. Filter semantics
+> were switched accordingly and the pinned pagination param renamed `q_required` →
+> `q_ignored`. Evidence and decision rule: `benchmark/INVESTIGATIONS.md` §14.
+```
+
+- [ ] **Step 4: Run the API spec, ratchet, lint**
+
+Run: `npx playwright test tests/features/datasets/q-mode-adapt.api.spec.ts && bash dev/check-types-ratchet.sh && npm run lint`
+Expected: PASS / no net-new errors / clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/contract/dataset-api-docs.ts api/src/misc/utils/query-advice.ts docs/architecture/text-search-evaluation.md tests/features/datasets/q-mode-adapt.api.spec.ts
+git commit -m "docs(datasets): q_ignored param docs, stale q_required tolerance, §7 amendment"
+```
+
+---
+
+### Task 5: Full verification sweep
+
+**Files:** none new — verification only.
+
+- [ ] **Step 1: Run every spec that exercises the adapt/approx machinery**
+
+Run: `npx playwright test tests/features/datasets/q-mode-adapt.api.spec.ts tests/features/datasets/q-mode-operations.unit.spec.ts tests/features/datasets/approx-count-operations.unit.spec.ts $(grep -rln "totalMarginPct\|ignoredWords\|q_mode" tests/features --include="*.spec.ts" | tr '\n' ' ')`
+Expected: PASS. Any spec still asserting `q_required` shows up here — fix it to `q_ignored` semantics before proceeding.
+
+- [ ] **Step 2: Grep for leftovers**
+
+Run: `grep -rn "q_required\|parseQRequired\|\brequired\b.*ignored" api/src api/contract ui/src --include="*.ts" --include="*.vue"`
+Expected: only the deliberate tolerance entry from Task 4 Step 1 (if the advice layer needed it) and historical mentions in `docs/superpowers/plans/2026-07-30-*` (leave those — plans are records).
+
+- [ ] **Step 3: Final ratchet + lint + build-types sanity**
+
+Run: `bash dev/check-types-ratchet.sh && npm run lint`
+Expected: clean. (Full suite runs on push via husky.)
+
+- [ ] **Step 4: Commit anything the sweep fixed**
+
+```bash
+git add -A && git commit -m "fix(datasets): sweep fixes from adapt OR-semantics verification" # only if the sweep changed files
+```

--- a/tests/features/datasets/q-mode-adapt.api.spec.ts
+++ b/tests/features/datasets/q-mode-adapt.api.spec.ts
@@ -5,19 +5,26 @@ import { waitForFinalize, setConfig } from '../../support/workers.ts'
 
 const testUser1 = await axiosAuth('test_user1@test.com')
 
-// q_mode=or|and|adapt (see docs/superpowers/plans/2026-07-30-approx-count-ranked-search.md
-// Tasks 6-8). adapt = ignore the most common query words in filtering — just enough that the
-// filtered set stays above the cap — while every word keeps scoring; report the ignored words.
+// q_mode=or|and|adapt (see docs/superpowers/plans/2026-08-01-adapt-or-of-retained.md and
+// benchmark/INVESTIGATIONS.md §14). adapt = ignore the most common query words in filtering —
+// just enough that the RETAINED-WORD UNION stays above the cap — while every word keeps
+// scoring; the match set is the plain OR minus docs that only matched ignored words.
 // THE INVARIANT under test: searches totalling under the cap are untouched.
 
 const id = 'qmodeadapt'
-// Deterministic word counts (test cap=100, dataset 2440 rows → probability clamps to 0.5,
+// Deterministic word counts (test cap=100, dataset 2640 rows → probability clamps to 0.5,
 // floorSample = ceil(100 × 0.5 × 1.2) = 60 sampled docs = 120 true docs):
-//  - 60 rows   'commun rare …'      (AND set 60 < ~120 → 'commun' must be dropped from filtering)
-//  - 140 rows  'rare autre …'       (count('rare') = 200 ≥ cap → the candidate "require rare" qualifies)
-//  - 2000 rows 'commun seulement …' (OR union 2200 ≥ cap → adapt engages)
-//  - 200 rows  'grand ensemble …'   (AND set 200 → nothing needs dropping)
+//  - 60 rows   'commun rare …'      (count('rare') = 200 ≥ cap → "retain rare" qualifies; 'commun' ignored)
+//  - 140 rows  'rare autre …'
+//  - 2000 rows 'commun seulement …' (OR unions ≥ cap → adapt engages)
+//  - 200 rows  'grand ensemble …'   (phrase-like: the words co-occur, so ignoring one would
+//    exclude nothing — the min-bite guard must keep adapt a no-op, ignoredWords absent)
 //  - 40 rows   'petit exemple …'    (OR union 40 < cap → invariant: untouched)
+//  - 70 rows   'commun alpha …'  +  130 rows 'commun beta …'  (the OR proof: for
+//    q='commun alpha beta' adapt must ignore 'commun' and retain BOTH rare words —
+//    alpha-rows and beta-rows share no rare word, so a conjunction would return nothing;
+//    retained-union 200 ≥ 120 qualifies, keep-only-alpha 70 < 120 cannot, with safe
+//    sampling margins on both sides at p=0.5)
 const rows: Array<{ _id: string, str: string, n: number }> = []
 const push = (str: string) => rows.push({ _id: String(rows.length).padStart(5, '0'), str, n: rows.length })
 for (let i = 0; i < 60; i++) push('commun rare')
@@ -25,6 +32,8 @@ for (let i = 0; i < 140; i++) push('rare autre')
 for (let i = 0; i < 2000; i++) push('commun seulement')
 for (let i = 0; i < 200; i++) push('grand ensemble')
 for (let i = 0; i < 40; i++) push('petit exemple')
+for (let i = 0; i < 70; i++) push('commun alpha')
+for (let i = 0; i < 130; i++) push('commun beta')
 
 const defaultCfg = { minDatasetSize: 100000, cap: 10000, sampleTarget: 20000 }
 const testCfg = { minDatasetSize: 1000, cap: 100, sampleTarget: 1000 }
@@ -60,11 +69,22 @@ test.describe('q_mode adapt — common words ignored in filtering', () => {
     assert.equal(res.results[0].str, 'commun rare')
   })
 
-  test('adapt keeps every word required when the strict set already clears the cap', async () => {
+  test('adapt ignores nothing when ignoring would not shrink the set (co-occurring words)', async () => {
     const res = (await testUser1.get(`/api/v1/datasets/${id}/lines`, { params: { q: 'grand ensemble', q_mode: 'adapt' } })).data
     assert.equal(res.meta.ignoredWords, undefined) // nothing was ignored → no field, just the estimate
     assert.ok(Number.isInteger(res.meta.totalMarginPct))
     assert.ok(res.total >= 140 && res.total < 280, `estimate ${res.total} implausible for true 200`)
+  })
+
+  test('retained words stay an OR: rows matching either rare word are all kept', async () => {
+    const res = (await testUser1.get(`/api/v1/datasets/${id}/lines`, { params: { q: 'commun alpha beta', q_mode: 'adapt', size: 100 } })).data
+    assert.deepEqual(res.meta.ignoredWords, ['commun'])
+    // the tightened set is the UNION of alpha-rows and beta-rows (70 + 130 = 200 — a
+    // conjunction of the retained words would be empty: no row contains both)
+    assert.ok(res.total >= 140 && res.total < 280, `estimate ${res.total} implausible for true 200`)
+    const strs = new Set(res.results.map((r: any) => r.str))
+    assert.ok(strs.has('commun alpha'), 'alpha-only rows must stay in the set')
+    assert.ok(strs.has('commun beta'), 'beta-only rows must stay in the set')
   })
 
   test('the invariant: searches under the cap are untouched by adapt', async () => {
@@ -73,17 +93,19 @@ test.describe('q_mode adapt — common words ignored in filtering', () => {
     assert.equal(res.meta, undefined)
   })
 
-  test('q_required applies the filter directly, no preflight', async () => {
-    const res = (await testUser1.get(`/api/v1/datasets/${id}/lines`, { params: { q: 'commun rare', q_required: 'rare', count: 'exact' } })).data
-    assert.equal(res.total, 200)
+  test('q_ignored applies the filter directly, no preflight', async () => {
+    const res = (await testUser1.get(`/api/v1/datasets/${id}/lines`, { params: { q: 'commun rare', q_ignored: 'commun', count: 'exact' } })).data
+    assert.equal(res.total, 200) // docs matching the retained word 'rare'
     assert.equal(res.meta, undefined)
-    const bad = await testUser1.get(`/api/v1/datasets/${id}/lines`, { params: { q: 'commun rare', q_required: 'absent' } }).catch((err: any) => err)
-    assert.equal(bad.status, 400) // q_required words must be tokens of q
+    const bad = await testUser1.get(`/api/v1/datasets/${id}/lines`, { params: { q: 'commun rare', q_ignored: 'absent' } }).catch((err: any) => err)
+    assert.equal(bad.status, 400) // q_ignored words must be tokens of q
+    const bad2 = await testUser1.get(`/api/v1/datasets/${id}/lines`, { params: { q: 'commun rare', q_ignored: 'commun,rare' } }).catch((err: any) => err)
+    assert.equal(bad2.status, 400) // at least one word must remain retained
   })
 
   test('adapt pins the exclusion in the next link', async () => {
     const res = (await testUser1.get(`/api/v1/datasets/${id}/lines`, { params: { q: 'commun rare', q_mode: 'adapt', size: 10 } })).data
-    assert.ok(res.next.includes('q_required=rare'), res.next)
+    assert.ok(res.next.includes('q_ignored=commun'), res.next)
   })
 
   test('q_mode=and stays available as a manual mode', async () => {
@@ -105,7 +127,7 @@ test.describe('q_mode adapt — common words ignored in filtering', () => {
   test('q_mode=or and count=exact keep the broad exact behaviour', async () => {
     for (const params of [{ q: 'commun rare', count: 'exact' }, { q: 'commun rare', q_mode: 'or', count: 'exact' }] as Record<string, any>[]) {
       const res = (await testUser1.get(`/api/v1/datasets/${id}/lines`, { params })).data
-      assert.equal(res.total, 2200) // union (60 both-words rows counted once)
+      assert.equal(res.total, 2400) // union (60 both-words rows counted once, plus the alpha/beta commun rows)
       assert.equal(res.meta, undefined)
     }
   })
@@ -116,7 +138,7 @@ test.describe('q_mode adapt — common words ignored in filtering', () => {
     const res = (await testUser1.get(`/api/v1/datasets/${id}/lines`, { params: { q: '+commun rare', q_mode: 'adapt' } })).data
     assert.equal(res.meta.ignoredWords, undefined)
     assert.ok(Number.isInteger(res.meta.totalMarginPct))
-    assert.ok(res.total >= 1600 && res.total < 2600, `estimate ${res.total} implausible for true 2060`)
+    assert.ok(res.total >= 1600 && res.total < 2600, `estimate ${res.total} implausible for true 2260`)
   })
 
   test('the ignored words are reported once, as data — never duplicated as a hint', async () => {
@@ -135,7 +157,7 @@ test.describe('q_mode adapt — common words ignored in filtering', () => {
       assert.ok(page < 10, 'chain must terminate')
       const res: any = (await testUser1.get(url)).data
       collected.push(...res.results.map((r: any) => r._id))
-      if (res.next) assert.ok(res.next.includes('q_required=rare'), res.next)
+      if (res.next) assert.ok(res.next.includes('q_ignored=commun'), res.next)
       url = res.next
     }
     assert.equal(collected.length, 200)

--- a/tests/features/datasets/q-mode-adapt.api.spec.ts
+++ b/tests/features/datasets/q-mode-adapt.api.spec.ts
@@ -103,6 +103,15 @@ test.describe('q_mode adapt — common words ignored in filtering', () => {
     assert.equal(bad2.status, 400) // at least one word must remain retained
   })
 
+  test('a stale q_required link (pre-rename #528) degrades gracefully', async () => {
+    // q_required shipped in #528 and was renamed before any release; a stale next link
+    // must not 400 — the unknown param is dropped (with a hint) and the preflight re-runs
+    const res = (await testUser1.get(`/api/v1/datasets/${id}/lines`, { params: { q: 'commun rare', q_required: 'rare' } })).data
+    assert.deepEqual(res.meta.ignoredWords, ['commun']) // the preflight re-ran; q_required is inert
+    assert.ok(res.meta.hints.some((h: string) => h.includes('q_required')), JSON.stringify(res.meta.hints))
+    assert.ok(res.total >= 140 && res.total < 280)
+  })
+
   test('adapt pins the exclusion in the next link', async () => {
     const res = (await testUser1.get(`/api/v1/datasets/${id}/lines`, { params: { q: 'commun rare', q_mode: 'adapt', size: 10 } })).data
     assert.ok(res.next.includes('q_ignored=commun'), res.next)

--- a/tests/features/datasets/q-mode-operations.unit.spec.ts
+++ b/tests/features/datasets/q-mode-operations.unit.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test'
 import assert from 'node:assert/strict'
-import { parseQMode, parseQRequired, parseQIgnored, buildOrAdaptCandidates, chooseStrictestCandidate } from '../../../api/src/datasets/es/operations.ts'
+import { parseQMode, parseQIgnored, buildOrAdaptCandidates, chooseStrictestCandidate } from '../../../api/src/datasets/es/operations.ts'
 
 test('parseQMode accepts the legacy and new modes', () => {
   assert.equal(parseQMode(undefined, 'simple'), 'simple')
@@ -12,14 +12,6 @@ test('parseQMode accepts the legacy and new modes', () => {
   assert.equal(parseQMode('adapt', 'simple'), 'adapt')
   assert.throws(() => parseQMode('3', 'simple'), { status: 400 }) // numeric msm deliberately not supported
   assert.throws(() => parseQMode('bogus', 'simple'), { status: 400 })
-})
-
-test('parseQRequired accepts only whitespace tokens of q', () => {
-  assert.deepEqual(parseQRequired('commun rare', 'rare'), ['rare'])
-  assert.deepEqual(parseQRequired('commun rare', 'rare,commun'), ['rare', 'commun'])
-  assert.deepEqual(parseQRequired('commun rare', ' rare , '), ['rare']) // trimmed, empties dropped
-  assert.throws(() => parseQRequired('commun rare', 'absent'), { status: 400 })
-  assert.throws(() => parseQRequired('commun rare', 'rar'), { status: 400 }) // partial words are not tokens
 })
 
 test('parseQIgnored accepts only whitespace tokens of q and must leave a word retained', () => {

--- a/tests/features/datasets/q-mode-operations.unit.spec.ts
+++ b/tests/features/datasets/q-mode-operations.unit.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test'
 import assert from 'node:assert/strict'
-import { parseQMode, parseQRequired, chooseStrictestCandidate } from '../../../api/src/datasets/es/operations.ts'
+import { parseQMode, parseQRequired, parseQIgnored, buildOrAdaptCandidates, chooseStrictestCandidate } from '../../../api/src/datasets/es/operations.ts'
 
 test('parseQMode accepts the legacy and new modes', () => {
   assert.equal(parseQMode(undefined, 'simple'), 'simple')
@@ -20,6 +20,44 @@ test('parseQRequired accepts only whitespace tokens of q', () => {
   assert.deepEqual(parseQRequired('commun rare', ' rare , '), ['rare']) // trimmed, empties dropped
   assert.throws(() => parseQRequired('commun rare', 'absent'), { status: 400 })
   assert.throws(() => parseQRequired('commun rare', 'rar'), { status: 400 }) // partial words are not tokens
+})
+
+test('parseQIgnored accepts only whitespace tokens of q and must leave a word retained', () => {
+  assert.deepEqual(parseQIgnored('commun rare', 'commun'), ['commun'])
+  assert.deepEqual(parseQIgnored('commun alpha beta', ' commun , alpha '), ['commun', 'alpha'])
+  assert.throws(() => parseQIgnored('commun rare', 'absent'), { status: 400 })
+  assert.throws(() => parseQIgnored('commun rare', 'commu'), { status: 400 }) // partial words are not tokens
+  assert.throws(() => parseQIgnored('commun rare', 'commun,rare'), { status: 400 }) // nothing left to filter on
+  assert.throws(() => parseQIgnored('commun rare', 'commun,commun,rare'), { status: 400 }) // duplicates don't hide full coverage
+})
+
+test('buildOrAdaptCandidates orders strictest-first and lets bounds fill the counts', () => {
+  // rue-baudelaire shape: one rare pivot — the strictest candidate is decided by its solo count
+  const c1 = buildOrAdaptCandidates(['rue', 'baudelaire'], { rue: 14000, baudelaire: 7 }, 14119, 120)
+  assert.deepEqual(c1, [
+    { ignored: ['rue'], retained: ['baudelaire'], sampledCount: 7 }, // solo bound, disqualified
+    { ignored: [], retained: ['rue', 'baudelaire'], sampledCount: 14119 } // the plain-OR fallback
+  ])
+  // a qualifying single-word candidate stops the walk (nothing looser can be chosen)
+  const c2 = buildOrAdaptCandidates(['commun', 'rare'], { commun: 1030, rare: 100 }, 1100, 60)
+  assert.deepEqual(c2, [
+    { ignored: ['commun'], retained: ['rare'], sampledCount: 100 },
+    { ignored: [], retained: ['commun', 'rare'], sampledCount: 1100 }
+  ])
+  // sum-bound disqualifies without counting; max-bound qualifies and stops the walk with
+  // sampledCount null (the preflight counts it for the display total)
+  const c3 = buildOrAdaptCandidates(
+    ['de', 'la', 'amis', 'bibliothèque'],
+    { de: 25000, la: 22000, amis: 750, bibliothèque: 101 },
+    30000, 120)
+  assert.deepEqual(c3, [
+    { ignored: ['de', 'la', 'amis'], retained: ['bibliothèque'], sampledCount: 101 }, // solo, disqualified
+    { ignored: ['de', 'la'], retained: ['amis', 'bibliothèque'], sampledCount: null }, // max 750 ≥ 120: chosen, needs its total
+    { ignored: [], retained: ['de', 'la', 'amis', 'bibliothèque'], sampledCount: 30000 }
+  ])
+  // sum-bound: two tiny words can be disqualified together without an ES count
+  const c4 = buildOrAdaptCandidates(['big', 'x', 'y'], { big: 5000, x: 20, y: 30 }, 5040, 120)
+  assert.equal(c4[1].sampledCount, 50) // {x,y} union ≤ 20+30 < 120 — no count needed
 })
 
 test('chooseStrictestCandidate picks the strictest candidate clearing the floor', () => {


### PR DESCRIPTION
`q_mode=adapt` now filters on the **union** of the retained words instead of a conjunction of the rarest ones: the match set is the plain OR search minus documents that only matched ignored words, scores stay pure OR, and page 1 is unchanged. The pagination param pinned in `next` links is renamed `q_required` → `q_ignored` (never released; stale links degrade gracefully via a hint and a re-run preflight — tested). A new min-bite guard keeps adapt a no-op on phrase-like queries whose words co-occur, where ignoring would exclude nothing.

**Why:** the shipped #528 semantics quietly required the rarest words together, which contradicted both the adapt objective (return as much as possible the same results as the plain search, minus noise) and the user-facing message ("some words were ignored", `meta.ignoredWords`).

Grounded in a new benchmark round on the RNA corpus (3.3M rows, ES 7.17.28 + 8.19.9), recorded as `benchmark/INVESTIGATIONS.md` §14: top-20 pages identical to plain OR everywhere for both designs; the OR form is cheaper wherever both act (union-size bounds eliminate the second probe in most queries — e.g. 73.5 → 32 ms on "comité des fêtes saint pierre", ES 7 warm), adapts in cases the conjunction lattice cannot ("les amis de la bibliothèque": ~3M → ~88k where AND gave up), and fixed noise-threshold alternatives are refuted.