### PR TITLE
feat(datasets): complete mode narrows as you type, scoped singleSearch

### DIFF
--- a/api/contract/dataset-api-docs.ts
+++ b/api/contract/dataset-api-docs.ts
@@ -178,7 +178,7 @@ export default (
 
   Le mode "simple" (alias "or") expose directement la fonctionnalité [simple-query-string de Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html)
 
-  Le mode "complete" permet d'enrichir automatiquement la requête soumise par l'utilisateur pour un résultat intuitif dans le contexte d'un champ de type autocomplete. Attention ce mode est potentiellement moins performant et à limiter à des jeux de données au volume raisonnable.
+  Le mode "complete" permet d'enrichir automatiquement la requête soumise par l'utilisateur pour un résultat intuitif dans le contexte d'un champ de type autocomplete : le dernier mot est traité comme un préfixe et chaque mot saisi est exigé, les résultats se restreignent donc au fur et à mesure de la frappe. Attention ce mode est potentiellement moins performant et à limiter à des jeux de données au volume raisonnable.
 
   Le mode "and" exige que chaque mot de la recherche soit présent (le classement des résultats reste celui de la recherche large).
     `,

--- a/api/src/datasets/es/commons.ts
+++ b/api/src/datasets/es/commons.ts
@@ -335,11 +335,15 @@ export const prepareQuery = (dataset: any, query: Record<string, any>, qFields?:
     if (q) {
       const qMode = parseQMode(query.q_mode, DEFAULT_Q_MODE)
       const ignoredWords = query.q_ignored ? parseQIgnored(q, query.q_ignored) : undefined
-      // only new-shape index settings define the `_exact` query-time analyzer
-      const exactMatch = (dataset as any)._indexShape?.singleTextField
-        ? { analyzer: textAnalyzers(config.elasticsearch.defaultAnalyzer).exact, boost: EXACT_MATCH_BOOST }
-        : undefined
-      must.push(buildQClauses(dataset, q, qFields, qMode, sqsOptions, ignoredWords, exactMatch))
+      // only new-shape index settings define the `_exact` query-time analyzer — and only
+      // new-shape indexes need the AND filters' language-analyzed alternative reading (their
+      // string columns have no `.text_standard` left, so a typed stopword would otherwise be
+      // required on scalar fields that cannot contain it; legacy indexes match it in prose)
+      const newShape = !!(dataset as any)._indexShape?.singleTextField
+      const analyzers = textAnalyzers(config.elasticsearch.defaultAnalyzer)
+      const exactMatch = newShape ? { analyzer: analyzers.exact, boost: EXACT_MATCH_BOOST } : undefined
+      const filterAnalyzer = newShape ? analyzers.search : undefined
+      must.push(buildQClauses(dataset, q, qFields, qMode, sqsOptions, ignoredWords, exactMatch, filterAnalyzer))
     }
   }
   // pre-build schema lookup maps for O(1) field resolution

--- a/api/src/datasets/es/operations.ts
+++ b/api/src/datasets/es/operations.ts
@@ -593,6 +593,10 @@ export const buildQClauses = (
 ): any => {
   const { qSearchFields, qStandardFields, qExactFields, qWildcardFields, reduced } = getFilterableFields(dataset, q, qFields)
   const should: any[] = []
+  // on a legacy index the prefix ladder only works on `.text_standard` (legacy `.text` stems
+  // the prefix away). A new-shape `.text` indexes the original tokens too, so it works there —
+  // but scalar/date columns still carry `.text_standard`, hence the union rather than a swap.
+  const prefixFields = dataset._indexShape?.singleTextField ? [...qExactFields, ...qStandardFields] : qStandardFields
   if (qMode === 'complete') {
     // "complete" mode, we try to accomodate for most cases and give the most intuitive results
     // to a search query where the user might be using a autocomplete type control
@@ -601,10 +605,6 @@ export const buildQClauses = (
     // this is performed on the innerfield that uses standard analysis, as language stemming doesn't work well in this case
     // we also perform a contains filter if some wildcard functionnality is activate
     if (!q.includes('*') && !q.includes('?')) {
-      // on a legacy index the prefix ladder only works on `.text_standard` (legacy `.text` stems
-      // the prefix away). A new-shape `.text` indexes the original tokens too, so it works there —
-      // but scalar/date columns still carry `.text_standard`, hence the union rather than a swap.
-      const prefixFields = dataset._indexShape?.singleTextField ? [...qExactFields, ...qStandardFields] : qStandardFields
       if (prefixFields.length) {
         should.push({ simple_query_string: { query: `${q}*`, fields: prefixFields, ...sqsOptions } })
       }
@@ -646,7 +646,7 @@ export const buildQClauses = (
   // of the retained (non-ignored) words: the match set is the plain OR minus docs that
   // only matched ignored words — ignored words keep scoring. Requirements must NEVER move
   // into scoring position (measured 2.5× slower on ES 7, see load-management.md §9).
-  // Not composed with `complete` mode (its prefix/wildcard clauses carry their own semantics).
+  // q_mode=and and q_ignored never compose with `complete`, which gets its own filter below.
   if (qMode !== 'complete') {
     const matchFields = reduced ? qSearchFields : [...qSearchFields, ...qStandardFields]
     if (qMode === 'and' && matchFields.length) {
@@ -660,6 +660,26 @@ export const buildQClauses = (
           filter: [{ bool: { should: retained.map(word => ({ multi_match: { query: word, fields: matchFields } })), minimum_should_match: 1 } }]
         }
       }
+    }
+  }
+
+  // same pattern for a multi-word `complete` query, for a different reason: an autocomplete
+  // must NARROW as the user types, but the scored clauses are a broad OR — their match set is
+  // the union of every typed word (measured 152k → 22k matches once filtered on the §16 corpus,
+  // benchmark/INVESTIGATIONS.md). The filter requires every word, the last one as a prefix —
+  // the startsWith clause's own `q*` expression, so filter and scoring read the prefix
+  // identically. A doc reachable only through the opt-in `*q*` wildcard clause is preserved
+  // by the filter-side alternative. Scores are untouched: page-1 ordering is unchanged, only
+  // totals/aggregations/pagination see the narrowed set.
+  if (qMode === 'complete' && /\s/.test(q)) {
+    const userWildcards = q.includes('*') || q.includes('?')
+    const filterFields = [...new Set([...prefixFields, ...qSearchFields])]
+    if (filterFields.length) {
+      const andClause = { simple_query_string: { query: userWildcards ? q : `${q}*`, fields: filterFields, ...sqsOptions, default_operator: 'and' } }
+      const filter = (qWildcardFields.length && !userWildcards)
+        ? [{ bool: { should: [andClause, { query_string: { query: `*${q}*`, fields: qWildcardFields, ...sqsOptions } }], minimum_should_match: 1 } }]
+        : [andClause]
+      return { bool: { must: [scored], filter } }
     }
   }
   return scored

--- a/api/src/datasets/es/operations.ts
+++ b/api/src/datasets/es/operations.ts
@@ -589,9 +589,26 @@ export const buildQClauses = (
   qMode: string | undefined,
   sqsOptions: any = {},
   ignoredWords?: string[],
-  exactMatch?: { analyzer: string, boost: number }
+  exactMatch?: { analyzer: string, boost: number },
+  filterAnalyzer?: string
 ): any => {
   const { qSearchFields, qStandardFields, qExactFields, qWildcardFields, reduced } = getFilterableFields(dataset, q, qFields)
+
+  // Readings of an AND requirement. The per-field-analyzed reading alone zeroes out on a
+  // new-shape index whenever the query carries a stopword: the only fields whose analyzer
+  // KEEPS the stopword are scalar `.text_standard` and `keyword_insensitive` fields, whose
+  // content can never contain it (string columns lost their `.text_standard`). So the caller
+  // passes the language search analyzer on new-shape datasets and a SECOND reading of the
+  // same requirement is added, analyzed with it (stopwords dropped, numbers kept): a doc
+  // matches if EITHER reading satisfies every word. The field-analyzed reading stays because
+  // it is the only one matching a pure-keyword column's whole value (e.g. "cat-alpha" —
+  // the language analyzer would tokenize it apart).
+  const andReadings = (query: string, fields: string[]): any[] => {
+    const readings: any[] = [{ simple_query_string: { query, fields, ...sqsOptions, default_operator: 'and' } }]
+    if (filterAnalyzer) readings.push({ simple_query_string: { query, fields, ...sqsOptions, analyzer: filterAnalyzer, default_operator: 'and' } })
+    return readings
+  }
+  const anyReading = (readings: any[]): any => readings.length === 1 ? readings[0] : { bool: { should: readings, minimum_should_match: 1 } }
   const should: any[] = []
   // on a legacy index the prefix ladder only works on `.text_standard` (legacy `.text` stems
   // the prefix away). A new-shape `.text` indexes the original tokens too, so it works there —
@@ -650,7 +667,7 @@ export const buildQClauses = (
   if (qMode !== 'complete') {
     const matchFields = reduced ? qSearchFields : [...qSearchFields, ...qStandardFields]
     if (qMode === 'and' && matchFields.length) {
-      return { bool: { must: [scored], filter: [{ simple_query_string: { query: q, fields: matchFields, default_operator: 'and' } }] } }
+      return { bool: { must: [scored], filter: [anyReading(andReadings(q, matchFields))] } }
     }
     if (ignoredWords?.length && matchFields.length) {
       const retained = [...new Set(q.split(/\s+/))].filter(word => !ignoredWords.includes(word))
@@ -675,11 +692,11 @@ export const buildQClauses = (
     const userWildcards = q.includes('*') || q.includes('?')
     const filterFields = [...new Set([...prefixFields, ...qSearchFields])]
     if (filterFields.length) {
-      const andClause = { simple_query_string: { query: userWildcards ? q : `${q}*`, fields: filterFields, ...sqsOptions, default_operator: 'and' } }
-      const filter = (qWildcardFields.length && !userWildcards)
-        ? [{ bool: { should: [andClause, { query_string: { query: `*${q}*`, fields: qWildcardFields, ...sqsOptions } }], minimum_should_match: 1 } }]
-        : [andClause]
-      return { bool: { must: [scored], filter } }
+      const readings = andReadings(userWildcards ? q : `${q}*`, filterFields)
+      if (qWildcardFields.length && !userWildcards) {
+        readings.push({ query_string: { query: `*${q}*`, fields: qWildcardFields, ...sqsOptions } })
+      }
+      return { bool: { must: [scored], filter: [anyReading(readings)] } }
     }
   }
   return scored

--- a/api/src/datasets/routes/master-data.ts
+++ b/api/src/datasets/routes/master-data.ts
@@ -21,8 +21,24 @@ export const registerMasterDataRoutes = (router: Router) => {
     let select = singleSearch.output.key
     if (singleSearch.label) select += ',' + singleSearch.label.key
     // collapse on the output key so suggestions are deduplicated server-side
-    // (the underlying dataset may have multiple rows sharing the same output value)
-    const params: any = { q: req.query.q, size: req.query.size, q_mode: 'complete', select, collapse: singleSearch.output.key }
+    // (the underlying dataset may have multiple rows sharing the same output value).
+    // q is scoped to the value/label columns (a match in an unrelated column would surface
+    // irrelevant suggestions) and suggestions are ordered alphabetically on the output key —
+    // the leading part of the displayed "output (label)" string, and the collapse field, so
+    // every row of a group shares the sort value. Complete-mode scores are constant on
+    // mid-typing prefixes, so relevance ordering would fall back to arbitrary row order
+    // (benchmark/INVESTIGATIONS.md §16). Sorting the output key is safe whenever the endpoint
+    // works at all: a `values: false` output column already breaks the collapse itself, and
+    // parseSort only rejects a column with BOTH sort capabilities disabled.
+    const params: any = {
+      q: req.query.q,
+      size: req.query.size,
+      q_mode: 'complete',
+      q_fields: select,
+      sort: singleSearch.output.key,
+      select,
+      collapse: singleSearch.output.key
+    }
     const qs = []
 
     if (singleSearch.filters) {

--- a/benchmark/INVESTIGATIONS.md
+++ b/benchmark/INVESTIGATIONS.md
@@ -1109,6 +1109,25 @@ these costs the phrase clause is not a perf concern — it's a semantics questio
   user-typed `*`/`?` skips the prefix clause today, so the filter would fall back to the plain
   `q` with `default_operator: and`.
 
+**Stopword trap in AND-position filters (2026-08-07, found while reviewing this branch's
+trade-offs, fixed).** On a new-shape index, `q="de commune"` under the new complete filter —
+and under the PRE-EXISTING `q_mode=and` — returned **0** (live probe; simple: 77). Mechanism,
+verified per-field: string columns lost their `.text_standard` in the keyword_repeat rework,
+so the only fields whose query-side analyzer KEEPS a stopword are scalar `.text_standard`
+(`2019,07,20`-style content) and `keyword_insensitive` — fields whose content can never
+contain it; `simple_query_string` only drops a term when NO field emits tokens for it, so the
+stopword stayed required where it cannot match. This was a silent #534 regression for
+`q_mode=and`, inherited by the complete filter. Fix (prototyped on bench-small, all corners
+measured): the AND requirement gets a SECOND reading analyzed with the language search
+analyzer (stopwords dropped, numbers kept), OR'd with the field-analyzed reading — a doc
+passes if either reading satisfies every word. The field-analyzed reading must stay: it is
+the only one matching a pure-keyword column's whole value («cat-alpha commune» 6 → 0 under an
+analyzer-override-only design, 6 under dual reading). Corner matrix (bench-small, 300 rows):
+`de commune` 0→77, `école de commune` 0→24, `commune 2019` 13 (unchanged, scalar narrowing
+kept), `cat-alpha commune` 6 (kept), `zzz commune` 0 (kept). Gated on new-shape datasets like
+the exact-match clause — legacy indexes match stopwords in their string `.text_standard`
+prose and stay byte-identical.
+
 **Outcome — implemented on this branch (2026-08-06).** Two of the directions shipped as code:
 (1) multi-word `complete` queries now carry the AND filter described above (`buildQClauses`,
 with the wildcard-clause alternative preserved and user-typed wildcards falling back to the

--- a/benchmark/INVESTIGATIONS.md
+++ b/benchmark/INVESTIGATIONS.md
@@ -967,6 +967,168 @@ wide indexes were rebuilt once for the new analyzer (see Setup); subsequent runs
 
 ---
 
+## 16. `q_mode=complete` — ranking review & candidate fixes (2026-08-06)
+
+Follow-up to the §15 family: the keyword_repeat work verified (via `_explain`) that
+`complete` mode's prefix matching is constant-score. This investigation reviews the mode
+end to end — what ordering it actually produces, what it costs, and what ranked
+alternatives would cost — on both a real API-seeded dataset and a purpose-built
+referential corpus. Code: `src/complete-check.ts` (live API+ES probe) and
+`src/experiments/complete-ranking.ts` (self-built-index experiment, §15 convention —
+the `Experiment` interface gained an optional `prepare` hook for raw-ES indexes).
+
+**Part A — live verification (`complete-check.ts`, bench-small seeded at 300 rows through
+the dev API, real post-#534 new-shape index).** The raw-ES reproduction of
+`buildQClauses`' complete-mode body matches the `/lines` API exactly (identical totals
+AND identical scores on all four probes) — the findings below are production behavior,
+not a harness approximation.
+
+| probe | complete total | top-12 distinct scores | simple total |
+|---|---:|---:|---:|
+| `comm` (mid-typing) | 144 | **1** (all 2.0) | **0** |
+| `commune` (full word) | 77 | 8 | 77 |
+| `ecol` (mid-typing) | 87 | 10 | 87 |
+| `commune tour` | **142** (widens!) | 10 | 77 |
+
+Three production facts:
+
+1. **Mid-typing ranking is constant.** `_explain` for `comm`: `sum of: 1.0 text2.text:comm*
+   + 1.0 text1.text:comm*` — the sqs prefix clause rewrites to constant-score per field,
+   summed. Every matching row scores identically; the page order is the `_score` tie-break —
+   `_updatedAt desc, _i desc` on REST datasets (most-recently-written rows first), `_i` asc
+   (file row order) otherwise. An autocomplete over a referential returns "the first/latest
+   rows whose text contains a token starting with what you typed", not the best completions.
+2. **Scoring flickers keystroke by keystroke.** `ecol` IS scored (10 distinct) — not because
+   prefix ranking works but because "ecol" happens to be the `light_french` stem of «école»,
+   so the *plain* clause matches. Same for `commune`. But `comm` is no stem → constant. The
+   stems are unpredictable (`_analyze`: «Marie» → `mar`, «marché» → `march`, «Marseille» →
+   `marseil`), so as the user types, the suggestion order oscillates between real scoring and
+   arbitrary row order at stem-coincidence boundaries.
+3. **Multi-word queries widen instead of narrowing.** The prefix clause `commune tour*` is an
+   OR (`simple_query_string` default): 77 hits for `commune` grows to 142 — the opposite of
+   what an autocomplete user expects as they keep typing. Page-1 still looks right (docs
+   matching both words sum both clauses and outrank), but the match set — what
+   aggregations/facets/exports/totals see — is the union.
+
+**Part B — cost & candidate-fix A/B (`complete-ranking` experiments).** Self-built index
+`benchmark-complete-ranking`: 200k docs, 1 shard, force-merged; a referential-flavored
+corpus (establishment `label` = «{type} {commune}», `commune` drawn Zipfian from 78 names
+with deliberate prefix families — mar → Marseille/Martigues/Marché/Mairie/Saint-Martin/
+Sainte-Marie…, comm → Commercy/Communay/commune/commerce —, French-sentence `description`,
+keyword `category`, integer `year`); mapping is the exact new-shape `esProperty` output and
+the analysis settings are transcribed from `indexBase`. Arms: production complete body
+(baseline), its prefix clause alone, production simple-mode body, `multi_match bool_prefix`,
+per-field `prefix` with `rewrite: top_terms_blended_freqs_1024` (ranked-prefix), baseline +
+scoring-only value tiers (`term`^8 / value-`prefix`^4 on `label/commune.keyword_insensitive`),
+and the aggregation alternative (prefix filter + `terms` agg on `label` ordered by `_count`,
+`request_cache: false` since a `size:0` body is shard-request-cacheable and the hits arms
+are not).
+
+`took` p50 ms, 20 runs, warm (`experiment-2026-08-06T15-39-06-000Z.json`):
+
+| arm | `mar` (124 682) | `comm` (108 905) | `marseille` (40 696) | `saint mar` (152 422) |
+|---|---:|---:|---:|---:|
+| complete-today | 4.0 | 3.0 | 3.0 | 7.0 |
+| prefix-only | 4.5 | 2.0 | 2.0 | 5.5 |
+| simple-mode | 0.0 (1 015 hits) | 0.0 (**0 hits**) | 4.0 | 4.0 (49 655) |
+| bool-prefix | 5.0 | 3.0 | 2.0 | 6.0 |
+| ranked-prefix | 9.0 (**+125%**) | 3.0 | 2.0 | 11.0 (**+57%**) |
+| tiered | 5.0 | 3.0 | 4.0 | 7.0 |
+| agg-popularity | **2.0** | **2.0** | **1.0** | **2.0** |
+
+Ranking evidence (top-5 labels + distinct-score count in the top-20, printed by
+`printRankingEvidence`):
+
+- **complete-today**: 1 distinct score on every probe. For `mar` the top-20 is whatever rows
+  the tie-break yields — here «…Sainte-Marie» rows, because «Marie» stems to `mar` and the
+  plain clause adds an identical constant on this uniform corpus. Order conveys nothing.
+- **bool-prefix**: identical constant behavior (1 distinct score) at the same cost —
+  confirms from the query side what §15/T9 found from the index side (`index_prefixes`/SAYT):
+  ES has no cheap ranked-prefix primitive; `bool_prefix`'s prefix leg is constant-score too.
+- **ranked-prefix** (`top_terms_blended_freqs_1024`): the only arm whose *scores* respond to
+  the prefix expansion — but on a short-label corpus it still collapses to 1 distinct score
+  (docs match the same expanded terms with TF=1), ranks by "how many mar\*-terms does the doc
+  contain" («Marché couvert Marseille» first — 2 expansions), and costs up to +125%. Blended
+  IDF also ranks *rare* completions above common ones — backwards for autocomplete. Not the fix.
+- **tiered**: value-startsWith rows do surface («Marché couvert …» for `mar`) at +0..+33%
+  cost, but the additive tier boosts (^8/^4 constants) sit ON TOP of unbounded BM25 clause
+  sums: for `mar` the accidental «Sainte-Marie» stem score (21.5) swamps the ^4 startsWith
+  tier — the "best" tier only wins the tie-break within equal base scores. A real tiered
+  design must let tiers dominate (rescore/dis_max or much larger constants) — same class of
+  interaction §15.c found between a static boost clause and shape-dependent scoring.
+- **agg-popularity**: the *cheapest* arm on every probe (aggs skip top-k scoring entirely;
+  1-2 ms with request cache off) and the only one whose order is intuitively right — most
+  frequent matching values first («Piscine municipale Marseille (4163)» for `mar`;
+  «Gymnase Saint-Martin (199)» for `saint martin`). It also exposes a mode-independent flaw:
+  for `comm` the suggestions are all «… Marseille» — the query matched «commune» in the
+  *description* of popular rows, not the label. Any group-by-output autocomplete (today's
+  singleSearch `collapse` included) must restrict `q` to the fields the user is completing
+  (`q_fields`), or popular-but-irrelevant values dominate.
+
+**Sanity checks (all PASS).** `term`/`prefix` on `.keyword_insensitive` normalizes the query
+input (folded «école primaire marseille» → 4 063); the accent prefix ladder never zeroes on
+the new shape (`ec/ecu/ecul/ecull` → 51 548/1 939/1 939/1 939); complete-today `mar` top-20 =
+1 distinct score; prefix-only `comm` top-20 `_i` values are strictly ascending — the "ranking"
+is literally row order.
+
+**Reading.** `complete` mode is *correct as a matcher* (the union prefix routing works,
+accents included, and page-1 cost is a non-issue at 3-7 ms/200k — consistent with §15.b's
+5 ms at 40×100k) but *vacuous as a ranker* exactly where it is aimed: mid-typing over a
+referential. No query-shape tweak measured here fixes that — the two levers that actually
+order suggestions usefully are (a) popularity of the completed *value* (agg-shaped, cheapest)
+and (b) explicit match-quality tiers on the *value* fields (needs dominance design). Both
+point away from "scored line search" and toward a value-completion primitive for the
+singleSearch/autocomplete use case, with `q_fields` restricted to the completed column(s);
+`q_mode=complete` on `/lines` would remain as the recall-oriented legacy surface. Multi-word
+narrowing (AND-filter with OR scoring, the `q_mode=and` "score broad, match strict" pattern)
+composes with either. §15's R7 (phrase/wildcard clause contribution) remains open, though at
+these costs the phrase clause is not a perf concern — it's a semantics question.
+
+**Follow-up probes (same day).**
+
+- *Is singleSearch really line-ordered, or alphabetical?* Line-ordered, verified live: a real
+  `masterData.singleSearchs` config on bench-small, `q=comm` → suggestions `cat-eta, cat-alpha,
+  cat-beta, cat-kappa, cat-zeta, cat-epsilon`, all at score 2 — not alphabetical; the collapse
+  groups ride the `_score → _updatedAt desc → _i desc` tie-break (`prepareQuery`, commons.ts;
+  the collapse wiring adds no ordering of its own). The alphabetical impression comes from the
+  OTHER autocomplete surface: `/values/{field}` (`es/values.ts`) sorts `_key asc` by default
+  and, with a `q`, cascades `[max_score desc, _count desc, _key asc]` — and since complete-mode
+  scores are constant, that cascade already degrades gracefully to popularity-then-alphabetical.
+  `/values` also scopes `q` to the completed field itself (`prepareQuery(dataset, query,
+  [fieldKey])`), so it dodges the matched-in-description trap natively. In other words the
+  "value-completion primitive" §16 points at already exists for raw values; singleSearch is
+  the outlier (it needs the output+label pair and static filters, which `/values` lacks — and
+  count ordering there implies the agg shape, since `collapse` can only sort groups by the top
+  hit's sort values, never by group size).
+- *AND instead of OR in complete mode* — filter-side (the `q_mode=and` "score broad, match
+  strict" pattern; scoring clauses untouched), filter = `simple_query_string(q*,
+  prefixFields, default_operator: and)`: `saint mar` 152 422 → **21 915** matches, top =
+  Sainte-Marie/Saint-Mar\* rows; `commune tour` 87 120 → **2 152**, top = «Mairie Tours» —
+  the narrowing-as-you-type semantics an autocomplete expects, totals/facets coherent, for
+  ~+2 ms e2e on the 200k corpus. Edge cases for an implementation: single-word q is a no-op;
+  user-typed `*`/`?` skips the prefix clause today, so the filter would fall back to the plain
+  `q` with `default_operator: and`.
+
+**Outcome — implemented on this branch (2026-08-06).** Two of the directions shipped as code:
+(1) multi-word `complete` queries now carry the AND filter described above (`buildQClauses`,
+with the wildcard-clause alternative preserved and user-typed wildcards falling back to the
+plain `q` requirement); (2) singleSearch scopes `q` to the output+label columns
+(`q_fields`) and orders suggestions alphabetically on the OUTPUT key (`sort`, via
+`.keyword_insensitive`) — it leads the displayed «output (label)» string and is the collapse
+field, so group order is well-defined, and it can never introduce a sort 400 on a working
+config (a `values: false` output already breaks the collapse itself, and `parseSort` only
+rejects a column with both sort capabilities disabled). Count ordering was considered and
+rejected by the repo owner; label-sort was rejected because the label column is not
+collapse-constrained (it could legitimately be fully non-sortable and would then 400).
+Covered by q-fields.unit, search-basic.api and master-data-advanced.api specs.
+
+Index kept and reused (drop with `curl -XDELETE $ES/benchmark-complete-ranking`). Results:
+`experiment-2026-08-06T15-39-06-000Z.json` (warm + profile; an earlier
+`…15-37-16-074Z.json` run predates the `request_cache: false` fix on the agg arm — its
+agg-popularity 0 ms rows are cache reads, ignore them).
+
+---
+
 ## Recording results
 
 Harness runs save JSON to `benchmark/results/` tagged with the git commit. When an

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -37,7 +37,8 @@ and `BENCHMARK_ES_NODES` environment variables if needed.
 
 Presets: `small` (1k rows), `tall` (2M, for track_total_hits), `wide-text` (300k, ~40
 text columns), `mixed` (500k, all types). Experiments: `track-total-hits:*`,
-`search-catchall:wide-q`, `min-should-match:wide-q`.
+`search-catchall:wide-q`, `min-should-match:wide-q`, `complete-ranking:*` (self-built
+index — runs with `--no-seed`, no API needed), and more — see `src/experiments.ts`.
 
 ## Results
 

--- a/benchmark/src/complete-check.ts
+++ b/benchmark/src/complete-check.ts
@@ -1,0 +1,104 @@
+// Live probe of `q_mode=complete` ranking behavior against a real (API-seeded) dataset.
+// Runs the data-fair /lines API and a raw-ES reproduction of buildQClauses' complete-mode
+// body side by side: validates the reproduction (totals must match), prints the _score
+// distribution of the top hits (the constant-ranking question), and _explain's account
+// of where the score comes from.
+// Usage: node --experimental-strip-types src/complete-check.ts [--dataset=bench-small] [--size=12]
+
+import { parseArgs } from 'node:util'
+import { init, getAxios } from './setup.ts'
+import { getEsClient, resolveIndex } from './es.ts'
+
+const { values } = parseArgs({
+  options: {
+    dataset: { type: 'string', default: 'bench-small' },
+    size: { type: 'string', default: '12' }
+  }
+})
+const size = parseInt(values.size!)
+
+const PROBES = ['comm', 'commune', 'ecol', 'commune tour']
+
+/** Transcription of getFilterableFields for a raw mapping (new keyword_repeat shape). */
+function deriveFields (mappingProps: Record<string, any>) {
+  const qExactFields: string[] = []
+  const qStandardFields: string[] = []
+  const qSearchFields: string[] = []
+  for (const [key, prop] of Object.entries(mappingProps)) {
+    if (key.startsWith('_')) continue
+    const fields = prop.fields ?? {}
+    if (fields.text) { qExactFields.push(`${key}.text`); qSearchFields.push(`${key}.text`) }
+    if (fields.text_standard) { qStandardFields.push(`${key}.text_standard`); qSearchFields.push(`${key}.text_standard`) }
+    // pure-keyword string column: keyword main type, no analyzed inner fields
+    if (prop.type === 'keyword' && !fields.text && !fields.text_standard) {
+      qSearchFields.push(fields.keyword_insensitive ? `${key}.keyword_insensitive` : key)
+    }
+  }
+  return { qExactFields, qStandardFields, qSearchFields }
+}
+
+/** buildQClauses, complete mode, new-shape dataset (no wildcard columns). */
+function completeBody (q: string, f: ReturnType<typeof deriveFields>) {
+  const should: any[] = []
+  const prefixFields = [...f.qExactFields, ...f.qStandardFields]
+  if (!q.includes('*') && !q.includes('?')) {
+    should.push({ simple_query_string: { query: `${q}*`, fields: prefixFields } })
+  }
+  if (q.includes(' ') && !q.includes('"')) {
+    should.push({ simple_query_string: { query: `"${q}"`, fields: f.qSearchFields } })
+  }
+  should.push({ simple_query_string: { query: q, fields: f.qSearchFields } })
+  return {
+    query: { bool: { should, minimum_should_match: 1 } },
+    size,
+    track_total_hits: true,
+    sort: ['_score', { _updatedAt: 'desc' as const }, { _i: 'desc' as const }]
+  }
+}
+
+function scoreSummary (scores: number[]): string {
+  const distinct = [...new Set(scores.map(s => s.toFixed(4)))]
+  return `${scores.length} hits, ${distinct.length} distinct score(s): [${distinct.slice(0, 6).join(', ')}${distinct.length > 6 ? ', …' : ''}]`
+}
+
+async function main () {
+  await init()
+  const ax = getAxios()
+  const es = getEsClient()
+  const index = await resolveIndex(values.dataset!)
+  const mapping: any = await es.indices.getMapping({ index })
+  const props = Object.values(mapping as Record<string, any>)[0].mappings.properties
+  const fields = deriveFields(props)
+  console.log(`\nindex=${index}`)
+  console.log(`prefixFields=${[...fields.qExactFields, ...fields.qStandardFields].join(',')}`)
+  console.log(`qSearchFields=${fields.qSearchFields.join(',')}`)
+
+  for (const q of PROBES) {
+    console.log(`\n=== q="${q}" ===`)
+    for (const qMode of ['complete', 'simple']) {
+      const api: any = (await ax.get(`/api/v1/datasets/${values.dataset}/lines`, { params: { q, q_mode: qMode, size } })).data
+      const scores = api.results.map((r: any) => r._score)
+      console.log(`  API  ${qMode.padEnd(8)} total=${String(api.total).padEnd(4)} ${scoreSummary(scores)}`)
+    }
+    const body = completeBody(q, fields)
+    const esRes: any = await es.search({ index, ...body })
+    const esScores = esRes.hits.hits.map((h: any) => h._score)
+    console.log(`  ES   repro    total=${String(esRes.hits.total.value).padEnd(4)} ${scoreSummary(esScores)}`)
+
+    // _explain the top hit of the raw-ES reproduction
+    const top = esRes.hits.hits[0]
+    if (top) {
+      const explain: any = await es.explain({ index: top._index, id: top._id, query: body.query })
+      const flat: string[] = []
+      const walk = (node: any, depth: number) => {
+        if (depth > 2 || !node) return
+        flat.push(`${'  '.repeat(depth)}${node.value?.toFixed?.(4)} ${node.description?.slice(0, 110)}`)
+        for (const d of node.details ?? []) walk(d, depth + 1)
+      }
+      walk(explain.explanation, 0)
+      console.log('  explain(top hit):\n    ' + flat.join('\n    '))
+    }
+  }
+}
+
+main().then(() => process.exit(0), (err) => { console.error(err); process.exit(1) })

--- a/benchmark/src/experiments.test.ts
+++ b/benchmark/src/experiments.test.ts
@@ -6,7 +6,8 @@ import { generateSchema, schemaContext, type SchemaContext } from './generator.t
 
 test('every variant body builds a valid ES query for its preset', () => {
   for (const exp of allExperiments) {
-    const ctx = schemaContext(generateSchema(getPreset(exp.preset)))
+    // prepare-based experiments build their own index; their bodies ignore the preset ctx
+    const ctx = exp.prepare ? schemaContext([]) : schemaContext(generateSchema(getPreset(exp.preset)))
     for (const v of [exp.baseline, ...exp.variants]) {
       const body = v.body(ctx)
       assert.ok(body.query, `${exp.name}/${v.name} produced no query`)
@@ -55,6 +56,8 @@ function isValidQueryTarget (field: string, ctx: SchemaContext): boolean {
 
 test('experiment queries target valid analyzed-text or pure-keyword fields', () => {
   for (const exp of allExperiments) {
+    // prepare-based experiments target their own self-built mapping, not a preset's
+    if (exp.prepare) continue
     const ctx = schemaContext(generateSchema(getPreset(exp.preset)))
     for (const v of [exp.baseline, ...exp.variants]) {
       for (const field of referencedFields(v.body(ctx).query)) {

--- a/benchmark/src/experiments.ts
+++ b/benchmark/src/experiments.ts
@@ -8,6 +8,7 @@ import { msmSearchVsSplitExperiments } from './experiments/msm-search-vs-split.t
 import { terminateAfterExperiments } from './experiments/terminate-after.ts'
 import { msmSkewedExperiments } from './experiments/msm-skewed.ts'
 import { countSplitExperiments } from './experiments/count-split.ts'
+import { completeRankingExperiments } from './experiments/complete-ranking.ts'
 
 export interface QueryVariant {
   name: string
@@ -23,6 +24,9 @@ export interface Experiment {
   name: string
   description: string
   preset: string
+  /** Self-built raw-ES index (bypasses the preset seed path — §15 convention).
+   *  Returns the index name and the row count actually used. */
+  prepare?: (rows?: number) => Promise<{ index: string, rows: number }>
   baseline: QueryVariant
   variants: QueryVariant[]
 }
@@ -36,7 +40,8 @@ export const allExperiments: Experiment[] = [
   ...msmSearchVsSplitExperiments,
   ...terminateAfterExperiments,
   ...msmSkewedExperiments,
-  ...countSplitExperiments
+  ...countSplitExperiments,
+  ...completeRankingExperiments
 ]
 
 const byName = new Map(allExperiments.map(e => [e.name, e]))

--- a/benchmark/src/experiments/complete-ranking.ts
+++ b/benchmark/src/experiments/complete-ranking.ts
@@ -1,0 +1,376 @@
+// q_mode=complete ranking & cost review (INVESTIGATIONS.md §16).
+//
+// Question: `complete` mode's prefix clause is constant-score (verified against a real
+// API-seeded dataset by src/complete-check.ts — every mid-typing keystroke whose prefix
+// is not accidentally a stem returns a single score tier, so "ranking" degenerates to
+// the _i/_updatedAt tie-break, i.e. row order). What would ranked autocomplete cost,
+// and what ordering would each candidate produce?
+//
+// The experiment builds its own index (same convention as §15's text-analyzer family):
+// a referential-flavored corpus — establishments with a label ("École primaire
+// Saint-Martin-de-Provence"), a commune column with Zipfian popularity and deliberate
+// prefix families (mar → Marseille/Martigues/Marché/Saint-Martin…), a French sentence
+// description, a keyword category, a year — mapped EXACTLY as the post-#534 new shape
+// maps them (keyword main + .text keyword_repeat + .keyword_insensitive; analysis
+// settings transcribed from indexBase, api/src/datasets/es/manage-indices.ts).
+//
+// Arms (per probe):
+//   complete-today  production buildQClauses complete-mode body (baseline)
+//   prefix-only     the startsWith clause alone (cost isolation)
+//   simple-mode     production default-mode body (plain q + exact-match boost 0.5)
+//   bool-prefix     multi_match type=bool_prefix over the .text fields
+//   ranked-prefix   per-field prefix queries, rewrite=top_terms_blended_freqs_1024
+//   tiered          complete-today + scoring-only value tiers (term^8 / value-prefix^4
+//                   on label/commune .keyword_insensitive)
+//   agg-popularity  the singleSearch alternative: prefix filter + terms agg on label
+//                   ordered by _count (suggestions = most frequent values)
+
+import type { Experiment } from '../experiments.ts'
+import type { SchemaContext } from '../generator.ts'
+import { mulberry32 } from '../generator.ts'
+import { getEsClient } from '../es.ts'
+
+export const COMPLETE_RANKING_INDEX = 'benchmark-complete-ranking'
+const DEFAULT_ROWS = 200_000
+
+// ---- corpus ----
+
+const SAINT_BASES = ['Martin', 'Marcel', 'Maurice', 'Médard', 'Michel', 'Pierre', 'Paul', 'Denis', 'Julien', 'Étienne']
+const SUFFIXES = ['', '-de-Provence', '-sur-Loire', '-en-Retz', '-la-Forêt']
+const STANDALONE = [
+  'Marseille', 'Martigues', 'Marmande', 'Margaux', 'Marckolsheim',
+  'Commercy', 'Communay', 'Commentry', 'Combourg', 'Compiègne',
+  'Toulouse', 'Tours', 'Tourcoing', 'Nantes', 'Nice', 'Lyon', 'Lille',
+  'Bordeaux', 'Brest', 'Dijon', 'Écully', 'Équeurdreville'
+]
+
+function communeList (): string[] {
+  const list = [...STANDALONE]
+  for (const base of SAINT_BASES) for (const suffix of SUFFIXES) list.push(`Saint-${base}${suffix}`)
+  list.push('Sainte-Marie', 'Sainte-Marie-aux-Mines', 'Sainte-Maxime')
+  return list
+}
+
+const TYPES = [
+  'École primaire', 'Collège', 'Gymnase', 'Médiathèque', 'Marché couvert',
+  'Mairie', 'Piscine municipale', 'Stade', 'Crèche', 'Maison de santé'
+]
+
+const CATEGORIES = ['enseignement', 'sport', 'culture', 'administration', 'santé', 'commerce']
+
+const TEMPLATES = [
+  'La {type} de {commune} publie chaque année les données de fréquentation de la commune.',
+  'Les services municipaux de {commune} assurent la gestion des équipements sportifs et culturels.',
+  'Cet établissement accueille les habitants de {commune} et des communes environnantes.',
+  'Le budget communal de {commune} finance les travaux d\'entretien de la {type}.',
+  'Les associations locales de {commune} organisent des activités dans la {type}.',
+  'La commune de {commune} recense les équipements publics accessibles aux personnes à mobilité réduite.',
+  'Les commerces de proximité de {commune} participent au marché hebdomadaire.',
+  'Le territoire de {commune} regroupe plusieurs écoles et établissements scolaires.',
+  'La {type} contribue à la vie culturelle et associative de {commune}.',
+  'Les données de {commune} sont publiées en open data par les services de la mairie.',
+  'Le tourisme représente une part importante de l\'économie de {commune}.',
+  'La population de {commune} bénéficie des transports en commun de l\'agglomération.'
+]
+
+/** Zipfian pick: rank r with weight 1/(r+1). */
+function zipfPick<T> (list: T[], rand: () => number, cum: number[]): T {
+  const x = rand() * cum[cum.length - 1]
+  let lo = 0; let hi = cum.length - 1
+  while (lo < hi) { const mid = (lo + hi) >> 1; if (cum[mid] < x) lo = mid + 1; else hi = mid }
+  return list[lo]
+}
+
+function cumWeights (n: number): number[] {
+  const cum: number[] = []
+  let acc = 0
+  for (let r = 0; r < n; r++) { acc += 1 / (r + 1); cum.push(acc) }
+  return cum
+}
+
+// ---- index build (production new-shape mapping) ----
+
+// analysis settings transcribed from indexBase (api/src/datasets/es/manage-indices.ts)
+const ANALYSIS = {
+  normalizer: {
+    insensitive_normalizer: { type: 'custom', filter: ['lowercase', 'asciifolding'] }
+  },
+  filter: {
+    french_elision: {
+      type: 'elision',
+      articles_case: true,
+      articles: ['l', 'm', 't', 'qu', 'n', 's', 'j', 'd', 'c', 'jusqu', 'quoiqu', 'lorsqu', 'puisqu']
+    },
+    french_stop: { type: 'stop', stopwords: '_french_' },
+    french_stemmer: { type: 'stemmer', language: 'light_french' }
+  },
+  analyzer: {
+    custom_french: {
+      tokenizer: 'standard',
+      filter: ['french_elision', 'lowercase', 'french_stop', 'french_stemmer', 'asciifolding']
+    },
+    custom_french_repeat: {
+      tokenizer: 'standard',
+      filter: ['french_elision', 'lowercase', 'keyword_repeat', 'french_stop', 'french_stemmer', 'remove_duplicates', 'asciifolding']
+    },
+    custom_french_exact: {
+      tokenizer: 'standard',
+      filter: ['french_elision', 'lowercase', 'asciifolding']
+    }
+  }
+}
+
+/** esProperty new-shape output for a full-text string column. */
+const textColumn = () => ({
+  type: 'keyword',
+  ignore_above: 200,
+  fields: {
+    text: { type: 'text', analyzer: 'custom_french_repeat', search_analyzer: 'custom_french' },
+    keyword_insensitive: { type: 'keyword', ignore_above: 200, normalizer: 'insensitive_normalizer' }
+  }
+})
+
+const MAPPING = {
+  properties: {
+    _i: { type: 'long' },
+    label: textColumn(),
+    commune: textColumn(),
+    description: textColumn(),
+    category: {
+      type: 'keyword',
+      ignore_above: 200,
+      fields: { keyword_insensitive: { type: 'keyword', ignore_above: 200, normalizer: 'insensitive_normalizer' } }
+    },
+    year: { type: 'long', fields: { text_standard: { type: 'text', analyzer: 'standard' } } }
+  }
+}
+
+// production field routing for this schema (getFilterableFields transcription)
+const Q_EXACT_FIELDS = ['label.text', 'commune.text', 'description.text']
+const Q_STANDARD_FIELDS = ['year.text_standard']
+const Q_SEARCH_FIELDS = [...Q_EXACT_FIELDS, ...Q_STANDARD_FIELDS, 'category.keyword_insensitive']
+const PREFIX_FIELDS = [...Q_EXACT_FIELDS, ...Q_STANDARD_FIELDS]
+
+function * docs (rows: number): Generator<Record<string, unknown>> {
+  const communes = communeList()
+  const cum = cumWeights(communes.length)
+  const rand = mulberry32(1234)
+  for (let i = 0; i < rows; i++) {
+    const commune = zipfPick(communes, rand, cum)
+    const type = TYPES[Math.floor(rand() * TYPES.length)]
+    const template = TEMPLATES[Math.floor(rand() * TEMPLATES.length)]
+    yield {
+      _i: i,
+      label: `${type} ${commune}`,
+      commune,
+      description: template.replaceAll('{commune}', commune).replaceAll('{type}', type.toLowerCase()),
+      category: CATEGORIES[Math.floor(rand() * CATEGORIES.length)],
+      year: 2015 + Math.floor(rand() * 10)
+    }
+  }
+}
+
+/** Build (or reuse) the index. Reuse requires matching doc count AND the repeat analyzer
+ *  (§15.c lesson: a doc-count-only check silently reuses a stale-analysis index). */
+export async function prepareCompleteRankingIndex (rows = DEFAULT_ROWS): Promise<string> {
+  const es = getEsClient()
+  const index = COMPLETE_RANKING_INDEX
+  if (await es.indices.exists({ index })) {
+    const [count, settings] = await Promise.all([
+      es.count({ index }),
+      es.indices.getSettings({ index })
+    ])
+    const analyzers = (Object.values(settings as Record<string, any>)[0])?.settings?.index?.analysis?.analyzer ?? {}
+    if (count.count === rows && analyzers.custom_french_repeat && analyzers.custom_french_exact) {
+      console.log(`[complete-ranking] reusing ${index} (${rows.toLocaleString()} docs)`)
+      return index
+    }
+    console.log(`[complete-ranking] rebuilding ${index} (stale count or analysis)`)
+    await es.indices.delete({ index })
+  }
+  console.log(`[complete-ranking] building ${index} (${rows.toLocaleString()} docs)…`)
+  await es.indices.create({
+    index,
+    settings: { index: { number_of_shards: 1, number_of_replicas: 0, refresh_interval: '-1' }, analysis: ANALYSIS } as any,
+    mappings: MAPPING as any
+  })
+  let batch: any[] = []
+  let sent = 0
+  const flush = async () => {
+    if (!batch.length) return
+    const res = await es.bulk({ operations: batch })
+    if (res.errors) throw new Error('bulk indexing errors: ' + JSON.stringify(res.items.find((it: any) => it.index?.error)))
+    sent += batch.length / 2
+    batch = []
+  }
+  for (const doc of docs(rows)) {
+    batch.push({ index: { _index: index, _id: `r${doc._i}` } }, doc)
+    if (batch.length >= 4000) await flush()
+  }
+  await flush()
+  await es.indices.refresh({ index })
+  await es.indices.forcemerge({ index, max_num_segments: 1 })
+  await es.indices.putSettings({ index, settings: { refresh_interval: '1s' } })
+  console.log(`[complete-ranking] built ${index} (${sent.toLocaleString()} docs, force-merged)`)
+  await sanityChecks(index)
+  return index
+}
+
+// ---- query bodies ----
+
+const PAGE = { size: 20, track_total_hits: true, sort: ['_score', '_i'] }
+
+/** Fold a prefix the way insensitive/exact analysis would (raw prefix queries skip analysis). */
+const fold = (s: string) => s.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '')
+
+/** buildQClauses complete mode, new shape, no wildcard columns (production baseline). */
+export function completeTodayBody (q: string) {
+  const should: any[] = []
+  if (!q.includes('*') && !q.includes('?')) {
+    should.push({ simple_query_string: { query: `${q}*`, fields: PREFIX_FIELDS } })
+  }
+  if (q.includes(' ') && !q.includes('"')) {
+    should.push({ simple_query_string: { query: `"${q}"`, fields: Q_SEARCH_FIELDS } })
+  }
+  should.push({ simple_query_string: { query: q, fields: Q_SEARCH_FIELDS } })
+  return { query: { bool: { should, minimum_should_match: 1 } }, ...PAGE }
+}
+
+/** buildQClauses default (simple) mode incl. the exact-match boost clause (EXACT_MATCH_BOOST = 0.5). */
+export function simpleModeBody (q: string) {
+  const should: any[] = [
+    { simple_query_string: { query: q, fields: Q_SEARCH_FIELDS } },
+    { simple_query_string: { query: q, fields: Q_EXACT_FIELDS, analyzer: 'custom_french_exact', boost: 0.5 } }
+  ]
+  return { query: { bool: { should, minimum_should_match: 1 } }, ...PAGE }
+}
+
+export function prefixOnlyBody (q: string) {
+  return { query: { simple_query_string: { query: `${q}*`, fields: PREFIX_FIELDS } }, ...PAGE }
+}
+
+export function boolPrefixBody (q: string) {
+  return { query: { multi_match: { query: q, type: 'bool_prefix', fields: Q_EXACT_FIELDS } }, ...PAGE }
+}
+
+/** Ranked prefix: per-field prefix queries with a scoring rewrite — docs score by the
+ *  blended TF/IDF of the expanded completion terms instead of a constant. */
+export function rankedPrefixBody (q: string) {
+  const terms = fold(q).split(/\s+/)
+  const last = terms[terms.length - 1]
+  const scored = terms.slice(0, -1).join(' ')
+  const should: any[] = Q_EXACT_FIELDS.map(f => ({
+    prefix: { [f]: { value: last, rewrite: 'top_terms_blended_freqs_1024' } }
+  }))
+  if (scored) should.push({ simple_query_string: { query: scored, fields: Q_SEARCH_FIELDS } })
+  return { query: { bool: { should, minimum_should_match: 1 } }, ...PAGE }
+}
+
+/** complete-today + scoring-only "match quality" tiers on the value columns:
+ *  whole-value equality (^8) then value-startsWith (^4), case/accent-insensitive. */
+export function tieredBody (q: string) {
+  const base = completeTodayBody(q)
+  const folded = fold(q)
+  for (const col of ['label', 'commune']) {
+    base.query.bool.should.push(
+      { term: { [`${col}.keyword_insensitive`]: { value: folded, boost: 8 } } },
+      { prefix: { [`${col}.keyword_insensitive`]: { value: folded, boost: 4 } } }
+    )
+  }
+  return base
+}
+
+/** The singleSearch alternative: same match set as prefix-only, suggestions ranked by
+ *  popularity (terms agg ordered by _count) instead of by (constant) score. */
+export function aggPopularityBody (q: string) {
+  return {
+    query: { simple_query_string: { query: `${q}*`, fields: PREFIX_FIELDS } },
+    size: 0,
+    track_total_hits: true,
+    // size:0 requests are shard-request-cacheable, unlike the hits arms — disable for a fair A/B
+    request_cache: false,
+    aggs: { suggestions: { terms: { field: 'label', order: { _count: 'desc' }, size: 20 } } }
+  }
+}
+
+const ARMS: Record<string, (q: string) => Record<string, any>> = {
+  'complete-today': completeTodayBody,
+  'prefix-only': prefixOnlyBody,
+  'simple-mode': simpleModeBody,
+  'bool-prefix': boolPrefixBody,
+  'ranked-prefix': rankedPrefixBody,
+  tiered: tieredBody,
+  'agg-popularity': aggPopularityBody
+}
+
+// ---- sanity checks & ranking evidence (printed at build time) ----
+
+async function sanityChecks (index: string): Promise<void> {
+  const es = getEsClient()
+
+  // S1 — normalizer applies to term/prefix input on .keyword_insensitive
+  const s1: any = await es.search({ index, query: { term: { 'label.keyword_insensitive': 'école primaire marseille' } }, size: 0, track_total_hits: true })
+  console.log(`[sanity] S1 term on keyword_insensitive (folded input) hits=${s1.hits.total.value} ${s1.hits.total.value > 0 ? 'PASS' : 'FAIL'}`)
+
+  // S2 — accent ladder: every ASCII prefix of "écully" matches on the new shape
+  let s2ok = true
+  for (const p of ['ec', 'ecu', 'ecul', 'ecull']) {
+    const r: any = await es.search({ index, ...prefixOnlyBody(p), size: 0 })
+    if (r.hits.total.value === 0) { s2ok = false; console.log(`[sanity] S2 prefix "${p}" → 0 hits`) }
+  }
+  console.log(`[sanity] S2 accent prefix ladder ${s2ok ? 'PASS' : 'FAIL'}`)
+
+  // S3 — constant-ranking exhibit: distinct score count of complete-today at a mid-typing keystroke
+  const s3: any = await es.search({ index, ...completeTodayBody('mar') })
+  const distinct = [...new Set(s3.hits.hits.map((h: any) => h._score))]
+  console.log(`[sanity] S3 complete-today q="mar": total=${s3.hits.total.value}, top-20 distinct scores=${distinct.length} (${distinct.slice(0, 4).join(', ')}) — expected 1-2 tiers`)
+}
+
+/** Qualitative ranking evidence: top suggestions per arm for each probe. */
+export async function printRankingEvidence (index: string, probes: string[]): Promise<void> {
+  const es = getEsClient()
+  for (const q of probes) {
+    console.log(`\n[ranking] q="${q}"`)
+    for (const [arm, builder] of Object.entries(ARMS)) {
+      const body = builder(q)
+      const res: any = await es.search({ index, ...body })
+      let display: string
+      if (body.aggs) {
+        display = res.aggregations.suggestions.buckets.slice(0, 5).map((b: any) => `${b.key} (${b.doc_count})`).join(' | ')
+      } else {
+        const distinct = new Set(res.hits.hits.map((h: any) => h._score)).size
+        display = res.hits.hits.slice(0, 5).map((h: any) => `${h._source.label}@${h._score.toFixed(2)}`).join(' | ') + `  [${distinct} distinct scores/20]`
+      }
+      console.log(`  ${arm.padEnd(15)} total=${String(res.hits.total.value).padEnd(7)} ${display}`)
+    }
+  }
+}
+
+// ---- experiment definitions ----
+
+const PROBES: Record<string, string> = {
+  'mid-word': 'mar',
+  ambiguous: 'comm',
+  'full-word': 'marseille',
+  'two-words': 'saint mar'
+}
+
+export const completeRankingExperiments: Experiment[] = Object.entries(PROBES).map(([probeName, q]) => ({
+  name: `complete-ranking:${probeName}`,
+  description: `complete-mode ranking/cost candidates, q="${q}"`,
+  preset: 'custom',
+  prepare: async (rows?: number) => ({
+    index: await prepareCompleteRankingIndex(rows ?? DEFAULT_ROWS),
+    rows: rows ?? DEFAULT_ROWS
+  }),
+  baseline: {
+    name: 'complete-today',
+    description: 'production complete-mode body (constant-score prefix)',
+    body: (_ctx: SchemaContext) => completeTodayBody(q)
+  },
+  variants: Object.entries(ARMS).filter(([name]) => name !== 'complete-today').map(([name, builder]) => ({
+    name,
+    description: name,
+    body: (_ctx: SchemaContext) => builder(q)
+  }))
+}))

--- a/benchmark/src/index.ts
+++ b/benchmark/src/index.ts
@@ -74,11 +74,22 @@ async function experimentCommand (argv: string[]): Promise<void> {
   if (!values['no-seed']) await init()
   const results: ExperimentResult[] = []
   for (const exp of selectExperiments(values.name!)) {
-    const spec = getPreset(exp.preset)
-    if (values.rows) spec.rows = parseInt(values.rows)
-    if (!values['no-seed']) await seedDataset(spec)
-    const index = await resolveIndex(spec.id)
-    const ctx = schemaContext(generateSchema(spec))
+    let index: string
+    let rows: number
+    let ctx = schemaContext([])
+    if (exp.prepare) {
+      // self-built raw-ES index — no preset seeding, no API dependency
+      const prepared = await exp.prepare(values.rows ? parseInt(values.rows) : undefined)
+      index = prepared.index
+      rows = prepared.rows
+    } else {
+      const spec = getPreset(exp.preset)
+      if (values.rows) spec.rows = parseInt(values.rows)
+      if (!values['no-seed']) await seedDataset(spec)
+      index = await resolveIndex(spec.id)
+      ctx = schemaContext(generateSchema(spec))
+      rows = spec.rows
+    }
     const variants = [
       { ...exp.baseline, isBaseline: true },
       ...exp.variants.map(v => ({ ...v, isBaseline: false }))
@@ -101,7 +112,7 @@ async function experimentCommand (argv: string[]): Promise<void> {
       experiment: exp.name,
       description: exp.description,
       preset: exp.preset,
-      rows: spec.rows,
+      rows,
       variants: variantResults
     }
     printExperimentReport(er)

--- a/docs/architecture/text-search-evaluation.md
+++ b/docs/architecture/text-search-evaluation.md
@@ -434,6 +434,22 @@ design proposal and defer the empirical leg to the implementation worktree.
 — paired with T13. Replace `q_mode=complete` with an SAYT-backed `multi_match.bool_prefix`;
 the current 4-clause flow becomes the deprecation target once parity is shown.
 
+> **Addendum (2026-08-06)** — measured dead twice over: the SAYT/`index_prefixes` leg in
+> §15 (store cost, no ranking gain), and the query-side leg in `benchmark/INVESTIGATIONS.md`
+> §16 — `bool_prefix` produces the same constant-score prefix as today at the same cost.
+> §16 is the full `complete`-mode review: matching is correct and cheap, but mid-typing
+> ranking degenerates to the `_i`/`_updatedAt` tie-break (row order), oscillating with
+> stem coincidences as the user types, and multi-word queries widen the match set. The
+> levers that actually order suggestions are value-popularity (agg-shaped, cheapest arm
+> measured) and value-level match-quality tiers — both point toward a value-completion
+> primitive (with `q_fields` restricted to the completed column) for the singleSearch /
+> autocomplete workflow, rather than any rework of the scored line search. Shipped from
+> that review: multi-word `complete` queries now require every word through a non-scoring
+> AND filter (last word as prefix — narrowing-as-you-type), and singleSearch scopes `q` to
+> its output+label columns with alphabetical ordering on the output key — the leading part
+> of the displayed «output (label)» string and the collapse field (count ordering was
+> considered and rejected).
+
 ---
 
 ### D. Niche / discussion-only

--- a/docs/architecture/text-search-evaluation.md
+++ b/docs/architecture/text-search-evaluation.md
@@ -445,7 +445,9 @@ the current 4-clause flow becomes the deprecation target once parity is shown.
 > primitive (with `q_fields` restricted to the completed column) for the singleSearch /
 > autocomplete workflow, rather than any rework of the scored line search. Shipped from
 > that review: multi-word `complete` queries now require every word through a non-scoring
-> AND filter (last word as prefix — narrowing-as-you-type), and singleSearch scopes `q` to
+> AND filter (last word as prefix — narrowing-as-you-type; stopword-safe via a dual-reading
+> requirement that also repaired a silent #534 stopword regression in `q_mode=and`), and
+> singleSearch scopes `q` to
 > its output+label columns with alphabetical ordering on the output key — the leading part
 > of the displayed «output (label)» string and the collapse field (count ordering was
 > considered and rejected).

--- a/tests/features/datasets/master-data/master-data-advanced.api.spec.ts
+++ b/tests/features/datasets/master-data/master-data-advanced.api.spec.ts
@@ -576,12 +576,12 @@ test.describe('master data - Multi-level extensions, sorting, date-interval/geo-
     assert.equal(results[0]['_country.name'], 'Japan')
   })
 
-  test('singleSearch should deduplicate results on the output key (ES collapse)', async () => {
+  test('singleSearch deduplicates on the output key, scopes q to value/label columns, alphabetical order', async () => {
     const ax = testSuperadmin
 
     await initMaster(
       ax,
-      [siretProperty, { key: 'denomination', title: 'Denomination', type: 'string' }],
+      [siretProperty, { key: 'denomination', title: 'Denomination', type: 'string' }, { key: 'notes', title: 'Notes', type: 'string' }],
       {
         singleSearchs: [{
           id: 'siret-search',
@@ -592,12 +592,14 @@ test.describe('master data - Multi-level extensions, sorting, date-interval/geo-
       }
     )
 
-    // three lines share the same siret, one has a different siret
+    // three lines share the same siret, two have different sirets; the last one mentions
+    // "Acme" only in a column that is neither the output nor the label
     await ax.post('/api/v1/datasets/master/_bulk_lines', [
       { siret: '82898347800011', denomination: 'Acme A' },
       { siret: '82898347800011', denomination: 'Acme B' },
       { siret: '82898347800011', denomination: 'Acme C' },
-      { siret: '99999999900099', denomination: 'Other corp' }
+      { siret: '99999999900099', denomination: 'Other corp' },
+      { siret: '11111111100011', denomination: 'Zeta corp', notes: 'partner of Acme' }
     ])
     await waitForFinalize(ax, 'master')
 
@@ -605,10 +607,18 @@ test.describe('master data - Multi-level extensions, sorting, date-interval/geo-
     // collapse on `siret` should yield a single hit for the duplicated value, not three
     const acmeHits = res.data.results.filter((r: any) => r.output === '82898347800011')
     assert.equal(acmeHits.length, 1, 'duplicated siret values must be collapsed to a single suggestion')
+    // q only completes the value/label columns: the "partner of Acme" note must not surface Zeta corp
+    assert.deepEqual(res.data.results.map((r: any) => r.output), ['82898347800011'])
 
-    // a broader search must still surface the other distinct siret
+    // an empty search lists every distinct value, ordered alphabetically on the output key
+    // (the leading part of the displayed "output (label)" string)
     const resAll = await ax.get('/api/v1/datasets/master/master-data/single-searchs/siret-search', { params: { q: '' } })
-    const outputs = resAll.data.results.map((r: any) => r.output).sort()
-    assert.deepEqual(outputs, ['82898347800011', '99999999900099'])
+    assert.deepEqual(resAll.data.results.map((r: any) => r.output), ['11111111100011', '82898347800011', '99999999900099'])
+    // the collapsed group displays one of its rows' labels (which one is a tie-break detail)
+    assert.match(resAll.data.results[1].label, /^82898347800011 \(Acme [ABC]\)$/)
+
+    // suggestions stay ordered on the output key within a match set ("corp" matches two labels)
+    const resCorp = await ax.get('/api/v1/datasets/master/master-data/single-searchs/siret-search', { params: { q: 'corp' } })
+    assert.deepEqual(resCorp.data.results.map((r: any) => r.output), ['11111111100011', '99999999900099'])
   })
 })

--- a/tests/features/datasets/query/q-fields.unit.spec.ts
+++ b/tests/features/datasets/query/q-fields.unit.spec.ts
@@ -369,4 +369,36 @@ test.describe('complete-mode AND filter (multi-word narrowing)', () => {
     assert.deepEqual(alternatives[1].query_string.fields, ['w.wildcard'])
     assert.equal(alternatives[1].query_string.query, '*fo ba*')
   })
+
+  // On a new-shape dataset the only .text_standard fields left belong to scalar columns, whose
+  // content can never contain a stopword — a per-field-analyzed AND filter then requires the
+  // stopword where it cannot match and zeroes the query. The fix is a SECOND reading of the same
+  // requirement, analyzed with the language analyzer (stopwords dropped, numbers kept): a doc
+  // passes if EITHER reading matches every word. The field-analyzed reading stays because it is
+  // the only one that matches a pure-keyword column's whole value (e.g. "cat-alpha").
+  test('with a filterAnalyzer the complete filter carries a language-analyzed alternative reading', () => {
+    const schema = [{ key: 'a', type: 'string' }, { key: 'i', type: 'integer' }]
+    const out: any = buildQClauses({ id: 'cf5', finalizedAt: 'f', _indexShape: { singleTextField: true }, schema }, 'fo ba', undefined, 'complete', {}, undefined, undefined, 'custom_french')
+    const readings = out.bool.filter[0].bool.should
+    assert.equal(readings.length, 2)
+    assert.equal(readings[0].simple_query_string.query, 'fo ba*')
+    assert.equal(readings[0].simple_query_string.default_operator, 'and')
+    assert.ok(!readings[0].simple_query_string.analyzer)
+    assert.equal(readings[1].simple_query_string.analyzer, 'custom_french')
+    assert.equal(readings[1].simple_query_string.query, 'fo ba*')
+    assert.equal(readings[1].simple_query_string.default_operator, 'and')
+  })
+
+  test('without a filterAnalyzer (legacy dataset) the complete filter keeps a single reading', () => {
+    const out: any = buildQClauses({ id: 'cf6', finalizedAt: 'f', schema }, 'fo ba', undefined, 'complete')
+    assert.ok(out.bool.filter[0].simple_query_string)
+  })
+
+  test('q_mode=and gets the same alternative reading — it shares the scalar-.text_standard trap', () => {
+    const out: any = buildQClauses({ id: 'cf7', finalizedAt: 'f', _indexShape: { singleTextField: true }, schema }, 'fo ba', undefined, 'and', {}, undefined, undefined, 'custom_french')
+    const readings = out.bool.filter[0].bool.should
+    assert.equal(readings.length, 2)
+    assert.equal(readings[1].simple_query_string.analyzer, 'custom_french')
+    assert.equal(readings[1].simple_query_string.query, 'fo ba')
+  })
 })

--- a/tests/features/datasets/query/q-fields.unit.spec.ts
+++ b/tests/features/datasets/query/q-fields.unit.spec.ts
@@ -330,3 +330,43 @@ test.describe('exact-match routing (new index shape)', () => {
     assert.deepEqual(out.bool.should[1].simple_query_string.fields, ['a.text_standard'])
   })
 })
+
+test.describe('complete-mode AND filter (multi-word narrowing)', () => {
+  const schema = [{ key: 'a', type: 'string' }]
+
+  test('single-word query gets no filter — the prefix clause is the only requirement', () => {
+    const out: any = buildQClauses({ id: 'cf1', finalizedAt: 'f', schema }, 'fo', undefined, 'complete')
+    assert.ok(out.bool.should)
+    assert.ok(!out.bool.must && !out.bool.filter)
+  })
+
+  test('multi-word query wraps the scored OR in a non-scoring AND filter, last word as prefix', () => {
+    const out: any = buildQClauses({ id: 'cf2', finalizedAt: 'f', schema }, 'fo ba', undefined, 'complete')
+    // scores stay the broad OR: prefix + quoted-phrase + plain clauses, untouched
+    assert.equal(out.bool.must[0].bool.should.length, 3)
+    assert.equal(out.bool.must[0].bool.should[0].simple_query_string.query, 'fo ba*')
+    const filter = out.bool.filter[0].simple_query_string
+    assert.equal(filter.query, 'fo ba*')
+    assert.equal(filter.default_operator, 'and')
+    // filter surface covers both the prefix routing and the plain-clause routing
+    assert.ok(filter.fields.includes('a.text_standard'))
+    assert.ok(filter.fields.includes('a.text'))
+  })
+
+  test('user-typed wildcards: prefix clause is skipped and the filter requires q as-is', () => {
+    const out: any = buildQClauses({ id: 'cf3', finalizedAt: 'f', schema }, 'fo* ba', undefined, 'complete')
+    assert.ok(!JSON.stringify(out.bool.must).includes('fo* ba*'))
+    assert.equal(out.bool.filter[0].simple_query_string.query, 'fo* ba')
+    assert.equal(out.bool.filter[0].simple_query_string.default_operator, 'and')
+  })
+
+  test('a wildcard-capability column keeps its *q* recall through a filter-side alternative', () => {
+    const wSchema = [{ key: 'a', type: 'string' }, { key: 'w', type: 'string', 'x-capabilities': { wildcard: true } }]
+    const out: any = buildQClauses({ id: 'cf4', finalizedAt: 'f', schema: wSchema }, 'fo ba', undefined, 'complete')
+    const alternatives = out.bool.filter[0].bool.should
+    assert.equal(alternatives.length, 2)
+    assert.equal(alternatives[0].simple_query_string.default_operator, 'and')
+    assert.deepEqual(alternatives[1].query_string.fields, ['w.wildcard'])
+    assert.equal(alternatives[1].query_string.query, '*fo ba*')
+  })
+})

--- a/tests/features/datasets/query/search-basic.api.spec.ts
+++ b/tests/features/datasets/query/search-basic.api.spec.ts
@@ -398,5 +398,12 @@ test.describe('search - basic', () => {
     assert.equal(res.data.total, 3)
     res = await ax.get('/api/v1/datasets/qmodes/lines', { params: { q: 'mot1 de mot2', q_mode: 'and' } })
     assert.equal(res.data.total, 3)
+    // a QUOTED phrase containing a stopword is one term unit, not per-word requirements — no
+    // zero-out, no widening. The analyzer leaves a position GAP where "de" was, and that gap
+    // is a wildcard slot: the phrase matches p4 ("mot1 de mot2") AND p2 ("mot1 mot3 mot2",
+    // mot3 fills the hole), but not p1 whose mot2 is directly adjacent to mot1
+    res = await ax.get('/api/v1/datasets/qmodes/lines', { params: { q: '"mot1 de mot2"', q_mode: 'complete' } })
+    assert.equal(res.data.total, 2)
+    assert.deepEqual(res.data.results.map((r: any) => r._id).sort(), ['p2', 'p4'])
   })
 })

--- a/tests/features/datasets/query/search-basic.api.spec.ts
+++ b/tests/features/datasets/query/search-basic.api.spec.ts
@@ -345,7 +345,8 @@ test.describe('search - basic', () => {
       t2: 'prefixsuite',
       t3: 'configurations Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt configurations ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit configurer anim id est laborum.',
       p1: 'phrase 1 mot1 mot2 mot3 mot4',
-      p2: 'phrase 2 mot1 mot3 mot2 mot4'
+      p2: 'phrase 2 mot1 mot3 mot2 mot4',
+      p3: 'phrase 3 mot1 seul'
     }
     let res = await ax.post('/api/v1/datasets/qmodes/_bulk_lines', Object.keys(items).map(key => ({ _id: key, content: items[key] })))
     dataset = await waitForFinalize(ax, 'qmodes')
@@ -369,13 +370,23 @@ test.describe('search - basic', () => {
       assert.equal(res.data.total, 1)
     }
     res = await ax.get('/api/v1/datasets/qmodes/lines', { params: { q: 'mot1 mot2', q_mode: 'simple' } })
-    assert.equal(res.data.total, 2)
+    assert.equal(res.data.total, 3)
     assert.equal(res.data.results[0]._score, res.data.results[1]._score)
     res = await ax.get('/api/v1/datasets/qmodes/lines', { params: { q: '"mot1 mot2"', q_mode: 'simple' } })
     assert.equal(res.data.total, 1)
     assert.equal(res.data.results[0]._id, 'p1')
+    // complete mode narrows a multi-word query: every word is required (p3 has mot1 but not mot2),
+    // where the simple OR above matches all three
     res = await ax.get('/api/v1/datasets/qmodes/lines', { params: { q: 'mot1 mot2', q_mode: 'complete' } })
     assert.equal(res.data.total, 2)
     assert.ok(res.data.results[0]._score > res.data.results[1]._score)
+    // the last word acts as a prefix inside the requirement: "mot1 se" keeps only the doc
+    // with mot1 AND a word starting with "se"
+    res = await ax.get('/api/v1/datasets/qmodes/lines', { params: { q: 'mot1 se', q_mode: 'complete' } })
+    assert.equal(res.data.total, 1)
+    assert.equal(res.data.results[0]._id, 'p3')
+    // a single word never narrows: plain prefix behavior
+    res = await ax.get('/api/v1/datasets/qmodes/lines', { params: { q: 'mot1', q_mode: 'complete' } })
+    assert.equal(res.data.total, 3)
   })
 })

--- a/tests/features/datasets/query/search-basic.api.spec.ts
+++ b/tests/features/datasets/query/search-basic.api.spec.ts
@@ -346,7 +346,8 @@ test.describe('search - basic', () => {
       t3: 'configurations Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt configurations ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit configurer anim id est laborum.',
       p1: 'phrase 1 mot1 mot2 mot3 mot4',
       p2: 'phrase 2 mot1 mot3 mot2 mot4',
-      p3: 'phrase 3 mot1 seul'
+      p3: 'phrase 3 mot1 seul',
+      p4: 'phrase 4 mot1 de mot2'
     }
     let res = await ax.post('/api/v1/datasets/qmodes/_bulk_lines', Object.keys(items).map(key => ({ _id: key, content: items[key] })))
     dataset = await waitForFinalize(ax, 'qmodes')
@@ -370,15 +371,17 @@ test.describe('search - basic', () => {
       assert.equal(res.data.total, 1)
     }
     res = await ax.get('/api/v1/datasets/qmodes/lines', { params: { q: 'mot1 mot2', q_mode: 'simple' } })
-    assert.equal(res.data.total, 3)
-    assert.equal(res.data.results[0]._score, res.data.results[1]._score)
+    assert.equal(res.data.total, 4)
+    // p1 and p2 carry the same words in the same amount of text: same score
+    const simpleScores = Object.fromEntries(res.data.results.map((r: any) => [r._id, r._score]))
+    assert.equal(simpleScores.p1, simpleScores.p2)
     res = await ax.get('/api/v1/datasets/qmodes/lines', { params: { q: '"mot1 mot2"', q_mode: 'simple' } })
     assert.equal(res.data.total, 1)
     assert.equal(res.data.results[0]._id, 'p1')
     // complete mode narrows a multi-word query: every word is required (p3 has mot1 but not mot2),
-    // where the simple OR above matches all three
+    // where the simple OR above matches all four
     res = await ax.get('/api/v1/datasets/qmodes/lines', { params: { q: 'mot1 mot2', q_mode: 'complete' } })
-    assert.equal(res.data.total, 2)
+    assert.equal(res.data.total, 3)
     assert.ok(res.data.results[0]._score > res.data.results[1]._score)
     // the last word acts as a prefix inside the requirement: "mot1 se" keeps only the doc
     // with mot1 AND a word starting with "se"
@@ -387,6 +390,13 @@ test.describe('search - basic', () => {
     assert.equal(res.data.results[0]._id, 'p3')
     // a single word never narrows: plain prefix behavior
     res = await ax.get('/api/v1/datasets/qmodes/lines', { params: { q: 'mot1', q_mode: 'complete' } })
+    assert.equal(res.data.total, 4)
+    // a typed stopword is never a requirement: on this new-shape dataset "de" only survives
+    // analysis on scalar .text_standard fields (_updatedAt), whose content cannot contain it —
+    // the language-analyzed alternative reading of the filter drops it instead of matching nothing
+    res = await ax.get('/api/v1/datasets/qmodes/lines', { params: { q: 'mot1 de mot2', q_mode: 'complete' } })
+    assert.equal(res.data.total, 3)
+    res = await ax.get('/api/v1/datasets/qmodes/lines', { params: { q: 'mot1 de mot2', q_mode: 'and' } })
     assert.equal(res.data.total, 3)
   })
 })


### PR DESCRIPTION
Review of `q_mode=complete` (constant ranking surfaced during the keyword_repeat work), with the evidence recorded in `benchmark/INVESTIGATIONS.md` §16 and the retained improvements shipped:

- **`q_mode=complete` requires every typed word** on multi-word queries (last word as a prefix): results narrow as the user types, and totals/facets/exports match what an autocomplete user means. Scoring is untouched — page-1 ordering is unchanged, the requirement lives in a non-scoring filter.
- **Typed stopwords are never required where they cannot match**: on post-#534 indexes the AND filters (complete *and* the pre-existing `q_mode=and`, which silently returned 0 on `q="de commune"`-style queries since #534) carry a second, language-analyzed reading of the requirement — stopwords dropped, numbers kept, pure-keyword whole values still matched.
- **singleSearch completes on its own columns**: `q` is scoped to the output+label columns (a match in an unrelated column no longer surfaces irrelevant suggestions) and suggestions are ordered alphabetically on the output key — the leading part of the displayed «output (label)» string — instead of the arbitrary row order that constant prefix scores produced.
- Benchmark harness: new `complete-ranking:*` experiments (self-built 200k referential corpus, `prepare` hook for raw-ES indexes) and a `complete-check.ts` live probe; measured dead ends (SAYT/`bool_prefix`, scoring prefix rewrites, count ordering) recorded so they don't get re-explored.

**Why:** complete mode was shown to have constant ranking; the review established it is correct as a matcher but vacuous as a ranker exactly where it is aimed (mid-typing autocomplete), and that its OR semantics widened the match set as the user typed.

**Heads-up:** behavior changes for existing consumers — multi-word `complete` totals shrink to the all-words set; `q_mode=and` with stopwords stops returning 0 on new-shape datasets; singleSearch suggestions change order (alphabetical) and no longer match on non-output/label columns.
