### PR TITLE
fix(datasets): line expiration without explicit delay unit deleted all past-dated lines

### DIFF
--- a/api/src/datasets/utils/rest.ts
+++ b/api/src/datasets/utils/rest.ts
@@ -1522,7 +1522,9 @@ export const count = (dataset: RestDataset, filter?: Filter<DatasetLine>) => {
 
 export const applyTTL = async (dataset: RestDataset) => {
   if (!dataset.rest.ttl) return
-  const qs = `${dataset.rest.ttl.prop}:[* TO ${moment().subtract(dataset.rest.ttl.delay.value, dataset.rest.ttl.delay.unit).toISOString()}]`
+  // delay.unit is often absent (the UI only sends delay.value and schema defaults are not
+  // injected at validation), and moment interprets an undefined unit as milliseconds
+  const qs = `${dataset.rest.ttl.prop}:[* TO ${moment().subtract(dataset.rest.ttl.delay.value, dataset.rest.ttl.delay.unit || 'days').toISOString()}]`
 
   const summary = initSummary()
   // @ts-ignore

--- a/tests/features/datasets/rest/rest-datasets-history.api.spec.ts
+++ b/tests/features/datasets/rest/rest-datasets-history.api.spec.ts
@@ -283,6 +283,33 @@ test.describe('REST datasets - History', () => {
     assert.equal(res.data.total, 1)
   })
 
+  // the UI configures TTL without delay.unit and the patch validator does not inject the
+  // schema default, so the stored config must still be interpreted as days (not milliseconds)
+  test('Apply a TTL configured without an explicit delay unit', async () => {
+    const ax = testUser4
+    await ax.post('/api/v1/datasets/restttlnounit', {
+      isRest: true,
+      title: 'restttlnounit',
+      rest: {
+        ttl: {
+          active: true,
+          prop: 'attr2',
+          delay: {
+            value: 1
+          }
+        }
+      },
+      schema: [{ key: 'attr1', type: 'string' }, { key: 'attr2', type: 'string', format: 'date-time' }]
+    })
+    await ax.post('/api/v1/datasets/restttlnounit/lines', { attr1: 'test1', attr2: moment().subtract(3, 'days').toISOString() })
+    await ax.post('/api/v1/datasets/restttlnounit/lines', { attr1: 'test1', attr2: moment().subtract(2, 'days').toISOString() })
+    await ax.post('/api/v1/datasets/restttlnounit/lines', { attr1: 'test1', attr2: moment().subtract(1, 'hours').toISOString() })
+    await waitForFinalize(ax, 'restttlnounit')
+    await waitForFinalize(ax, 'restttlnounit')
+    const res = await ax.get('/api/v1/datasets/restttlnounit/lines')
+    assert.equal(res.data.total, 1)
+  })
+
   test('Applying the exact same data twice in history mode should not duplicate revisions', async () => {
     const ax = await testUser4
     let res = await ax.post('/api/v1/datasets/resthistidem', {

--- a/ui/src/components/dataset/rest/dataset-rest-ttl-menu.vue
+++ b/ui/src/components/dataset/rest/dataset-rest-ttl-menu.vue
@@ -130,6 +130,7 @@ watch(() => props.ttl, () => {
 
 function change () {
   editTtl.value.delay.value = editTtl.value.delay.value || 0
+  editTtl.value.delay.unit = editTtl.value.delay.unit || 'days'
   const result = { ...editTtl.value }
   if (props.revisions) delete result.prop
   emit('change', result)


### PR DESCRIPTION
Line expiration (`rest.ttl`) configured through the UI deleted **all** lines whose reference date was in the past — including same-day lines — on every hourly TTL pass, regardless of the configured number of days.

**Root cause:** the UI only sends `rest.ttl.delay.value` and the patch validator does not inject the schema default for `unit`, so `applyTTL` called `moment().subtract(value, undefined)` — which moment interprets as **milliseconds**. The cutoff was effectively "now".

**What changed:**
- `applyTTL` falls back to `'days'` when `delay.unit` is absent (same guard the `historyTTL` path already had), which fixes every already-stored config with no migration.
- The TTL menu now stores `unit: 'days'` explicitly on save.
- Regression test: a TTL posted without `unit` (the UI shape) now only deletes expired lines (previously wiped everything).
