### PR TITLE
fix(datasets): bump finalizedAt on slug change to bust stale caches

### DIFF
--- a/api/src/datasets/utils/patch.ts
+++ b/api/src/datasets/utils/patch.ts
@@ -120,6 +120,18 @@ export const preparePatch = async (app: any, patch: any, dataset: any, sessionSt
     patch.dataUpdatedBy = patch.updatedBy
   }
 
+  // `patch.slug` survived the no-op filtering above, so the slug really changed. A slug is part of the
+  // URL a dataset is addressed by on a publication site, hence of the proxy cache key: moving it to
+  // another dataset lets stored entries revalidate against a date that no longer identifies their
+  // content. Bumping finalizedAt past any date previously served under that slug is what makes those
+  // stale validators unusable — see docs/architecture/caching.md "Why a slug change bumps finalizedAt"
+  // for the two false-304 mechanisms, why finalizedAt is the right field, and what stays uncovered.
+  // Only for an already finalized dataset: its presence is a "has been finalized" flag elsewhere.
+  // The next whole second, not `now`: Last-Modified is second-precision and equal reads as unmodified.
+  if (patch.slug && dataset.finalizedAt) {
+    patch.finalizedAt = new Date(Math.floor(Date.parse(patch.updatedAt) / 1000) * 1000 + 1000).toISOString()
+  }
+
   if (patch.extensions) extensions.prepareExtensions(locale, patch.extensions, dataset.extensions ?? [])
   // extendedSchema computed by either branch below already covers everything checkConstraints
   // needs (real columns with their final type/x-capabilities/x-refersTo, plus x-calculated and

--- a/docs/architecture/caching.md
+++ b/docs/architecture/caching.md
@@ -217,10 +217,45 @@ Related top-level keys: `remoteAttachmentCacheDuration`, `extensionUpdateDelay`,
 - **Memoize caches** are deliberately short (30 s datasets, 1 min settings/ODS, 1 h pure compiled
   artefacts whose key already includes `finalizedAt`/`updatedAt`). The dataset one additionally has
   the `getDatasetFresh` validation path and the `?updatedAt=`/`?finalizedAt=` bypass.
+- **Slug changes** bump `finalizedAt` (`datasets/utils/patch.ts`, right after `updatedAt` is stamped) —
+  see below.
 - **Cache busting**: the `x-fg87fa6658fpbuia83hb8` header/cookie (or `x-cache-bypass` in the test
   harness) makes the proxy bypass its cache; `DELETE /api/v1/test-env/dataset-cache` and
   `…/publication-sites-cache` clear the memoize caches; restarting the proxy empties the
   (ephemeral) reverse-proxy cache; restarting an API/worker process empties its memoize caches.
+
+### Why a slug change bumps `finalizedAt`
+
+On a publication site a dataset is addressed by its **slug** (`getByUniqueRef`, and `_uniqueRefs` only
+ever holds the *current* slug), so the slug is part of the proxy cache key. Changing it moves which
+dataset a URL designates, while stored entries — proxy and browser — keep revalidating against
+`Last-Modified` (= `finalizedAt` on the data endpoints). Two ways that revalidation then lies:
+
+1. `resourceBased`'s own date short-circuit is an exact match on the **second-truncated** UTC date and
+   runs *before* anything ETag-related — a mismatching `If-None-Match` does not prevent it. Two
+   datasets finalized in the same second (a batch import) collide.
+2. Express's `fresh()` treats `If-Modified-Since >= Last-Modified` as "not modified", so a slug taken
+   over by a dataset finalized **earlier** answers 304 to a client holding the previous occupant's
+   date. The body ETag saves clients that send `If-None-Match` (nginx does); one that revalidates on
+   the date alone is not covered.
+
+Either way the proxy refreshes the *previous* occupant's response for another full max-age, and repeats
+— a self-renewing stale entry, not a bounded window. So `preparePatch` sets `finalizedAt` to the next
+whole second after `updatedAt` whenever the slug actually changes (and only if the dataset was already
+finalized — its presence is a "has been finalized" flag elsewhere). Rounding up matters: a plain `now`
+still compares equal to anything served in that same second, and equal reads as "not modified" in both
+mechanisms above.
+
+`finalizedAt` is the right knob because it is what the data endpoints send as `Last-Modified` and
+timestamp their URLs with, it is in integrity's `EXCLUDED_TOP_LEVEL` (no snapshot coverage, no outbox
+stamping), and it is absent from the user-facing `_modified` (`compute-modified.ts`), from DCAT and from
+the ODS-compat surface. The cost is that the dataset's Mongo vector-tile entries (keyed on
+`finalizedAt`) are discarded and regenerate. Applications need no equivalent: their `resourceBased()`
+uses `updatedAt`, which a slug change already moves.
+
+Not covered: entries that never revalidate during their lifetime — the `publicMaxAge` window on plain
+URLs, and timestamped entries, whose keys embed `finalizedAt` so a cross-dataset collision would need
+two datasets finalized at the identical timestamp.
 
 ## Known sharp edges
 

--- a/tests/features/datasets/query/cache-headers.api.spec.ts
+++ b/tests/features/datasets/query/cache-headers.api.spec.ts
@@ -152,4 +152,40 @@ test.describe('Cache headers', () => {
     assert.equal(res.headers['cache-control'], 'must-revalidate, public, max-age=' + config.cache.publicMaxAge)
     assert.equal(res.data.count, 1)
   })
+
+  // a slug change moves which dataset a slug-addressed URL designates, while proxies and browsers keep
+  // entries keyed on that URL and revalidate them against finalizedAt. Bumping finalizedAt is what makes
+  // the stale validator unusable — see docs/architecture/caching.md
+  test('Changing the slug bumps finalizedAt so a stale validator cannot match', async () => {
+    const ax = testUser1
+    // dsB is finalized first, so its date is older than dsA's: a client holding dsA's Last-Modified
+    // would otherwise get a 304 out of dsB after taking over dsA's slug
+    const dsB = await createDataset(ax)
+    await new Promise(resolve => setTimeout(resolve, 1100))
+    const dsA = await createDataset(ax)
+    assert.ok(new Date(dsB.finalizedAt) < new Date(dsA.finalizedAt), 'dsB must be finalized before dsA')
+
+    const slug = 'reused-' + nanoid().toLowerCase().replace(/[^a-z0-9]/g, '')
+    const patched = (await ax.patch(`/api/v1/datasets/${dsB.id}`, { slug })).data
+    assert.equal(patched.slug, slug)
+    assert.ok(new Date(patched.finalizedAt) > new Date(dsA.finalizedAt), 'the slug change must bump finalizedAt past any previously served date')
+
+    // the date based short-circuit of resourceBased no longer matches the stale validator
+    const res = await ax.get(`/api/v1/datasets/${dsB.id}/lines`, { headers: { 'if-modified-since': new Date(dsA.finalizedAt).toUTCString() } })
+    assert.equal(res.status, 200)
+
+    // a patch that does not touch the slug must not invalidate anything
+    const repatched = (await ax.patch(`/api/v1/datasets/${dsB.id}`, { title: 'another title' })).data
+    assert.equal(repatched.finalizedAt, patched.finalizedAt)
+  })
+
+  test('Changing the slug of a dataset that was never finalized does not give it a finalizedAt', async () => {
+    const ax = testUser1
+    const dataset = (await ax.post('/api/v1/datasets', { isMetaOnly: true, title: 'meta only ' + nanoid() })).data
+    assert.ok(!dataset.finalizedAt)
+    const slug = 'meta-' + nanoid().toLowerCase().replace(/[^a-z0-9]/g, '')
+    const patched = (await ax.patch(`/api/v1/datasets/${dataset.id}`, { slug })).data
+    assert.equal(patched.slug, slug)
+    assert.ok(!patched.finalizedAt, 'a never finalized dataset must not acquire a finalizedAt')
+  })
 })


### PR DESCRIPTION
On a publication site a dataset is addressed by its slug, so the slug is part of the reverse-proxy cache key while `_uniqueRefs` only ever holds the current one. Reassigning a slug lets stored entries keep revalidating against a date that no longer identifies their content, and each false 304 refreshes the previous occupant's response for another full max-age — a self-renewing stale entry rather than a bounded window.

`preparePatch` now moves `finalizedAt` to the next whole second after `updatedAt` when the slug actually changes, past any date previously served under that slug. Only for an already finalized dataset, since the field's presence doubles as a "has been finalized" flag.

**Why:** stop a slug change from letting proxy/browser caches falsely revalidate stale responses.
