### PR TITLE
fix(integrity): attribute file updates and make the panel report the truth

### DIFF
--- a/api/src/datasets/operations.ts
+++ b/api/src/datasets/operations.ts
@@ -31,3 +31,44 @@ export const getDatasetCacheKey = (args: ArrayLike<any>): string => {
     !!args[5] // acceptInitialDraft
   ].join(KEY_SEP)
 }
+
+/**
+ * The cheap "did this dataset change?" probe behind `getDatasetFresh`: rather than re-reading the
+ * whole document, project a handful of fields and compare them against the memoized copy.
+ *
+ * Integrity verdicts and anchors have to be part of it. The checker writes `integrity.lastCheck`
+ * and the relay writes `integrity.lastRevision` WITHOUT touching `updatedAt` — deliberately, since
+ * that field is the dataset's user-facing modification date and a nightly check must not move it.
+ * Left out of the projection they are invisible here, so a reader keeps being served the previous
+ * verdict for the whole 30s cache window: a manual "check now" then appears to do nothing at all,
+ * even across a page reload, until the entry expires on its own.
+ */
+export const datasetFreshnessProjection = (useDraft?: boolean): Record<string, number> => ({
+  updatedAt: 1,
+  finalizedAt: 1,
+  status: 1,
+  errorStatus: 1,
+  errorRetry: 1,
+  'integrity.lastCheck.date': 1,
+  'integrity.lastRevision.date': 1,
+  ...(useDraft ? { 'draft.updatedAt': 1 } : {}),
+  _id: 0
+})
+
+/**
+ * True when the memoized document still matches the freshly projected one and may be served as is.
+ * `fresh` is the result of a find with `datasetFreshnessProjection`.
+ */
+export const isCachedDatasetFresh = (cachedFull: Record<string, any> | undefined, fresh: Record<string, any>, useDraft?: boolean): boolean => {
+  if (!cachedFull) return false
+  if (cachedFull.updatedAt !== fresh.updatedAt) return false
+  if (cachedFull.finalizedAt !== fresh.finalizedAt) return false
+  if (cachedFull.status !== fresh.status) return false
+  if (cachedFull.errorStatus !== fresh.errorStatus) return false
+  if (cachedFull.errorRetry !== fresh.errorRetry) return false
+  if (cachedFull.integrity?.lastCheck?.date !== fresh.integrity?.lastCheck?.date) return false
+  if (cachedFull.integrity?.lastRevision?.date !== fresh.integrity?.lastRevision?.date) return false
+  // draft-only changes are invisible to every field above
+  if (useDraft && cachedFull.draft?.updatedAt !== fresh.draft?.updatedAt) return false
+  return true
+}

--- a/api/src/datasets/service.ts
+++ b/api/src/datasets/service.ts
@@ -21,7 +21,7 @@ import { getExtensionKey, prepareExtensions, prepareExtensionsSchema, checkExten
 import assertImmutable from '../misc/utils/assert-immutable.ts'
 import { curateDataset, titleFromFileName } from './utils/index.ts'
 import { computeModified } from './utils/compute-modified.ts'
-import { getDatasetCacheKey } from './operations.ts'
+import { getDatasetCacheKey, datasetFreshnessProjection, isCachedDatasetFresh } from './operations.ts'
 import * as integrityOps from '../integrity/operations.ts'
 import { anchorDataset } from '../integrity/relay.ts'
 import * as virtualDatasetsUtils from './utils/virtual.ts'
@@ -253,23 +253,11 @@ export const getDatasetFresh = async (datasetId: string, publicationSite: string
   }
 
   // cache has a result — check if it's still fresh via a lightweight query
-  const projection: Record<string, number> = { updatedAt: 1, finalizedAt: 1, status: 1, errorStatus: 1, errorRetry: 1, _id: 0 }
-  if (useDraft) projection['draft.updatedAt'] = 1
-  const fresh = await db.collection('datasets').findOne({ id: cached.dataset.id }, { projection })
+  const fresh = await db.collection('datasets').findOne({ id: cached.dataset.id }, { projection: datasetFreshnessProjection(useDraft) })
   if (!fresh) return {} // dataset was deleted
 
-  // check top-level updatedAt, finalizedAt and status
-  if (!cached.datasetFull || cached.datasetFull.updatedAt !== fresh.updatedAt || cached.datasetFull.finalizedAt !== fresh.finalizedAt || cached.datasetFull.status !== fresh.status || cached.datasetFull.errorStatus !== fresh.errorStatus || cached.datasetFull.errorRetry !== fresh.errorRetry) {
+  if (!isCachedDatasetFresh(cached.datasetFull, fresh, useDraft)) {
     return getDataset(datasetId, publicationSite, mainPublicationSite, useDraft, fillDescendants, acceptInitialDraft, db, _acceptedStatuses, reqBody)
-  }
-
-  // when using draft mode, also check draft.updatedAt to detect draft-only changes
-  if (useDraft) {
-    const cachedDraftUpdatedAt = cached.datasetFull.draft?.updatedAt
-    const freshDraftUpdatedAt = fresh.draft?.updatedAt
-    if (cachedDraftUpdatedAt !== freshDraftUpdatedAt) {
-      return getDataset(datasetId, publicationSite, mainPublicationSite, useDraft, fillDescendants, acceptInitialDraft, db, _acceptedStatuses, reqBody)
-    }
   }
 
   // cache is fresh — return cached result directly (assertImmutable proxy guards against mutations in dev/test)

--- a/api/src/datasets/service.ts
+++ b/api/src/datasets/service.ts
@@ -525,7 +525,8 @@ export const applyPatch = async (dataset: any, patch: any, removedRestProps?: an
   // if (!dataset.draftReason) await datasetUtils.updateStorage(dataset)
 
   // integrity outbox (spec §4): a patch touching covered metadata fields must be anchored.
-  // Draft-prefixed patches land under the excluded `draft` subtree and are not anchored.
+  // Draft-prefixed patches land under the excluded `draft` subtree and are not anchored — they
+  // only carry the attribution forward to the anchor written when the draft is validated (below).
   // Plain-$set of the sub-doc can overwrite a concurrently written stamp between our read and
   // this write — accepted narrow window, both stamps only meant "re-anchor" (fail-loud recovery).
   // A REST dataset mid its extend/index/finalize partial-update pipeline (_partialRestStatus,
@@ -536,14 +537,29 @@ export const applyPatch = async (dataset: any, patch: any, removedRestProps?: an
   // indexLines/extend) is about to run next. finalize.ts always stamps explicitly (and clears
   // _partialRestStatus in that same write) once the pipeline settles, so defer to it rather than
   // anchoring every interim covered-key touch along the way.
-  if (dataset.integrity?.active && !dataset.draftReason && !patch._needsHistorizing && !dataset._partialRestStatus) {
-    if (integrityOps.coveredPatchKeys(patch).length) {
-      // preserve a stamp already pending on the doc rather than overwriting its context: a stamp
-      // only means "re-anchor", and the pending context is the more specific one — e.g. the
-      // pipeline-routed restore rides its 'restore' context through a full REST reindex, whose
-      // index-lines pass re-patches `schema` (covered) and would otherwise downgrade it to this
-      // generic update/user context before finalize gets to preserve it
-      patch._needsHistorizing = (dataset as any)._needsHistorizing ?? { context: { operation: 'update', origin: 'user', ...(who ? { who } : {}) } }
+  if (dataset.integrity?.active && !patch._needsHistorizing && !dataset._partialRestStatus) {
+    // preserve a stamp already pending on the doc rather than overwriting its context: a stamp
+    // only means "re-anchor", and the pending context is the more specific one — e.g. the
+    // pipeline-routed restore rides its 'restore' context through a full REST reindex, whose
+    // index-lines pass re-patches `schema` (covered) and would otherwise downgrade it to this
+    // generic update/user context before finalize gets to preserve it
+    const context = { operation: 'update', origin: 'user', ...(who ? { who } : {}) }
+    if (dataset.draftReason) {
+      // A draft write is never anchored itself (the stamp lands under the excluded `draft`
+      // subtree, which the relay's task filter — a top-level `_needsHistorizing` — never matches).
+      // But the anchor written when the draft is validated describes exactly these bytes, and its
+      // attribution has to come from somewhere: finalize preserves `_needsHistorizing` across the
+      // draft merge, so stamping here is what carries the uploader through to that anchor. Without
+      // it, finalize falls back to its anonymous `origin: 'worker'` context and every file update
+      // on an enrolled dataset reads as an internal write, attributed to nobody.
+      // Gated on `who`: only the route layer passes it (workers never do), so this stamps a user's
+      // draft write and stays out of the way of the pipeline's own interim draft patches.
+      // `patch.draftReason` means THIS write is the one opening the draft (a file upload): a stamp
+      // pending on the published doc belongs to an earlier, unrelated write that the relay will
+      // anchor on its own — never borrow its attribution for these new bytes.
+      if (who) patch._needsHistorizing = (patch.draftReason ? undefined : (dataset as any)._needsHistorizing) ?? { context }
+    } else if (integrityOps.coveredPatchKeys(patch).length) {
+      patch._needsHistorizing = (dataset as any)._needsHistorizing ?? { context }
     }
   }
 

--- a/api/src/workers/short-processor/finalize.ts
+++ b/api/src/workers/short-processor/finalize.ts
@@ -37,9 +37,11 @@ export default async function (_dataset: DatasetInternal) {
   // with `draft.` based on its TARGET's draftReason, which routes this correctly: a plain draft
   // finalize persists `draft._needsHistorizing` (never matched by the relay filter → drafts are NOT
   // historized), while a draft validation patches the published doc → top-level flag → anchored.
-  // preserve a caller-provided context (e.g. the _restore route rides its 'restore' context
-  // through the draft: mergeDraft overlays draft._needsHistorizing onto the working doc);
-  // default to the generic worker context otherwise
+  // preserve a caller-provided context (the _restore route rides its 'restore' context through the
+  // draft, and a user file upload rides its attributed 'user' context the same way: mergeDraft
+  // overlays draft._needsHistorizing onto the working doc — see the draft branch of applyPatch's
+  // integrity outbox). The generic worker context is the fallback for genuinely un-attributed
+  // pipeline runs (remote-file auto-update, revalidation), NOT for a user-initiated upload
   if (dataset.integrity?.active) result._needsHistorizing = (dataset as any)._needsHistorizing ?? { context: { operation: 'update', origin: 'worker' } }
 
   debug('prepare extended schema')

--- a/docs/architecture/integrity.md
+++ b/docs/architecture/integrity.md
@@ -931,10 +931,13 @@ The integrity API splits read from write:
   response whose reader cannot `readIntegrity`, so anonymous/unauthorized readers never see
   breach verdicts or anchors even when they can otherwise read the dataset. This also scopes the
   list breach badge to authorized readers.
-- **UI:** the integrity tab is shown when the reader holds `readIntegrity` (or is in admin
-  mode); the enable/disable switch and the check/fix action buttons inside it render only in
-  admin mode. The status alerts and revision-history table are visible to every viewer of the
-  tab. The three actions that change the trail or the protection state are **confirmed in a
+- **UI:** the integrity tab is shown when the reader holds `readIntegrity` **and integrity is
+  active on the dataset**, or whenever the reader is in admin mode; the enable/disable switch and
+  the check/fix action buttons inside it render only in admin mode. Hence the active condition on
+  the reader side: with integrity off, a reader has no status, no history and no action available
+  — the tab would be empty — while a superadmin always needs it, since the switch that turns
+  integrity on lives in it. The status alerts and revision-history table are visible to every
+  viewer of the tab. The three actions that change the trail or the protection state are **confirmed in a
   dialog stating their consequence**: restore (overwrites data), reconcile (blesses the current
   state as legitimate, so pending divergences stop being reported), **disable** (clears the
   verdicts and stops renewal — additive *enable* needs no such guard) and **trail-anomaly ack**

--- a/docs/architecture/integrity.md
+++ b/docs/architecture/integrity.md
@@ -941,8 +941,13 @@ The integrity API splits read from write:
   (round 3 — stops reporting the reviewed anomalies; itself a locked, audited revision).
   Reconcile, both restores, disable and the ack offer the optional free-text `reason`, which is
   the only free-text field a WORM revision carries; both history tables render it, so what an
-  admin can write is also what an auditor can read. The panel shows the trail verdict as a
-  second status row with the anomaly list (kind, key, confidence). Both revision-history tables
+  admin can write is also what an auditor can read. Under the aggregate verdict banner the panel
+  lists **one row per verified part** — data file (file datasets), metadata, lines (REST), search
+  index, locked history — each with its own status chip, and each followed by its detail block
+  when there is one (index divergences + reindex, diverging line ids + restore, trail anomalies
+  (kind, key, confidence) + ack). The parts are only rendered for a definitive verdict: an
+  `unknown` check carries no part-level information, and showing every row as verified would
+  overstate what was established. Both revision-history tables
   (dataset-level and per-line) additionally carry an **attribution column** (target 8 / A2, en +
   fr) showing the `.who` body when present — user id or API-key ref, IP, country flag/code — raw
   ids as stored, with **no display-name resolution**: looking one up would re-personalize what

--- a/docs/architecture/integrity.md
+++ b/docs/architecture/integrity.md
@@ -239,6 +239,19 @@ is pending), and a dataset permanently stuck mid-pipeline defers anchoring until
 write is atomic with no multi-document transaction, and the relay only ever acts on
 already-committed state (ordering preserved).
 
+**Drafts carry a stamp they never redeem.** A file update never anchors at request time: it opens
+a draft, and the anchor describing the new bytes is written by the worker at `finalize`, once the
+draft is validated (by hand, or by the worker itself when the schema stays compatible). A stamp
+written on a draft lands under the excluded `draft` subtree, which the relay's task filter — a
+*top-level* `_needsHistorizing` — never matches, so the draft itself is never historized. Its only
+job is to carry the **context**: `applyPatch` stamps `draft._needsHistorizing` on a user's draft
+write (gated on the presence of a `who` — only the route layer supplies one, workers never do),
+`mergeDraft` overlays it onto the doc the worker sees, and `finalize` preserves it instead of
+falling back to its anonymous `origin: 'worker'` default. That is what makes the anchor of a file
+update read as a `user` write attributed to the uploader, rather than as an internal one
+attributed to nobody. A genuinely un-attributed pipeline run (remote-file auto-update,
+revalidation) supplies no `who`, keeps the `worker` default, and writes no `.who` sibling.
+
 **The outbox is only for *organic* writes.** The rare superadmin actions — `PUT _integrity`
 (enable) and `POST _integrity/_fix` (reconcile) — **bypass the outbox and anchor inline** in the
 request, calling the same `anchorDataset()` the relay uses (§3.3). The outbox/relay path remains

--- a/docs/architecture/integrity.md
+++ b/docs/architecture/integrity.md
@@ -950,10 +950,13 @@ The integrity API splits read from write:
   when there is one (index divergences + reindex, diverging line ids + restore, trail anomalies
   (kind, key, confidence) + ack). The parts are only rendered for a definitive verdict: an
   `unknown` check carries no part-level information, and showing every row as verified would
-  overstate what was established. Both revision-history tables
-  (dataset-level and per-line) additionally carry an **attribution column** (target 8 / A2, en +
-  fr) showing the `.who` body when present — user id or API-key ref, IP, country flag/code — raw
-  ids as stored, with **no display-name resolution**: looking one up would re-personalize what
+  overstate what was established. In both revision-history tables
+  (dataset-level and per-line) the author column carries the **attribution** (target 8 / A2, en +
+  fr) under the write category: the `.who` body when present — user id or API-key ref, IP, country
+  flag/code. Category and identity are separate properties (one inside the locked revision, the
+  other in its short-retention sibling) but they answer one question, so they share a column rather
+  than leaving a mostly-empty second one. Identities are shown as raw ids
+  as stored, with **no display-name resolution**: looking one up would re-personalize what
   minimization deliberately stripped (§8), and the id is already meaningful to the owner admin and
   resolvable through the directory while the user still exists.
 

--- a/tests/features/datasets/dataset-cache-key.unit.spec.ts
+++ b/tests/features/datasets/dataset-cache-key.unit.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test'
 import assert from 'node:assert/strict'
-import { getDatasetCacheKey } from '../../../api/src/datasets/operations.ts'
+import { getDatasetCacheKey, datasetFreshnessProjection, isCachedDatasetFresh } from '../../../api/src/datasets/operations.ts'
 
 const siteA = { owner: { type: 'organization', id: 'orgA' }, type: 'data-fair-portals', id: 'portalA' }
 const siteB = { owner: { type: 'organization', id: 'orgB' }, type: 'data-fair-portals', id: 'portalB' }
@@ -30,4 +30,82 @@ test.describe('getDatasetCacheKey', () => {
     assert.notEqual(getDatasetCacheKey(args(siteA, undefined, { useDraft: true })), getDatasetCacheKey(args(siteA, undefined, { useDraft: false })))
     assert.notEqual(getDatasetCacheKey(args(siteA, undefined, { datasetId: 'other' })), getDatasetCacheKey(args(siteA, undefined)))
   })
+})
+
+// The freshness probe behind getDatasetFresh: which document changes are allowed to keep serving
+// the 30s-memoized copy, and which must force a full re-read.
+test.describe('isCachedDatasetFresh', () => {
+  const base = () => ({
+    updatedAt: '2026-08-01T10:00:00.000Z',
+    finalizedAt: '2026-08-01T10:00:05.000Z',
+    status: 'finalized',
+    integrity: { lastCheck: { date: '2026-08-06T09:00:00.000Z' }, lastRevision: { date: '2026-08-05T08:00:00.000Z' } }
+  })
+
+  test('an unchanged document may be served from the cache', () => {
+    assert.equal(isCachedDatasetFresh(base(), base()), true)
+  })
+
+  test('a missing cached document is never fresh', () => {
+    assert.equal(isCachedDatasetFresh(undefined, base()), false)
+  })
+
+  for (const [field, mutate] of [
+    ['updatedAt', (d: any) => { d.updatedAt = '2026-08-02T10:00:00.000Z' }],
+    ['finalizedAt', (d: any) => { d.finalizedAt = '2026-08-02T10:00:00.000Z' }],
+    ['status', (d: any) => { d.status = 'error' }],
+    ['errorStatus', (d: any) => { d.errorStatus = 'indexed' }],
+    ['errorRetry', (d: any) => { d.errorRetry = '2026-08-02T10:00:00.000Z' }]
+  ] as [string, (d: any) => void][]) {
+    test(`a change of ${field} forces a re-read`, () => {
+      const fresh = base()
+      mutate(fresh)
+      assert.equal(isCachedDatasetFresh(base(), fresh), false)
+    })
+  }
+
+  // the reason this probe exists in its current shape: an integrity check writes its verdict
+  // without touching updatedAt (that field is the dataset's user-facing modification date, and a
+  // nightly check must not move it), so before these two comparisons a "check now" kept serving
+  // the previous verdict for the whole cache window, page reloads included
+  test('a fresh integrity verdict forces a re-read even though nothing else moved', () => {
+    const fresh = base()
+    fresh.integrity.lastCheck.date = '2026-08-06T09:30:00.000Z'
+    assert.equal(isCachedDatasetFresh(base(), fresh), false)
+  })
+
+  test('a newly written anchor forces a re-read even though nothing else moved', () => {
+    const fresh = base()
+    fresh.integrity.lastRevision.date = '2026-08-06T09:30:00.000Z'
+    assert.equal(isCachedDatasetFresh(base(), fresh), false)
+  })
+
+  test('enrolling a dataset (integrity appearing) forces a re-read', () => {
+    const cached: any = base()
+    delete cached.integrity
+    assert.equal(isCachedDatasetFresh(cached, base()), false)
+  })
+
+  test('a dataset with no integrity at all stays cacheable', () => {
+    const cached: any = base()
+    const fresh: any = base()
+    delete cached.integrity
+    delete fresh.integrity
+    assert.equal(isCachedDatasetFresh(cached, fresh), true)
+  })
+
+  test('draft.updatedAt only counts when reading in draft mode', () => {
+    const fresh: any = base()
+    fresh.draft = { updatedAt: '2026-08-06T09:30:00.000Z' }
+    assert.equal(isCachedDatasetFresh(base(), fresh), true)
+    assert.equal(isCachedDatasetFresh(base(), fresh, true), false)
+  })
+})
+
+test('datasetFreshnessProjection projects draft.updatedAt only in draft mode', () => {
+  assert.equal('draft.updatedAt' in datasetFreshnessProjection(), false)
+  assert.equal(datasetFreshnessProjection(true)['draft.updatedAt'], 1)
+  // the integrity fields are the point of the projection — see isCachedDatasetFresh above
+  assert.equal(datasetFreshnessProjection()['integrity.lastCheck.date'], 1)
+  assert.equal(datasetFreshnessProjection()['integrity.lastRevision.date'], 1)
 })

--- a/tests/features/integrity/attribution.api.spec.ts
+++ b/tests/features/integrity/attribution.api.spec.ts
@@ -7,8 +7,11 @@
 // write path — user PATCH, `_fix` after tamper, dedupe suppression, and the attribution kill
 // switch.
 import { test, expect } from '@playwright/test'
+import fs from 'fs-extra'
+import path from 'node:path'
+import FormData from 'form-data'
 import { axios, axiosAuth, apiUrl, clean } from '../../support/axios.ts'
-import { sendDataset, setConfig, waitForFinalize } from '../../support/workers.ts'
+import { sendDataset, setConfig, waitForFinalize, doAndWaitForFinalize, getRawDataset } from '../../support/workers.ts'
 import {
   ensureIntegrityBucket, integrityTestStore, listIntegrityKeys,
   waitForIntegrityRevisions, waitForFlagCleared, revisionsPrefix, waitForLinesDrained
@@ -119,6 +122,60 @@ test('a worker-origin re-anchor (no preceding request context) writes no `.who`'
   expect(keys.filter(k => !k.endsWith('.file') && !k.endsWith('.who')).length).toBe(2)
 
   await expect(integrityTestStore.getWho(ops.whoKey(dataset.owner, dataset.id, 1))).rejects.toMatchObject({ name: 'NoSuchKey' })
+})
+
+// A file update never anchors at request time: it lands in a draft, and the anchor is written by
+// the worker at finalize, once the draft is validated. The attribution therefore has to RIDE the
+// draft (applyPatch stamps `draft._needsHistorizing`, finalize preserves it across mergeDraft) —
+// without that, finalize falls back to its anonymous `origin: 'worker'` context and every file
+// update on an enrolled dataset reads as an internal write with no attribution at all.
+const uploadFile = async (ax: any, datasetId: string, fileName: string, params?: Record<string, any>) => {
+  const form = new FormData()
+  form.append('file', fs.readFileSync(path.resolve('./tests/resources/datasets/', fileName)), 'dataset1.csv')
+  await ax.post(`/api/v1/datasets/${datasetId}`, form, { headers: form.getHeaders(), ...(params ? { params } : {}) })
+}
+
+test('an incompatible file upload validated by hand anchors with the uploader in `.who`, not an anonymous worker context', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  const prefix = revisionsPrefix(dataset)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+  await waitForIntegrityRevisions(prefix, 3) // rev0 JSON + .file + .who (enable)
+
+  // dataset2.csv drops columns of dataset1.csv: in `compatible` draft mode (?draft=true) the
+  // worker refuses to auto-validate such a breaking change, so the draft waits for the user's
+  // explicit validation — the exact reported scenario
+  await doAndWaitForFinalize(admin, dataset.id, () => uploadFile(admin, dataset.id, 'dataset2.csv', { draft: true }))
+  expect((await getRawDataset(dataset.id)).draft).toBeTruthy() // still a pending draft, not auto-validated
+
+  await doAndWaitForFinalize(admin, dataset.id, () => admin.post(`/api/v1/datasets/${dataset.id}/draft`))
+  await waitForIntegrityRevisions(prefix, 6) // rev1 JSON + .file + .who
+  await waitForFlagCleared(dataset.id)
+
+  const rev1 = await integrityTestStore.getRevision(ops.revisionKey(dataset.owner, dataset.id, 1))
+  expect(rev1.context.origin).toBe('user') // a user put those bytes there — not the pipeline
+  const who1 = await integrityTestStore.getWho(ops.whoKey(dataset.owner, dataset.id, 1))
+  expect(who1.user?.id).toBe('test_superadmin')
+  expect(who1.ip).toBeTruthy()
+})
+
+test('a plain file replacement (draft auto-validated by the worker) carries the uploader through to the anchor too', async () => {
+  const admin = await axiosAuth('test_superadmin@test.com', undefined, true)
+  const dataset = await sendDataset('datasets/dataset1.csv', admin)
+  const prefix = revisionsPrefix(dataset)
+  await admin.put(`/api/v1/datasets/${dataset.id}/_integrity`, { active: true })
+  await waitForIntegrityRevisions(prefix, 3)
+
+  // no ?draft param → validationMode 'always' → the worker validates the draft itself, with no
+  // second request to attribute: the upload's own attribution is the only one there ever is
+  await doAndWaitForFinalize(admin, dataset.id, () => uploadFile(admin, dataset.id, 'dataset2.csv'))
+  await waitForIntegrityRevisions(prefix, 6)
+  await waitForFlagCleared(dataset.id)
+
+  const rev1 = await integrityTestStore.getRevision(ops.revisionKey(dataset.owner, dataset.id, 1))
+  expect(rev1.context.origin).toBe('user')
+  const who1 = await integrityTestStore.getWho(ops.whoKey(dataset.owner, dataset.id, 1))
+  expect(who1.user?.id).toBe('test_superadmin')
 })
 
 test('_fix after an out-of-band tamper carries the fixing superadmin in `.who`', async () => {

--- a/ui/src/components/dataset/dataset-integrity.vue
+++ b/ui/src/components/dataset/dataset-integrity.vue
@@ -1,6 +1,23 @@
 <template>
   <div class="pa-4">
     <template v-if="state">
+      <!-- the switch that decides everything below it comes first (disabling clears the verdicts
+           and stops lock renewal — anchors then age out at retention — so it is confirmed, unlike
+           the additive enable which needs no guard) -->
+      <template v-if="adminMode">
+        <v-switch
+          :model-value="state.active"
+          :label="t('enableLabel')"
+          :loading="toggle.loading.value"
+          color="primary"
+          density="compact"
+          hide-details
+          class="mb-2"
+          @update:model-value="(v) => v ? toggle.execute(true) : disableDialog = true"
+        />
+        <v-divider class="mb-4" />
+      </template>
+
       <v-alert
         v-if="!state.active"
         type="info"
@@ -66,9 +83,9 @@
         />
         <div
           v-if="state.lastCheck"
-          class="text-caption mt-1"
+          class="text-caption text-medium-emphasis mt-1"
         >
-          {{ t('lastCheck') }}: {{ formatDate(state.lastCheck.date) }}
+          {{ t('lastCheck') }} : {{ formatDate(state.lastCheck.date) }}
         </div>
       </template>
 
@@ -78,8 +95,10 @@
            like the others, not special cases. Shown only for a definitive verdict — an 'unknown'
            check carries no part-level information and must not be rendered as all-clear. Each
            row is followed by its own detail block when there is something to show. -->
-      <template v-if="state.active && verdictParts.length">
-        <v-divider class="my-4" />
+      <div
+        v-if="state.active && verdictParts.length"
+        class="mt-4"
+      >
         <template
           v-for="part of verdictParts"
           :key="part.key"
@@ -236,13 +255,12 @@
             </div>
           </v-alert>
         </template>
-      </template>
+      </div>
 
       <!-- per-line anchoring progress (enrolled REST datasets): backfill state, not a verdict —
            it is reported even before any check has run -->
       <template v-if="state.active && dataset?.isRest">
-        <v-divider class="my-4" />
-        <div class="text-body-2">
+        <div class="text-body-2 mt-4">
           {{ state.lines?.anchored ?? 0 }} {{ t('linesAnchored') }}
         </div>
         <template v-if="(state.lines?.pending ?? 0) > 0">
@@ -303,22 +321,6 @@
           {{ t('fix') }}
         </v-btn>
       </div>
-
-      <template v-if="adminMode">
-        <v-divider class="my-4" />
-
-        <!-- disabling clears the verdicts and stops lock renewal (anchors then age out at
-             retention): confirm it, unlike the additive enable which needs no guard -->
-        <v-switch
-          :model-value="state.active"
-          :label="t('enableLabel')"
-          :loading="toggle.loading.value"
-          color="primary"
-          density="compact"
-          hide-details
-          @update:model-value="(v) => v ? toggle.execute(true) : disableDialog = true"
-        />
-      </template>
 
       <template v-if="state.active">
         <v-divider class="my-4" />

--- a/ui/src/components/dataset/dataset-integrity.vue
+++ b/ui/src/components/dataset/dataset-integrity.vue
@@ -764,6 +764,7 @@ fr:
   fixHelp: Ancre l'état courant du fichier, des métadonnées et, pour un jeu de données éditable, de chaque ligne comme référence légitime.
   enableLabel: Activer le contrôle d'intégrité
   checkOk: Contrôle effectué
+  checkPendingRelay: "Le contrôle n'a pas pu conclure : une écriture est encore en cours d'historisation, l'état affiché reste celui du contrôle précédent. Réessayez dans quelques instants."
   fixOk: Réconciliation effectuée
   toggleOk: Configuration enregistrée
   loadError: Impossible de charger l'état d'intégrité.
@@ -872,6 +873,7 @@ en:
   fixHelp: Anchors the current state of the file, metadata and, for an editable dataset, each line as the legitimate reference.
   enableLabel: Enable integrity checking
   checkOk: Check completed
+  checkPendingRelay: "The check could not conclude: a write is still being historized, so the status shown is still the previous check's. Try again shortly."
   fixOk: Reconciliation completed
   toggleOk: Configuration saved
   loadError: Could not load the integrity status.
@@ -1091,11 +1093,19 @@ watch(() => state.value?.lines?.pending, (pending) => {
 }, { immediate: true })
 onUnmounted(stopLinesPoll)
 
+// A check that runs while a write is still being historized cannot conclude, and the checker
+// deliberately records NOTHING in that case (it returns a bare `{status:'unknown'}`, no date —
+// the relay will drain and the next check gets a real verdict). Reporting that as a plain
+// "check completed" leaves the panel showing the previous verdict unchanged, which reads as a
+// button that does nothing: name the two outcomes apart instead.
+const { sendUiNotif } = useUiNotif()
 const check = useAsyncAction(async () => {
-  await $fetch(`datasets/${dataset.value!.id}/_integrity/_check`, { method: 'POST' })
+  const res = await $fetch<{ status: string, date?: string }>(`datasets/${dataset.value!.id}/_integrity/_check`, { method: 'POST' })
   await load.execute()
   datasetStore.datasetFetch.refresh() // the breach badge and tab color derive from the dataset doc
-}, { success: t('checkOk') })
+  const recorded = res.status !== 'unknown' || !!res.date
+  sendUiNotif({ type: recorded ? 'success' : 'warning', msg: recorded ? t('checkOk') : t('checkPendingRelay') })
+})
 
 // reconcile blesses the current state into the WORM trail: the optional reason is the only
 // free-text audit field a revision carries, so it is offered here rather than API-only

--- a/ui/src/components/dataset/dataset-integrity.vue
+++ b/ui/src/components/dataset/dataset-integrity.vue
@@ -24,12 +24,36 @@
           density="compact"
           :text="t('okBody')"
         />
+        <!-- neither ok nor breach: either no check has run yet, or one ran and could not
+             conclude ('unknown'). These read very differently to an operator, and the missing
+             anchor case is its own story — see below -->
+        <v-alert
+          v-else-if="!state.lastCheck"
+          type="warning"
+          variant="tonal"
+          density="compact"
+          :text="t('notCheckedBody')"
+        />
+        <!-- a check ran but the store holds NO revision for this dataset: there is nothing to
+             compare against, so the guarantee is not effective. The verdict is trustworthy on
+             this point — a check that finds an anchor heals a lost `lastRevision` mirror from
+             the store before returning, so its absence here means the store is genuinely empty
+             (initial anchor write failed at enable time, or the objects are gone/elsewhere) -->
+        <v-alert
+          v-else-if="missingAnchor"
+          type="warning"
+          variant="outlined"
+          density="compact"
+          :title="t('noAnchorTitle')"
+          :text="t('noAnchorBody')"
+        />
         <v-alert
           v-else
           type="warning"
           variant="tonal"
           density="compact"
-          :text="t('notCheckedBody')"
+          :title="t('inconclusiveTitle')"
+          :text="t('inconclusiveBody')"
         />
         <!-- verdict 2 (round 3): the trail itself — independent of the data verdict above -->
         <v-alert
@@ -232,6 +256,18 @@
       <div class="d-flex align-center ga-2 mt-4">
         <v-spacer />
         <v-btn
+          v-if="state.active"
+          :prepend-icon="mdiRefresh"
+          :loading="refresh.loading.value"
+          color="primary"
+          variant="text"
+          size="small"
+          :title="t('refreshHelp')"
+          @click="refresh.execute()"
+        >
+          {{ t('refresh') }}
+        </v-btn>
+        <v-btn
           v-if="adminMode && state.active"
           :prepend-icon="mdiShieldRefresh"
           :loading="check.loading.value"
@@ -243,7 +279,7 @@
           {{ t('checkNow') }}
         </v-btn>
         <v-btn
-          v-if="adminMode && state.active && anyBreach"
+          v-if="adminMode && state.active && (anyBreach || missingAnchor)"
           :prepend-icon="mdiWrench"
           :loading="fix.loading.value"
           color="warning"
@@ -713,11 +749,17 @@ fr:
   breachBody: modifié(es) en dehors du circuit d'écriture légitime
   okBody: L'intégrité a été vérifiée, aucune divergence détectée.
   notCheckedBody: L'intégrité est activée mais aucun contrôle n'a encore été effectué.
+  inconclusiveTitle: Contrôle non concluant
+  inconclusiveBody: Le dernier contrôle n'a pas pu se prononcer, le plus souvent parce qu'une écriture est encore en cours d'historisation. Un nouveau contrôle est lancé automatiquement.
+  noAnchorTitle: Aucune révision dans l'entrepôt
+  noAnchorBody: "L'intégrité est activée mais l'entrepôt ne contient aucune révision pour ce jeu de données : il n'y a rien à quoi comparer l'état courant, la garantie n'est donc pas effective. Soit l'écriture de la révision initiale a échoué à l'activation (entrepôt indisponible ou mal configuré), soit les révisions n'y sont plus. Vérifiez l'entrepôt, puis réconciliez pour y ancrer l'état courant."
   renewalFailedTitle: Renouvellement du verrou en échec
   renewalFailedBody: Le renouvellement de la protection anti-altération échoue. La garantie expirera à la date de rétention de l'ancre si le problème n'est pas résolu.
   lastCheck: Dernier contrôle
   neverChecked: Aucun contrôle effectué
   checkNow: Contrôler maintenant
+  refresh: Rafraîchir
+  refreshHelp: Relit l'état d'intégrité et l'historique des révisions.
   fix: Réconcilier
   fixHelp: Ancre l'état courant du fichier, des métadonnées et, pour un jeu de données éditable, de chaque ligne comme référence légitime.
   enableLabel: Activer le contrôle d'intégrité
@@ -815,11 +857,17 @@ en:
   breachBody: modified outside the legitimate write path
   okBody: Integrity verified, no divergence detected.
   notCheckedBody: Integrity is enabled but no check has been run yet.
+  inconclusiveTitle: Inconclusive check
+  inconclusiveBody: The last check could not reach a verdict, usually because a write is still being historized. Another check runs automatically.
+  noAnchorTitle: No revision in the store
+  noAnchorBody: "Integrity is enabled but the store holds no revision for this dataset: there is nothing to compare the current state against, so the guarantee is not effective. Either the initial revision failed to be written when integrity was enabled (store unavailable or misconfigured), or the revisions are no longer there. Check the store, then reconcile to anchor the current state."
   renewalFailedTitle: Lock renewal failing
   renewalFailedBody: Renewal of the tamper-protection lock is failing. The guarantee will lapse at the anchor's retain-until date unless resolved.
   lastCheck: Last check
   neverChecked: No check run yet
   checkNow: Check now
+  refresh: Refresh
+  refreshHelp: Re-reads the integrity status and the revision history.
   fix: Reconcile
   fixHelp: Anchors the current state of the file, metadata and, for an editable dataset, each line as the legitimate reference.
   enableLabel: Enable integrity checking
@@ -910,7 +958,7 @@ en:
 </i18n>
 
 <script setup lang="ts">
-import { mdiShieldRefresh, mdiWrench, mdiFileCompare, mdiDownload, mdiBackupRestore, mdiHistory, mdiCheckDecagram, mdiDatabaseRefresh } from '@mdi/js'
+import { mdiShieldRefresh, mdiRefresh, mdiWrench, mdiFileCompare, mdiDownload, mdiBackupRestore, mdiHistory, mdiCheckDecagram, mdiDatabaseRefresh } from '@mdi/js'
 import type { Dataset, WhoHint } from '#api/types'
 
 const { t, locale } = useI18n()
@@ -942,6 +990,10 @@ const formatWho = (who?: WhoHint): string => {
 const state = ref<IntegrityState | null>(null)
 
 const anyBreach = computed(() => state.value?.lastCheck?.status === 'breach')
+// enrolled, a check has run, and yet no anchor is recorded: the store holds no revision for this
+// dataset. Reconciling is exactly the remedy (it anchors the current state), so the action stays
+// offered here even though this is not a breach.
+const missingAnchor = computed(() => !!state.value?.active && !!state.value?.lastCheck && !state.value?.lastRevision)
 
 const size = 10
 const page = ref(1)
@@ -977,6 +1029,43 @@ const load = useAsyncAction(async () => {
   }
 })
 load.execute()
+
+// Re-read the state and the CURRENT page of the history, unlike load() which resets pagination:
+// a refresh only ever finds the trail grown (a new anchor), never shrunk.
+const refresh = useAsyncAction(async () => {
+  if (!dataset.value) return
+  state.value = await $fetch<IntegrityState>(`datasets/${dataset.value.id}/_integrity`)
+  if (state.value?.active) await loadRevisions.execute()
+})
+
+// Watchability on the existing journal channel (no new channel, no new permission): a new anchor
+// is always preceded by a pipeline run ending in 'finalize-end' — a file upload, a draft
+// validation, a metadata patch that triggers reindexing. The anchor itself lands slightly LATER
+// (the historize relay is a separate worker task with no journal event of its own), so a single
+// refresh on the event would still read the pre-anchor state: re-read a few times over the next
+// seconds and stop as soon as the trail has actually grown. Anything the panel cannot observe
+// this way (nightly checks, an admin action from another session) is what the refresh button and
+// the periodic checks are for.
+const ws = useWS('/data-fair/api/')
+let settleTimer: ReturnType<typeof setTimeout> | undefined
+const stopSettle = () => {
+  if (settleTimer) {
+    clearTimeout(settleTimer)
+    settleTimer = undefined
+  }
+}
+const refreshUntilAnchored = async (attempt = 0) => {
+  const before = state.value?.lastRevision?.i
+  await refresh.execute()
+  if (state.value?.lastRevision?.i !== before || attempt >= 4) return stopSettle()
+  settleTimer = setTimeout(() => refreshUntilAnchored(attempt + 1), 2000)
+}
+ws?.subscribe(`datasets/${dataset.value?.id}/journal`, (event: any) => {
+  if (event?.type !== 'finalize-end') return
+  stopSettle()
+  refreshUntilAnchored()
+})
+onUnmounted(stopSettle)
 
 // backfill progress (target 3, enrolled REST datasets): while lines are pending anchoring, poll
 // the lightweight summary every ~2s so the progress indicator reflects the relay draining, then

--- a/ui/src/components/dataset/dataset-integrity.vue
+++ b/ui/src/components/dataset/dataset-integrity.vue
@@ -347,18 +347,17 @@
           <template #item.operation="{ item }">
             {{ t('op_' + item.operation) }}
           </template>
+          <!-- write category and identity are two different properties (the category is inside
+               the locked revision, the identity in its short-retention `.who` sibling) but they
+               answer one question — who made this write — so they share a column -->
           <template #item.origin="{ item }">
-            {{ t('origin_' + item.origin) }}
-          </template>
-          <template #item.who="{ item }">
-            <span
+            <div>{{ t('origin_' + item.origin) }}</div>
+            <div
               v-if="item.who"
-              class="text-body-small"
-            >{{ formatWho(item.who) }}</span>
-            <span
-              v-else
-              class="text-body-small text-disabled"
-            >—</span>
+              class="text-body-small text-medium-emphasis"
+            >
+              {{ formatWho(item.who) }}
+            </div>
           </template>
           <template #item.reason="{ item }">
             <span
@@ -659,17 +658,13 @@
               {{ t('op_' + item.operation) }}
             </template>
             <template #item.origin="{ item }">
-              {{ t('origin_' + item.origin) }}
-            </template>
-            <template #item.who="{ item }">
-              <span
+              <div>{{ t('origin_' + item.origin) }}</div>
+              <div
                 v-if="item.who"
-                class="text-body-small"
-              >{{ formatWho(item.who) }}</span>
-              <span
-                v-else
-                class="text-body-small text-disabled"
-              >—</span>
+                class="text-body-small text-medium-emphasis"
+              >
+                {{ formatWho(item.who) }}
+              </div>
             </template>
             <template #item.reason="{ item }">
               <span
@@ -792,7 +787,6 @@ fr:
   colOperation: Opération
   colDate: Date
   colOriginator: Auteur
-  colAttribution: Attribution
   colReason: Raison
   colHash: Empreinte
   op_create: Création
@@ -899,7 +893,6 @@ en:
   colOperation: Operation
   colDate: Date
   colOriginator: Author
-  colAttribution: Attribution
   colReason: Reason
   colHash: Hash
   op_create: Create
@@ -1038,7 +1031,6 @@ const headers = computed(() => [
   { title: t('colOperation'), key: 'operation', sortable: false },
   { title: t('colDate'), key: 'date', sortable: false },
   { title: t('colOriginator'), key: 'origin', sortable: false },
-  { title: t('colAttribution'), key: 'who', sortable: false },
   { title: t('colReason'), key: 'reason', sortable: false },
   { title: t('colHash'), key: 'hash', sortable: false },
   { title: '', key: 'actions', sortable: false, align: 'end' as const }
@@ -1255,7 +1247,6 @@ const lineRevisionHeaders = computed(() => [
   { title: t('colOperation'), key: 'operation', sortable: false },
   { title: t('colDate'), key: 'date', sortable: false },
   { title: t('colOriginator'), key: 'origin', sortable: false },
-  { title: t('colAttribution'), key: 'who', sortable: false },
   { title: t('colReason'), key: 'reason', sortable: false },
   { title: '', key: 'actions', sortable: false, align: 'end' as const }
 ])

--- a/ui/src/components/dataset/dataset-integrity.vue
+++ b/ui/src/components/dataset/dataset-integrity.vue
@@ -85,7 +85,7 @@
         />
         <div
           v-if="state.lastCheck"
-          class="text-caption text-medium-emphasis mt-1"
+          class="text-body-small text-medium-emphasis mt-1"
         >
           {{ t('lastCheck') }} : {{ formatDate(state.lastCheck.date) }}
         </div>
@@ -106,7 +106,7 @@
           :key="part.key"
         >
           <div class="d-flex align-center ga-2 mb-2">
-            <span class="text-body-2">{{ t('part_' + part.key) }}</span>
+            <span class="text-body-medium">{{ t('part_' + part.key) }}</span>
             <v-chip
               size="small"
               label
@@ -173,7 +173,7 @@
           >
             <div
               v-if="state.lastCheck.index.count && state.lastCheck.index.count.expected !== state.lastCheck.index.count.actual"
-              class="text-caption"
+              class="text-body-small"
             >
               {{ t('indexCountMismatch', { expected: state.lastCheck.index.count.expected, actual: state.lastCheck.index.count.actual }) }}
             </div>
@@ -190,7 +190,7 @@
               </v-chip>
               <pre
                 v-if="entry.expected || entry.actual"
-                class="text-caption mt-1"
+                class="text-body-small mt-1"
                 style="white-space: pre-wrap; overflow-x: auto;"
               >{{ entry.expected ? t('indexExpected') + ' ' + entry.expected + '\n' : '' }}{{ entry.actual ? t('indexActual') + ' ' + entry.actual : '' }}</pre>
             </div>
@@ -219,7 +219,7 @@
             class="mt-2 mb-3"
             :title="t('trailAlteredTitle')"
           >
-            <div class="text-body-2">
+            <div class="text-body-medium">
               {{ t('trailAlteredBody') }}
             </div>
             <div
@@ -234,10 +234,10 @@
               >
                 {{ t('anomaly_' + anomaly.kind) }}
               </v-chip>
-              <code class="text-caption">{{ anomaly.key }}</code>
+              <code class="text-body-small">{{ anomaly.key }}</code>
               <span
                 v-if="anomaly.detail"
-                class="text-caption text-disabled"
+                class="text-body-small text-disabled"
               >{{ anomaly.detail }}</span>
             </div>
             <div
@@ -262,11 +262,11 @@
       <!-- per-line anchoring progress (enrolled REST datasets): backfill state, not a verdict —
            it is reported even before any check has run -->
       <template v-if="state.active && dataset?.isRest">
-        <div class="text-body-2 mt-4">
+        <div class="text-body-medium mt-4">
           {{ state.lines?.anchored ?? 0 }} {{ t('linesAnchored') }}
         </div>
         <template v-if="(state.lines?.pending ?? 0) > 0">
-          <div class="text-caption mt-1">
+          <div class="text-body-small mt-1">
             {{ state.lines!.pending }} {{ t('linesPending') }}
           </div>
           <v-progress-linear
@@ -325,7 +325,7 @@
       </div>
 
       <template v-if="state.active">
-        <h4 class="text-subtitle-1 mb-2 mt-6">
+        <h4 class="text-title-medium mb-2 mt-6">
           {{ t('historyTitle') }}
         </h4>
         <v-data-table-server
@@ -342,7 +342,7 @@
             {{ formatDate(item.date) }}
           </template>
           <template #item.hash="{ item }">
-            <code class="text-caption">{{ (item.hash.file ?? item.hash.metadata ?? '').slice(0, 12) }}…</code>
+            <code class="text-body-small">{{ (item.hash.file ?? item.hash.metadata ?? '').slice(0, 12) }}…</code>
           </template>
           <template #item.operation="{ item }">
             {{ t('op_' + item.operation) }}
@@ -353,21 +353,21 @@
           <template #item.who="{ item }">
             <span
               v-if="item.who"
-              class="text-caption"
+              class="text-body-small"
             >{{ formatWho(item.who) }}</span>
             <span
               v-else
-              class="text-caption text-disabled"
+              class="text-body-small text-disabled"
             >—</span>
           </template>
           <template #item.reason="{ item }">
             <span
               v-if="item.reason"
-              class="text-caption"
+              class="text-body-small"
             >{{ item.reason }}</span>
             <span
               v-else
-              class="text-caption text-disabled"
+              class="text-body-small text-disabled"
             >—</span>
           </template>
           <template #item.actions="{ item }">
@@ -401,7 +401,7 @@
             </template>
             <span
               v-else
-              class="text-caption text-disabled"
+              class="text-body-small text-disabled"
             >{{ t('noPayload') }}</span>
           </template>
         </v-data-table-server>
@@ -426,7 +426,7 @@
         <v-card-text v-if="diffData">
           <p
             v-if="!diffKeys.length"
-            class="text-caption"
+            class="text-body-small"
           >
             {{ t('noDiff') }}
           </p>
@@ -434,21 +434,21 @@
             v-for="key of diffKeys"
             :key="key"
           >
-            <h4 class="text-subtitle-2 mt-2">
+            <h4 class="text-title-small mt-2">
               {{ key }}
             </h4>
             <v-row dense>
               <v-col cols="6">
-                <div class="text-caption">
+                <div class="text-body-small">
                   {{ t('diffRevision') }}
                 </div>
-                <pre class="text-caption bg-surface-light pa-2 overflow-auto">{{ pretty(diffData.payload.metadata[key]) }}</pre>
+                <pre class="text-body-small bg-surface-light pa-2 overflow-auto">{{ pretty(diffData.payload.metadata[key]) }}</pre>
               </v-col>
               <v-col cols="6">
-                <div class="text-caption">
+                <div class="text-body-small">
                   {{ t('diffCurrent') }}
                 </div>
-                <pre class="text-caption bg-surface-light pa-2 overflow-auto">{{ pretty(diffData.current?.[key]) }}</pre>
+                <pre class="text-body-small bg-surface-light pa-2 overflow-auto">{{ pretty(diffData.current?.[key]) }}</pre>
               </v-col>
             </v-row>
           </template>
@@ -664,21 +664,21 @@
             <template #item.who="{ item }">
               <span
                 v-if="item.who"
-                class="text-caption"
+                class="text-body-small"
               >{{ formatWho(item.who) }}</span>
               <span
                 v-else
-                class="text-caption text-disabled"
+                class="text-body-small text-disabled"
               >—</span>
             </template>
             <template #item.reason="{ item }">
               <span
                 v-if="item.reason"
-                class="text-caption"
+                class="text-body-small"
               >{{ item.reason }}</span>
               <span
                 v-else
-                class="text-caption text-disabled"
+                class="text-body-small text-disabled"
               >—</span>
             </template>
             <template #item.actions="{ item }">
@@ -693,7 +693,7 @@
               />
               <span
                 v-else
-                class="text-caption text-disabled"
+                class="text-body-small text-disabled"
               >{{ t('noPayload') }}</span>
             </template>
           </v-data-table-server>
@@ -715,13 +715,13 @@
         <v-card-text v-if="lineDiffData">
           <p
             v-if="lineDiffData.line?.deleted"
-            class="text-caption"
+            class="text-body-small"
           >
             {{ t('lineDeletedRevision') }}
           </p>
           <p
             v-else-if="!lineDiffKeys.length"
-            class="text-caption"
+            class="text-body-small"
           >
             {{ t('noDiff') }}
           </p>
@@ -729,21 +729,21 @@
             v-for="key of lineDiffKeys"
             :key="key"
           >
-            <h4 class="text-subtitle-2 mt-2">
+            <h4 class="text-title-small mt-2">
               {{ key }}
             </h4>
             <v-row dense>
               <v-col cols="6">
-                <div class="text-caption">
+                <div class="text-body-small">
                   {{ t('diffRevision') }}
                 </div>
-                <pre class="text-caption bg-surface-light pa-2 overflow-auto">{{ pretty(lineDiffData.payload?.[key]) }}</pre>
+                <pre class="text-body-small bg-surface-light pa-2 overflow-auto">{{ pretty(lineDiffData.payload?.[key]) }}</pre>
               </v-col>
               <v-col cols="6">
-                <div class="text-caption">
+                <div class="text-body-small">
                   {{ t('diffCurrent') }}
                 </div>
-                <pre class="text-caption bg-surface-light pa-2 overflow-auto">{{ pretty(lineDiffData.current?.[key]) }}</pre>
+                <pre class="text-body-small bg-surface-light pa-2 overflow-auto">{{ pretty(lineDiffData.current?.[key]) }}</pre>
               </v-col>
             </v-row>
           </template>

--- a/ui/src/components/dataset/dataset-integrity.vue
+++ b/ui/src/components/dataset/dataset-integrity.vue
@@ -12,13 +12,8 @@
           color="primary"
           density="compact"
           hide-details
-          class="mb-2"
-          @update:model-value="(v) => v ? toggle.execute(true) : disableDialog = true"
-        />
-        <!-- nothing follows the switch when integrity is off: no rule to draw either -->
-        <v-divider
-          v-if="state.active"
           class="mb-4"
+          @update:model-value="(v) => v ? toggle.execute(true) : disableDialog = true"
         />
       </template>
 
@@ -330,8 +325,7 @@
       </div>
 
       <template v-if="state.active">
-        <v-divider class="my-4" />
-        <h4 class="text-subtitle-1 mb-2">
+        <h4 class="text-subtitle-1 mb-2 mt-6">
           {{ t('historyTitle') }}
         </h4>
         <v-data-table-server

--- a/ui/src/components/dataset/dataset-integrity.vue
+++ b/ui/src/components/dataset/dataset-integrity.vue
@@ -55,58 +55,6 @@
           :title="t('inconclusiveTitle')"
           :text="t('inconclusiveBody')"
         />
-        <!-- verdict 2 (round 3): the trail itself — independent of the data verdict above -->
-        <v-alert
-          v-if="state.lastCheck?.trail?.status === 'altered'"
-          type="error"
-          variant="outlined"
-          density="compact"
-          class="mt-1"
-          :title="t('trailAlteredTitle')"
-        >
-          <div class="text-body-2">
-            {{ t('trailAlteredBody') }}
-          </div>
-          <div
-            v-for="(anomaly, idx) of state.lastCheck!.trail!.anomalies ?? []"
-            :key="idx"
-            class="d-flex align-center ga-2 mt-1"
-          >
-            <v-chip
-              size="x-small"
-              label
-              :color="anomaly.confidence === 'confirmed' ? 'error' : 'warning'"
-            >
-              {{ t('anomaly_' + anomaly.kind) }}
-            </v-chip>
-            <code class="text-caption">{{ anomaly.key }}</code>
-            <span
-              v-if="anomaly.detail"
-              class="text-caption text-disabled"
-            >{{ anomaly.detail }}</span>
-          </div>
-          <div
-            v-if="adminMode"
-            class="mt-2"
-          >
-            <v-btn
-              :prepend-icon="mdiCheckDecagram"
-              color="warning"
-              variant="text"
-              size="small"
-              :title="t('ackHelp')"
-              @click="ackDialog = true; ackReason = ''"
-            >
-              {{ t('ackTrail') }}
-            </v-btn>
-          </div>
-        </v-alert>
-        <div
-          v-else-if="state.lastCheck?.trail?.status === 'ok'"
-          class="text-caption mt-1 text-success"
-        >
-          {{ t('trailOkBody') }}
-        </div>
         <v-alert
           v-if="state.lastRenewal?.status === 'failed'"
           type="warning"
@@ -124,6 +72,174 @@
         </div>
       </template>
 
+      <!-- Per-part verdict. The check covers several parts and records a per-part breach list, so
+           every part gets its own row and chip rather than being named inside the aggregate
+           sentence above and only on failure: the search index and the revision trail are parts
+           like the others, not special cases. Shown only for a definitive verdict — an 'unknown'
+           check carries no part-level information and must not be rendered as all-clear. Each
+           row is followed by its own detail block when there is something to show. -->
+      <template v-if="state.active && verdictParts.length">
+        <v-divider class="my-4" />
+        <template
+          v-for="part of verdictParts"
+          :key="part.key"
+        >
+          <div class="d-flex align-center ga-2 mb-2">
+            <span class="text-body-2">{{ t('part_' + part.key) }}</span>
+            <v-chip
+              size="small"
+              label
+              :color="part.status === 'ok' ? 'success' : (part.status === 'unknown' ? 'warning' : 'error')"
+            >
+              {{ t('partStatus_' + part.status) }}
+            </v-chip>
+          </div>
+
+          <!-- lines: the diverging ids, with a per-line history shortcut and the bulk restore -->
+          <v-alert
+            v-if="part.key === 'lines' && (state.lastCheck?.lines?.diverged ?? 0) > 0"
+            type="error"
+            variant="outlined"
+            density="compact"
+            class="mt-2 mb-3"
+            :title="`${state.lastCheck!.lines!.diverged} ${t('linesDivergedTitle')}`"
+          >
+            <div class="d-flex flex-wrap align-center ga-2 mt-2">
+              <div
+                v-for="lineId of state.lastCheck!.lines!.sample ?? []"
+                :key="lineId"
+                class="d-flex align-center ga-1"
+              >
+                <v-chip
+                  size="small"
+                  label
+                >
+                  {{ lineId }}
+                </v-chip>
+                <v-btn
+                  :icon="mdiHistory"
+                  variant="text"
+                  size="x-small"
+                  :title="t('viewLineRevisions')"
+                  @click="openLineRevisions(lineId)"
+                />
+              </div>
+            </div>
+            <div
+              v-if="adminMode"
+              class="mt-2"
+            >
+              <v-btn
+                :prepend-icon="mdiBackupRestore"
+                color="warning"
+                variant="text"
+                size="small"
+                @click="linesRestoreDialog = true"
+              >
+                {{ t('linesRestore') }}
+              </v-btn>
+            </div>
+          </v-alert>
+
+          <!-- search index: what diverges between the served index and the verified source -->
+          <v-alert
+            v-if="part.key === 'index' && state.lastCheck?.index?.status === 'diverged'"
+            type="error"
+            variant="outlined"
+            density="compact"
+            class="mt-2 mb-3"
+            :title="t('indexDivergedTitle', { diverged: state.lastCheck.index.diverged ?? 0 })"
+          >
+            <div
+              v-if="state.lastCheck.index.count && state.lastCheck.index.count.expected !== state.lastCheck.index.count.actual"
+              class="text-caption"
+            >
+              {{ t('indexCountMismatch', { expected: state.lastCheck.index.count.expected, actual: state.lastCheck.index.count.actual }) }}
+            </div>
+            <div
+              v-for="entry of state.lastCheck.index.sample ?? []"
+              :key="entry.kind + entry.key"
+              class="mt-2"
+            >
+              <v-chip
+                size="small"
+                label
+              >
+                {{ t('indexKind.' + entry.kind) }} — {{ entry.key }}
+              </v-chip>
+              <pre
+                v-if="entry.expected || entry.actual"
+                class="text-caption mt-1"
+                style="white-space: pre-wrap; overflow-x: auto;"
+              >{{ entry.expected ? t('indexExpected') + ' ' + entry.expected + '\n' : '' }}{{ entry.actual ? t('indexActual') + ' ' + entry.actual : '' }}</pre>
+            </div>
+            <div
+              v-if="adminMode"
+              class="mt-2"
+            >
+              <v-btn
+                :prepend-icon="mdiDatabaseRefresh"
+                color="warning"
+                variant="text"
+                size="small"
+                @click="indexReindexDialog = true"
+              >
+                {{ t('indexReindex') }}
+              </v-btn>
+            </div>
+          </v-alert>
+
+          <!-- revision trail: which anomalies were seen in the locked history, and the ack action -->
+          <v-alert
+            v-if="part.key === 'trail' && state.lastCheck?.trail?.status === 'altered'"
+            type="error"
+            variant="outlined"
+            density="compact"
+            class="mt-2 mb-3"
+            :title="t('trailAlteredTitle')"
+          >
+            <div class="text-body-2">
+              {{ t('trailAlteredBody') }}
+            </div>
+            <div
+              v-for="(anomaly, idx) of state.lastCheck!.trail!.anomalies ?? []"
+              :key="idx"
+              class="d-flex align-center ga-2 mt-1"
+            >
+              <v-chip
+                size="x-small"
+                label
+                :color="anomaly.confidence === 'confirmed' ? 'error' : 'warning'"
+              >
+                {{ t('anomaly_' + anomaly.kind) }}
+              </v-chip>
+              <code class="text-caption">{{ anomaly.key }}</code>
+              <span
+                v-if="anomaly.detail"
+                class="text-caption text-disabled"
+              >{{ anomaly.detail }}</span>
+            </div>
+            <div
+              v-if="adminMode"
+              class="mt-2"
+            >
+              <v-btn
+                :prepend-icon="mdiCheckDecagram"
+                color="warning"
+                variant="text"
+                size="small"
+                :title="t('ackHelp')"
+                @click="ackDialog = true; ackReason = ''"
+              >
+                {{ t('ackTrail') }}
+              </v-btn>
+            </div>
+          </v-alert>
+        </template>
+      </template>
+
+      <!-- per-line anchoring progress (enrolled REST datasets): backfill state, not a verdict —
+           it is reported even before any check has run -->
       <template v-if="state.active && dataset?.isRest">
         <v-divider class="my-4" />
         <div class="text-body-2">
@@ -147,110 +263,6 @@
           class="mt-2"
           :text="t('linesOverGate')"
         />
-        <v-alert
-          v-if="(state.lastCheck?.lines?.diverged ?? 0) > 0"
-          type="error"
-          variant="outlined"
-          density="compact"
-          class="mt-2"
-          :title="`${state.lastCheck!.lines!.diverged} ${t('linesDivergedTitle')}`"
-        >
-          <div class="d-flex flex-wrap align-center ga-2 mt-2">
-            <div
-              v-for="lineId of state.lastCheck!.lines!.sample ?? []"
-              :key="lineId"
-              class="d-flex align-center ga-1"
-            >
-              <v-chip
-                size="small"
-                label
-              >
-                {{ lineId }}
-              </v-chip>
-              <v-btn
-                :icon="mdiHistory"
-                variant="text"
-                size="x-small"
-                :title="t('viewLineRevisions')"
-                @click="openLineRevisions(lineId)"
-              />
-            </div>
-          </div>
-          <div
-            v-if="adminMode"
-            class="mt-2"
-          >
-            <v-btn
-              :prepend-icon="mdiBackupRestore"
-              color="warning"
-              variant="text"
-              size="small"
-              @click="linesRestoreDialog = true"
-            >
-              {{ t('linesRestore') }}
-            </v-btn>
-          </div>
-        </v-alert>
-      </template>
-
-      <template v-if="state.active && state.lastCheck?.index">
-        <v-divider class="my-4" />
-        <div class="text-body-2">
-          {{ t('indexVerdictTitle') }} :
-          <v-chip
-            size="small"
-            label
-            :color="state.lastCheck.index.status === 'ok' ? 'success' : (state.lastCheck.index.status === 'diverged' ? 'error' : 'warning')"
-          >
-            {{ t('indexStatus.' + state.lastCheck.index.status) }}
-          </v-chip>
-        </div>
-        <v-alert
-          v-if="state.lastCheck.index.status === 'diverged'"
-          type="error"
-          variant="outlined"
-          density="compact"
-          class="mt-2"
-          :title="t('indexDivergedTitle', { diverged: state.lastCheck.index.diverged ?? 0 })"
-        >
-          <div
-            v-if="state.lastCheck.index.count && state.lastCheck.index.count.expected !== state.lastCheck.index.count.actual"
-            class="text-caption"
-          >
-            {{ t('indexCountMismatch', { expected: state.lastCheck.index.count.expected, actual: state.lastCheck.index.count.actual }) }}
-          </div>
-          <div
-            v-for="entry of state.lastCheck.index.sample ?? []"
-            :key="entry.kind + entry.key"
-            class="mt-2"
-          >
-            <v-chip
-              size="small"
-              label
-            >
-              {{ t('indexKind.' + entry.kind) }} — {{ entry.key }}
-            </v-chip>
-            <pre
-              v-if="entry.expected || entry.actual"
-              class="text-caption mt-1"
-              style="white-space: pre-wrap; overflow-x: auto;"
-            >{{ entry.expected ? t('indexExpected') + ' ' + entry.expected + '\n' : '' }}{{ entry.actual ? t('indexActual') + ' ' + entry.actual : '' }}</pre>
-          </div>
-          <div
-            v-if="adminMode"
-            class="mt-2"
-          >
-            <v-btn
-              :prepend-icon="mdiDatabaseRefresh"
-              color="warning"
-              variant="text"
-              size="small"
-              @click="indexReindexDialog = true"
-            >
-              {{ t('indexReindex') }}
-            </v-btn>
-          </div>
-        </v-alert>
       </template>
 
       <div class="d-flex align-center ga-2 mt-4">
@@ -745,6 +757,11 @@ fr:
   part_metadata: Métadonnées
   part_lines: Lignes
   part_index: Index de recherche
+  part_trail: Historique verrouillé
+  partStatus_ok: vérifié
+  partStatus_diverged: divergent
+  partStatus_altered: altéré
+  partStatus_unknown: en attente
   breachTitle: Intégrité compromise
   breachBody: modifié(es) en dehors du circuit d'écriture légitime
   okBody: L'intégrité a été vérifiée, aucune divergence détectée.
@@ -756,7 +773,6 @@ fr:
   renewalFailedTitle: Renouvellement du verrou en échec
   renewalFailedBody: Le renouvellement de la protection anti-altération échoue. La garantie expirera à la date de rétention de l'ancre si le problème n'est pas résolu.
   lastCheck: Dernier contrôle
-  neverChecked: Aucun contrôle effectué
   checkNow: Contrôler maintenant
   refresh: Rafraîchir
   refreshHelp: Relit l'état d'intégrité et l'historique des révisions.
@@ -814,11 +830,6 @@ fr:
   linesRestoreOk: Restauration des lignes lancée
   lineRevisionsTitle: "Historique de la ligne {lineId}"
   lineDeletedRevision: Cette révision correspond à la suppression de la ligne.
-  indexVerdictTitle: Index de recherche (données servies)
-  indexStatus:
-    ok: cohérent
-    diverged: divergent
-    unknown: en attente
   indexDivergedTitle: "{diverged} divergence(s) entre l'index servi et la source vérifiée"
   indexCountMismatch: "nombre de lignes : {expected} attendues, {actual} servies"
   indexKind:
@@ -838,7 +849,6 @@ fr:
   disableConfirm: Désactiver
   trailAlteredTitle: Historique de révisions altéré
   trailAlteredBody: "L'historique verrouillé présente des signes d'altération (révisions réécrites ou masquées). Les versions d'origine sont intactes dans l'entrepôt ; investiguez (accès à l'entrepôt compromis ?) avant d'acquitter."
-  trailOkBody: Historique de révisions vérifié, aucune altération détectée.
   anomaly_delete-marker: Révision masquée
   anomaly_version-divergence: Révision réécrite
   anomaly_date-skew: Date incohérente
@@ -854,6 +864,11 @@ en:
   part_metadata: Metadata
   part_lines: Lines
   part_index: Search index
+  part_trail: Locked history
+  partStatus_ok: verified
+  partStatus_diverged: diverged
+  partStatus_altered: altered
+  partStatus_unknown: pending
   breachTitle: Integrity breach
   breachBody: modified outside the legitimate write path
   okBody: Integrity verified, no divergence detected.
@@ -865,7 +880,6 @@ en:
   renewalFailedTitle: Lock renewal failing
   renewalFailedBody: Renewal of the tamper-protection lock is failing. The guarantee will lapse at the anchor's retain-until date unless resolved.
   lastCheck: Last check
-  neverChecked: No check run yet
   checkNow: Check now
   refresh: Refresh
   refreshHelp: Re-reads the integrity status and the revision history.
@@ -923,11 +937,6 @@ en:
   linesRestoreOk: Line restore started
   lineRevisionsTitle: "History of line {lineId}"
   lineDeletedRevision: This revision corresponds to the line's deletion.
-  indexVerdictTitle: Search index (served data)
-  indexStatus:
-    ok: consistent
-    diverged: diverged
-    unknown: pending
   indexDivergedTitle: "{diverged} divergence(s) between the served index and the verified source"
   indexCountMismatch: "line count: {expected} expected, {actual} served"
   indexKind:
@@ -947,7 +956,6 @@ en:
   disableConfirm: Disable
   trailAlteredTitle: Revision trail altered
   trailAlteredBody: "The locked history shows signs of alteration (rewritten or hidden revisions). The original versions are intact in the store; investigate (compromised store access?) before acknowledging."
-  trailOkBody: Revision trail verified, no alteration detected.
   anomaly_delete-marker: Hidden revision
   anomaly_version-divergence: Rewritten revision
   anomaly_date-skew: Inconsistent date
@@ -996,6 +1004,26 @@ const anyBreach = computed(() => state.value?.lastCheck?.status === 'breach')
 // dataset. Reconciling is exactly the remedy (it anchors the current state), so the action stays
 // offered here even though this is not a breach.
 const missingAnchor = computed(() => !!state.value?.active && !!state.value?.lastCheck && !state.value?.lastRevision)
+
+// The parts the check actually covered, each with its own status — the panel renders one row per
+// entry. `breach` is a list of the parts that diverged, so a part not in it passed. Only a
+// definitive verdict (ok | breach) carries part-level information: after an inconclusive check
+// there is nothing to say per part, and rendering every row as verified would be a lie.
+// `file` exists only on file datasets, `lines` only on REST ones; `index` and `trail` carry their
+// own status (the index can be individually pending when Elasticsearch is unreachable).
+type VerdictPart = { key: string, status: 'ok' | 'diverged' | 'altered' | 'unknown' }
+const verdictParts = computed<VerdictPart[]>(() => {
+  const lastCheck = state.value?.lastCheck
+  if (!lastCheck || (lastCheck.status !== 'ok' && lastCheck.status !== 'breach')) return []
+  const breach: string[] = lastCheck.breach ?? []
+  const parts: VerdictPart[] = []
+  if (!dataset.value?.isRest) parts.push({ key: 'file', status: breach.includes('file') ? 'diverged' : 'ok' })
+  parts.push({ key: 'metadata', status: breach.includes('metadata') ? 'diverged' : 'ok' })
+  if (dataset.value?.isRest) parts.push({ key: 'lines', status: breach.includes('lines') ? 'diverged' : 'ok' })
+  if (lastCheck.index) parts.push({ key: 'index', status: lastCheck.index.status === 'diverged' ? 'diverged' : (lastCheck.index.status === 'ok' ? 'ok' : 'unknown') })
+  if (lastCheck.trail) parts.push({ key: 'trail', status: lastCheck.trail.status === 'altered' ? 'altered' : 'ok' })
+  return parts
+})
 
 const size = 10
 const page = ref(1)

--- a/ui/src/components/dataset/dataset-integrity.vue
+++ b/ui/src/components/dataset/dataset-integrity.vue
@@ -22,8 +22,9 @@
         />
       </template>
 
-      <!-- only for readers without the switch above (owner admins): for them this is the sole
-           indication that nothing is being checked -->
+      <!-- readers without the switch above only reach this while integrity is being turned off
+           under them (the tab itself is hidden to them once it is off) — keep telling them why
+           the panel emptied rather than showing a blank tab -->
       <v-alert
         v-if="!state.active && !adminMode"
         type="info"

--- a/ui/src/components/dataset/dataset-integrity.vue
+++ b/ui/src/components/dataset/dataset-integrity.vue
@@ -15,11 +15,17 @@
           class="mb-2"
           @update:model-value="(v) => v ? toggle.execute(true) : disableDialog = true"
         />
-        <v-divider class="mb-4" />
+        <!-- nothing follows the switch when integrity is off: no rule to draw either -->
+        <v-divider
+          v-if="state.active"
+          class="mb-4"
+        />
       </template>
 
+      <!-- only for readers without the switch above (owner admins): for them this is the sole
+           indication that nothing is being checked -->
       <v-alert
-        v-if="!state.active"
+        v-if="!state.active && !adminMode"
         type="info"
         variant="tonal"
         :text="t('disabledInfo')"

--- a/ui/src/pages/dataset/[id]/index.vue
+++ b/ui/src/pages/dataset/[id]/index.vue
@@ -1135,8 +1135,11 @@ const sections = computedDeepDiff(() => {
   }
   // Integrity tab — appended to the activity section, creating it if eventsIntegration is off.
   // Reads (status + revision history) are visible to the owner's admins; the enable/disable and
-  // reconcile (fix) actions inside the panel remain superadmin-only.
-  if (canReadIntegrity.value) {
+  // reconcile (fix) actions inside the panel remain superadmin-only. Which is why the tab is only
+  // offered to a reader once integrity is actually on: with nothing checked there is no status, no
+  // history and no action they could take — an empty tab. A superadmin always gets it, since the
+  // enable switch it holds is how integrity gets turned on in the first place.
+  if (canReadIntegrity.value && (adminMode.value || d.integrity?.active)) {
     // breach verdicts ride the dataset doc itself (integrity field, stripped by clean() for
     // readers without readIntegrity) — no extra request needed to color the tab
     const integrityBreach = d.integrity?.lastCheck?.status === 'breach'


### PR DESCRIPTION
Fixes three things the integrity panel was getting wrong, then makes what it shows readable.

**Attribution.** A file update never anchors at request time: it opens a draft, and the anchor is written by the worker at finalize. `applyPatch` refused to stamp the integrity outbox on any draft write, so the uploader captured at the HTTP boundary was dropped and finalize fell back to its anonymous `origin: 'worker'` — every file update on an enrolled dataset read as an internal write attributed to nobody, in both the hand-validated and auto-validated flows. The attribution now rides the draft through to the anchor.

**Stale verdicts.** `getDatasetFresh` serves a 30s-memoized document and re-reads only when a lightweight projection changes. The checker writes `integrity.lastCheck` without touching `updatedAt` (deliberately — it is the dataset's user-facing modification date), so "check now" kept serving the previous verdict, page reloads included, until the entry expired. The integrity fields joined the projection; the probe moved to `operations.ts` as two pure, unit-tested functions.

**Silent no-op.** A check that runs while a write is being historized reaches no verdict and records nothing by design. That was reported as a success over an unchanged panel; it now says so and tells the user to retry.

Panel, on top of that:
- the inconclusive verdicts are told apart — never checked, inconclusive, and **no revision in the store** (integrity active but the store is empty), which now offers reconcile as its remedy
- self-refreshes over the existing dataset journal channel, plus a refresh button for what no event announces
- one row per verified part (file, metadata, lines, search index, locked history) instead of three different presentations of the same verdict
- author and attribution merged into one column
- the tab is hidden from non-superadmin readers while integrity is off — it was a guaranteed empty page
- Vuetify 4 typography classes: the panel still used the v3 names, which v4 does not emit at all, so 34 of them were silently doing nothing

**Why:** three reports from staging — a file update attributed to "Traitement interne", a "last check" date that only appeared a minute later, and a status banner claiming no check had run next to the timestamp of one that just had.
