### PR TITLE
feat(datasets): leaner default capabilities for numeric and code columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ dev/logs/
 dev/profiles/
 test-results/
 /benchmark/results/*.json
+/benchmark/capabilities-defaults/data/
+/benchmark/capabilities-defaults/results.json
 /docs/**/*.pdf
 .playwright-mcp
 /superpowers/**/*.md

--- a/api/src/datasets/es/commons.ts
+++ b/api/src/datasets/es/commons.ts
@@ -440,11 +440,21 @@ export const prepareQuery = (dataset: any, query: Record<string, any>, qFields?:
       // `.text_standard`. Targeting an unmapped subfield would make simple_query_string return
       // zero results silently instead of the intended 400.
       const isPlainString = prop.type === 'string' && (!prop.format || prop.format === 'uri-reference')
-      const subfields = []
-      if (prop['x-capabilities']?.textStandard !== false) subfields.push('text_standard')
-      if (isPlainString && prop['x-capabilities']?.text !== false) subfields.push('text')
-      if (!subfields.length) requiredCapability(prop, filterSuffix, 'textStandard')
-      must.push({ simple_query_string: { query: query[queryKey], fields: subfields.map(subfield => `${prop.key}.${subfield}`) } })
+      const isNumeric = prop.type === 'integer' || prop.type === 'number'
+      const noNumericText = !!(dataset as any)._indexShape?.noNumericText
+      // an explicit textStandard:false opt-out must still 400 rather than be routed to the
+      // lenient fallback — it was deliberately removed from `q`-style matching.
+      if (isNumeric && noNumericText && prop['x-capabilities']?.textStandard !== false) {
+        // rebuilt indexes carry no numeric `.text_standard`: whole-value match on the main field
+        if (prop['x-capabilities']?.index === false) requiredCapability(prop, filterSuffix, 'index')
+        must.push({ simple_query_string: { query: query[queryKey], fields: [prop.key], lenient: true } })
+      } else {
+        const subfields = []
+        if (prop['x-capabilities']?.textStandard !== false) subfields.push('text_standard')
+        if (isPlainString && prop['x-capabilities']?.text !== false) subfields.push('text')
+        if (!subfields.length) requiredCapability(prop, filterSuffix, 'textStandard')
+        must.push({ simple_query_string: { query: query[queryKey], fields: subfields.map(subfield => `${prop.key}.${subfield}`) } })
+      }
     } else if (filterSuffix === '_exists') {
       const fields = resolveExistsFields(prop, ignoredKeywordFields.has(prop.key))
       if (fields.length === 1) filter.push({ exists: { field: fields[0] } })

--- a/api/src/datasets/es/commons.ts
+++ b/api/src/datasets/es/commons.ts
@@ -24,6 +24,7 @@ import {
   hasManyQSearchFields,
   getFilterableFields,
   buildQClauses,
+  hasNumericLenientRouting,
   textAnalyzers,
   EXACT_MATCH_BOOST,
   FILTER_CAPABILITIES,
@@ -441,11 +442,19 @@ export const prepareQuery = (dataset: any, query: Record<string, any>, qFields?:
       // zero results silently instead of the intended 400.
       const isPlainString = prop.type === 'string' && (!prop.format || prop.format === 'uri-reference')
       const isNumeric = prop.type === 'integer' || prop.type === 'number'
-      const noNumericText = !!(dataset as any)._indexShape?.noNumericText
+      // same predicate as buildQClauses (see hasNumericLenientRouting) so the two `q` entry points
+      // can never drift: on a mixed-fleet virtual dataset a rebuilt descendant already routes here
+      // even though the parent's own `_indexShape.noNumericText` is false (bubble-up requires
+      // every descendant to have it).
+      const noNumericText = hasNumericLenientRouting(dataset as any)
       // an explicit textStandard:false opt-out must still 400 rather than be routed to the
       // lenient fallback — it was deliberately removed from `q`-style matching.
       if (isNumeric && noNumericText && prop['x-capabilities']?.textStandard !== false) {
-        // rebuilt indexes carry no numeric `.text_standard`: whole-value match on the main field
+        // rebuilt indexes carry no numeric `.text_standard`: whole-value match on the main field.
+        // Deliberate behavior change on rebuild: on a legacy index this same request matched via
+        // `.text_standard` even when `index: false` (200); on a rebuilt (noNumericText) index the
+        // main field is the only route left, so `index: false` now 400s here — ES cannot search a
+        // non-indexed field, and there is no fallback subfield left to catch it silently.
         if (prop['x-capabilities']?.index === false) requiredCapability(prop, filterSuffix, 'index')
         must.push({ simple_query_string: { query: query[queryKey], fields: [prop.key], lenient: true } })
       } else {

--- a/api/src/datasets/es/operations.ts
+++ b/api/src/datasets/es/operations.ts
@@ -593,6 +593,22 @@ export const getFilterableFields = memoize((dataset: any, hasQ: any, qFields: an
   maxAge: 1000 * 60 * 60, // 1 hour
 })
 
+// Whether numeric columns' `q` / `col_search` matching should use the lenient main-field fallback
+// (see `qLenientFields`): the dataset's own index carries no numeric `.text_standard`
+// (`_indexShape.noNumericText`), OR — for virtual datasets — any fetched descendant's index
+// doesn't either. This is ROUTING, not a change to finalize.ts's bubble-up (which still only
+// stamps the virtual parent's own `noNumericText` when ALL descendants have it, so mapping-time
+// decisions like the exact-match analyzer stay conservative). Over a mixed fleet {legacy child,
+// rebuilt child} the parent's own flag is false (bubble-up requires unanimity), but a rebuilt
+// child's numeric columns carry no `.text_standard` any more — without this routing their rows
+// would silently stop matching numeric `q`/`col_search` until every sibling rebuilds. On an
+// all-legacy virtual (no descendant flagged) this reduces to exactly `!!dataset._indexShape?.
+// noNumericText`, so clauses stay byte-identical to a dataset with no `descendants` field.
+// Non-virtual (or queried-without-fillDescendants) datasets have no `descendants` array, so the
+// `some` is skipped and behavior is unchanged.
+export const hasNumericLenientRouting = (dataset: any): boolean =>
+  !!dataset._indexShape?.noNumericText || !!dataset.descendants?.some((d: any) => d._indexShape?.noNumericText)
+
 // Builds the `q`-side `should`/`minimum_should_match` bool clause used inside `prepareQuery`.
 // Pure: caller resolves `q` (already trimmed) and supplies `qMode` / `sqsOptions`.
 // `exactMatch` adds the scoring-only exact-match boost clause. It carries a query-time `analyzer:`
@@ -608,7 +624,7 @@ export const buildQClauses = (
   exactMatch?: { analyzer: string, boost: number }
 ): any => {
   const { qSearchFields, qStandardFields, qExactFields, qWildcardFields, qLenientFields, reduced } = getFilterableFields(dataset, q, qFields)
-  const noNumericText = !!dataset._indexShape?.noNumericText
+  const noNumericText = hasNumericLenientRouting(dataset)
   const should: any[] = []
   if (qMode === 'complete') {
     // "complete" mode, we try to accomodate for most cases and give the most intuitive results

--- a/api/src/datasets/es/operations.ts
+++ b/api/src/datasets/es/operations.ts
@@ -479,6 +479,10 @@ export const getFilterableFields = memoize((dataset: any, hasQ: any, qFields: an
   // left to run on there) — both gated in buildQClauses.
   const qExactFields: string[] = []
   const qWildcardFields: string[] = []
+  // numeric columns: whole-value `q` matching through the main long/double field. Always
+  // computed, but only consumed on noNumericText shapes (buildQClauses) — on older indexes
+  // `.text_standard` covers these columns and a second clause would double-score them.
+  const qLenientFields: string[] = []
   const esFields: string[] = []
 
   // pick the `q` regime (only when no explicit q_fields was requested)
@@ -505,6 +509,12 @@ export const getFilterableFields = memoize((dataset: any, hasQ: any, qFields: an
     // legacy indexes exist (unmapped `.text_standard` entries are ignored by simple_query_string).
     // Shape-gated consumers branch in buildQClauses instead.
     const esProp = esProperty(f, DUMMY_ANALYZERS, LEGACY_INDEX_SHAPE)
+    // numeric columns: whole-value `q` matching through the main long/double field. Excludes
+    // explicit `x-capabilities: { textStandard: false }` opt-outs — a column deliberately
+    // removed from `q` must stay out of the lenient fallback too.
+    if (isQField && !f['x-calculated'] && (f.type === 'integer' || f.type === 'number') && esProp.index !== false && capabilities.textStandard !== false) {
+      qLenientFields.push(f.key)
+    }
     if (esProp.index !== false && esProp.enabled !== false && esProp.type === 'keyword') {
       // keyword main type: only contributes to `qSearchFields` when the column has no analyzed
       // text inner field (no `.text`, no `.text_standard`) — i.e. a pure-keyword string column
@@ -572,7 +582,7 @@ export const getFilterableFields = memoize((dataset: any, hasQ: any, qFields: an
     qExactFields.push('_search')
   }
 
-  return { searchFields, wildcardFields, qSearchFields, qStandardFields, qExactFields, qWildcardFields, esFields, copyToSearch, reduced }
+  return { searchFields, wildcardFields, qSearchFields, qStandardFields, qExactFields, qWildcardFields, qLenientFields, esFields, copyToSearch, reduced }
 }, {
   profileName: 'getFilterableFields',
   primitive: true,
@@ -597,7 +607,8 @@ export const buildQClauses = (
   ignoredWords?: string[],
   exactMatch?: { analyzer: string, boost: number }
 ): any => {
-  const { qSearchFields, qStandardFields, qExactFields, qWildcardFields, reduced } = getFilterableFields(dataset, q, qFields)
+  const { qSearchFields, qStandardFields, qExactFields, qWildcardFields, qLenientFields, reduced } = getFilterableFields(dataset, q, qFields)
+  const noNumericText = !!dataset._indexShape?.noNumericText
   const should: any[] = []
   if (qMode === 'complete') {
     // "complete" mode, we try to accomodate for most cases and give the most intuitive results
@@ -626,6 +637,9 @@ export const buildQClauses = (
     if (qSearchFields.length) {
       should.push({ simple_query_string: { query: q, fields: qSearchFields, ...sqsOptions } })
     }
+    if (noNumericText && qLenientFields.length) {
+      should.push({ simple_query_string: { query: q, fields: qLenientFields, lenient: true, ...sqsOptions } })
+    }
   } else {
     // default "simple" mode uses ES simple query string directly
     // only tuning is that we match both on stemmed and raw inner fields to boost exact matches
@@ -636,6 +650,9 @@ export const buildQClauses = (
     // (qStandardFields is still populated but only meant for the complete-mode prefix query)
     if (qStandardFields.length && !reduced) {
       should.push({ simple_query_string: { query: q, fields: qStandardFields, ...sqsOptions } })
+    }
+    if (noNumericText && qLenientFields.length) {
+      should.push({ simple_query_string: { query: q, fields: qLenientFields, lenient: true, ...sqsOptions } })
     }
     // scoring-only exact-match boost: same fields, analyzed without stemming so a literal match
     // outranks a merely stem-equal one. Not added in complete mode, whose clauses have their own
@@ -655,15 +672,20 @@ export const buildQClauses = (
   // Not composed with `complete` mode (its prefix/wildcard clauses carry their own semantics).
   if (qMode !== 'complete') {
     const matchFields = reduced ? qSearchFields : [...qSearchFields, ...qStandardFields]
-    if (qMode === 'and' && matchFields.length) {
-      return { bool: { must: [scored], filter: [{ simple_query_string: { query: q, fields: matchFields, default_operator: 'and' } }] } }
+    // numeric main fields are unioned into the filter set (not the scored `should`) so q_mode=and
+    // and q_ignored's requirement stage still catches a whole-value numeric match; `lenient: true`
+    // keeps ES from erroring when a non-numeric word in the same query is evaluated against them.
+    const filterFields = noNumericText && qLenientFields.length ? [...matchFields, ...qLenientFields] : matchFields
+    const filterLenient = noNumericText && qLenientFields.length ? { lenient: true } : {}
+    if (qMode === 'and' && filterFields.length) {
+      return { bool: { must: [scored], filter: [{ simple_query_string: { query: q, fields: filterFields, default_operator: 'and', ...filterLenient } }] } }
     }
-    if (ignoredWords?.length && matchFields.length) {
+    if (ignoredWords?.length && filterFields.length) {
       const retained = [...new Set(q.split(/\s+/))].filter(word => !ignoredWords.includes(word))
       return {
         bool: {
           must: [scored],
-          filter: [{ bool: { should: retained.map(word => ({ multi_match: { query: word, fields: matchFields } })), minimum_should_match: 1 } }]
+          filter: [{ bool: { should: retained.map(word => ({ multi_match: { query: word, fields: filterFields, ...filterLenient } })), minimum_should_match: 1 } }]
         }
       }
     }

--- a/api/src/datasets/es/operations.ts
+++ b/api/src/datasets/es/operations.ts
@@ -241,8 +241,9 @@ export const esProperty = (prop: any, analyzers: { search: string, index: string
   const capabilities = prop['x-capabilities'] || {}
   const isFullTextString = prop.type === 'string' && (prop.format === 'uri-reference' || !prop.format)
   // Add inner text field to almost everybody so that even dates, numbers, etc can be matched textually as well as exactly.
-  // Non-string columns keep `.text_standard` under both shapes; full-text strings lose it under the
-  // new shape, replaced by the single `.text` field emitted below.
+  // Emission rules for `.text_standard`: dates keep it everywhere (year search); numeric columns lose it
+  // under noNumericText (their `q` matching uses the main long/double field); full-text strings lose it
+  // under singleTextField (replaced by the single `.text` field emitted below).
   const innerFields: any = {}
   const isNumeric = prop.type === 'integer' || prop.type === 'number'
   if (capabilities.textStandard !== false && (!isFullTextString || !shape.singleTextField) && !(isNumeric && shape.noNumericText)) {

--- a/api/src/datasets/es/operations.ts
+++ b/api/src/datasets/es/operations.ts
@@ -203,6 +203,9 @@ export const extractError = (err: any): ExtractedError => {
 export interface IndexShape {
   singleTextField?: boolean
   wordAggField?: boolean
+  // numeric (integer/number) columns carry no `.text_standard` inner field; their `q`
+  // matching goes through the main long/double field (lenient clause, see buildQClauses)
+  noNumericText?: boolean
 }
 
 // The analyzer family is derived from `defaultAnalyzer` by naming convention; all three must be
@@ -219,7 +222,7 @@ export const EXACT_MATCH_BOOST = 0.5
 
 // New shape: one analyzed `.text` per column (indexed original + stem via keyword_repeat, searched
 // on the stem), plus `.words` on textAgg columns.
-export const NEW_INDEX_SHAPE: IndexShape = Object.freeze({ singleTextField: true, wordAggField: true })
+export const NEW_INDEX_SHAPE: IndexShape = Object.freeze({ singleTextField: true, wordAggField: true, noNumericText: true })
 // Legacy shape: dual `.text` + `.text_standard`, what every index carries until its next reindex.
 export const LEGACY_INDEX_SHAPE: IndexShape = Object.freeze({})
 
@@ -241,7 +244,8 @@ export const esProperty = (prop: any, analyzers: { search: string, index: string
   // Non-string columns keep `.text_standard` under both shapes; full-text strings lose it under the
   // new shape, replaced by the single `.text` field emitted below.
   const innerFields: any = {}
-  if (capabilities.textStandard !== false && (!isFullTextString || !shape.singleTextField)) {
+  const isNumeric = prop.type === 'integer' || prop.type === 'number'
+  if (capabilities.textStandard !== false && (!isFullTextString || !shape.singleTextField) && !(isNumeric && shape.noNumericText)) {
     // more "raw" analysis good to boost more exact matches and for wildcard queries
     innerFields.text_standard = { type: 'text', analyzer: 'standard' }
   }
@@ -249,8 +253,9 @@ export const esProperty = (prop: any, analyzers: { search: string, index: string
   const index = capabilities.index !== false
   const values = capabilities.values !== false
   if (prop.type === 'object') esProp = { type: 'object', enabled: index }
-  if (prop.type === 'integer') esProp = { type: 'long', fields: innerFields, index, doc_values: values }
-  if (prop.type === 'number') esProp = { type: 'double', fields: innerFields, index, doc_values: values }
+  const numericFields = Object.keys(innerFields).length ? { fields: innerFields } : {}
+  if (prop.type === 'integer') esProp = { type: 'long', ...numericFields, index, doc_values: values }
+  if (prop.type === 'number') esProp = { type: 'double', ...numericFields, index, doc_values: values }
   if (prop.type === 'boolean') esProp = { type: 'boolean', index, doc_values: values }
   if (prop.type === 'string' && prop.format === 'date-time') esProp = { type: 'date', fields: innerFields, index, doc_values: values }
   if (prop.type === 'string' && prop.format === 'date') esProp = { type: 'date', fields: innerFields, index, doc_values: values }

--- a/api/src/datasets/utils/data-schema.ts
+++ b/api/src/datasets/utils/data-schema.ts
@@ -73,10 +73,11 @@ export const mergeFileSchema = (dataset: FileDataset) => {
       // preserve existing fields, cleanSchema will adapt stuff if necessary
       const existingField = dataset.schema.find(f => f.key === field.key && !f['x-extension'])
       if (existingField) return existingField
-      const { dateFormat, dateTimeFormat, ...f } = field
+      const { dateFormat, dateTimeFormat, codeLike, ...f } = field
       // manage default capabilities
       if (field.type === 'string' && field['x-display'] === 'textarea') f['x-capabilities'] = { index: false, values: false, insensitive: false }
       if (field.type === 'string' && field['x-display'] === 'markdown') f['x-capabilities'] = { index: false, values: false, insensitive: false }
+      if (field.type === 'string' && !field['x-display'] && codeLike) f['x-capabilities'] = { text: false, insensitive: false }
       return f
     })
 

--- a/api/src/datasets/utils/operations.ts
+++ b/api/src/datasets/utils/operations.ts
@@ -93,6 +93,12 @@ const defaultSniffDateConfig: SniffDateConfig = {
   ]
 }
 
+// A "code" value: ascii letters/digits plus common code punctuation, no whitespace, and at
+// least one digit. The digit requirement keeps short label columns (enums, French words)
+// out — for them stemming/insensitive-sort genuinely matter.
+const codeRegexp = /^[A-Za-z0-9_./-]+$/
+const isCodeValue = (value: string): boolean => codeRegexp.test(value) && /\d/.test(value)
+
 export const sniff = (values: string[], attachmentsPaths: string[] = [], existingField?: any, dateConfig?: SniffDateConfig): any => {
   if (!values.length) return { type: 'empty' }
 
@@ -112,7 +118,12 @@ export const sniff = (values: string[], attachmentsPaths: string[] = [], existin
     if (checkAll(values, hasDateFormat(dateFormat))) return { type: 'string', format: 'date', dateFormat }
   }
   if (checkAll(values, dateSchema)) return { type: 'string', format: 'date' }
-  if (checkAll(values, val => val.length <= 200)) return { type: 'string' }
+  if (checkAll(values, val => val.length <= 200)) {
+    // machine codes: analyzed-french matching and insensitive sort are irrelevant
+    // (mergeFileSchema translates this into default x-capabilities on NEW fields only)
+    if (checkAll(values, isCodeValue)) return { type: 'string', codeLike: true }
+    return { type: 'string' }
+  }
   return { type: 'string', 'x-display': 'textarea' }
 }
 

--- a/api/src/workers/short-processor/finalize.ts
+++ b/api/src/workers/short-processor/finalize.ts
@@ -204,7 +204,8 @@ export default async function (_dataset: DatasetInternal) {
     // clause's analyzer reference would 400 on it).
     result._indexShape = {
       singleTextField: descendants.length > 0 && descendants.every(d => d._indexShape?.singleTextField === true),
-      wordAggField: descendants.length > 0 && descendants.every(d => d._indexShape?.wordAggField === true)
+      wordAggField: descendants.length > 0 && descendants.every(d => d._indexShape?.wordAggField === true),
+      noNumericText: descendants.length > 0 && descendants.every(d => d._indexShape?.noNumericText === true)
     }
     result.count = dataset.count = await esUtils.count(queryableDataset, {})
   }

--- a/api/types/dataset/index.ts
+++ b/api/types/dataset/index.ts
@@ -78,7 +78,7 @@ export type DatasetInternal = Dataset & {
   // shape of the mapping this dataset's current index was built with (set on full reindex and by
   // the REST index-creation paths; AND-merged over descendants for virtual datasets). Absent =
   // legacy shape, per flag.
-  _indexShape?: { singleTextField?: boolean, wordAggField?: boolean }
+  _indexShape?: { singleTextField?: boolean, wordAggField?: boolean, noNumericText?: boolean }
   // true when this dataset's current index was fully (re)built by code that stamps
   // the _bytes CSV-equivalent size on every line (set by the index-lines worker on
   // full reindex only); storage() then reads indexed size as a sum over _bytes

--- a/api/types/dataset/schema.js
+++ b/api/types/dataset/schema.js
@@ -43,7 +43,11 @@ const fileSchema = {
       separator: { type: ['string', 'null'] },
       dateFormat: { type: ['string', 'null'] },
       dateTimeFormat: { type: ['string', 'null'] },
-      timeZone: { type: ['string', 'null'] }
+      timeZone: { type: ['string', 'null'] },
+      codeLike: {
+        type: 'boolean',
+        title: 'Colonne de codes détectée à l\'analyse (pas de recherche linguistique ni de tri insensible par défaut)'
+      }
     }
   }
 }

--- a/benchmark/capabilities-defaults/RESULTS.md
+++ b/benchmark/capabilities-defaults/RESULTS.md
@@ -1,0 +1,136 @@
+# A/B bench: store size & indexing time impact of default capabilities (this branch)
+
+Measures the disk/indexing impact of `NEW_INDEX_SHAPE`'s `noNumericText` flag (this branch)
+and the Task 5 sniffer's `{ text: false, insensitive: false }` capability injection on
+code-like string columns, against the current production mapping shape.
+
+**Protocol note (deviates from the original task brief):** rather than uploading through the
+data-fair API and diffing `master` vs this branch via dev-process restarts, this bench runs
+directly against dev Elasticsearch (`localhost:27528`) using the **real branch mapping code**
+(`buildIndexMappings` / `textAnalyzers` / `NEW_INDEX_SHAPE` imported straight from
+`api/src/datasets/es/operations.ts`), with index *settings* (analyzers/normalizers) copied
+verbatim from `indexBase` in `api/src/datasets/es/manage-indices.ts`. This was a controller
+decision (the plan's own sanctioned fallback) to avoid coordinating dev-process restarts and
+API uploads. See `benchmark/capabilities-defaults/bench.mjs`.
+
+- **Shape A ("before", current production behavior):** `{ singleTextField: true, wordAggField: true }`
+- **Shape B ("after", this branch):** `NEW_INDEX_SHAPE` = `{ singleTextField: true, wordAggField: true, noNumericText: true }`
+- **Shape B2 (code-heavy dataset only):** shape B + the sniffer's capability injection
+  (`x-capabilities: { text: false, insensitive: false }`) applied to every string column whose
+  values are all "code-like" (ASCII letters/digits/`_./-`, at least one digit — the same
+  regexp as `sniff()` in `api/src/datasets/utils/operations.ts`)
+
+## Results
+
+### 1. `PAC - Campagne de mesures 100 PACs` — numeric-heavy
+
+Heat-pump measurement campaign: 1 date-time column (`time`) + 14 numeric columns
+(temperatures, resistances, calorimetric counters).
+
+| | A (before) | B (after) | delta |
+|---|---|---|---|
+| store bytes | 32,886,017 | 2,543,001 | **-92.3%** |
+| bulk wall time | 4,233 ms | 2,892 ms | **-31.7%** |
+| docs | 200,000 | 200,000 | — |
+
+### 2. `Compétences des acteurs par année` — code-heavy
+
+Waste-management actor competences by year: SIRET + INSEE region/department codes + 3
+integer columns (`annee`, `code_acteur`, `nb_service`) + a handful of French label columns.
+
+| | A (before) | B (after) | B2 (+ code-like capabilities) |
+|---|---|---|---|
+| store bytes | 24,385,585 | 17,229,917 (**-29.3%** vs A) | 16,348,157 (**-5.1%** vs B, **-33.0%** vs A) |
+| bulk wall time | 5,678 ms | 3,672 ms (**-35.3%** vs A) | 3,336 ms (**-9.2%** vs B) |
+| docs | 106,092 | 106,092 | 106,092 |
+
+B2 code-like columns detected (sniffer heuristic applied to the actual downloaded values):
+`code_region`, `code_departement`, `code_type_acteur`, `siret`, `code_competence`.
+(`code_valideur` was NOT flagged — its values include a `" | "`-separated multi-value form,
+e.g. `"62957 | 100000"`, which fails the code regexp's no-whitespace/no-pipe rule.)
+
+### 3. `Données EO-REFASHION` — string/prose control
+
+Textile take-back point directory: 34 columns, mostly strings (addresses, opening hours,
+SIRET/SIREN, phone/email, labels) + 7 booleans + 4 numeric geocoordinate columns
+(`latitudewgs84`, `longitudewgs84`, `latitudemercator`, `longitudemercator`).
+
+| | A (before) | B (after) | delta |
+|---|---|---|---|
+| store bytes | 22,638,074 | 20,759,742 | **-8.3%** |
+| bulk wall time | 3,045 ms | 2,863 ms | **-6.0%** |
+| docs | 44,708 | 44,708 | — |
+
+## Interpretation
+
+The measured deltas confirm the spec's predictions, in direction and in relative ordering:
+
+- **Numeric-heavy sees by far the largest cut (-92.3% store).** Every one of the 14 numeric
+  columns loses its `.text_standard` analyzed inner field under `noNumericText`. Numeric
+  values (especially high-precision floats like the temperature/resistance readings here) are
+  near-unique per document, so their analyzed-text representation was dominated by a huge term
+  dictionary + postings + norms — vastly more expensive than the compact `doc_values`-only
+  `long`/`double` main field that remains. This is the single biggest lever in the whole
+  branch: `bytes/doc` drops from ~164 to ~13.
+- **Code-heavy sees a real but smaller cut from B alone (-29.3%, only 3/17 columns are
+  numeric), then an additional, distinct cut from B2's capability injection (-5.1% further,
+  -33.0% total vs A).** The B2 delta isolates the Task 5 sniffer's effect: dropping
+  `.text` and `.keyword_insensitive` on 5 code-like string columns (SIRET + 4 INSEE-style
+  codes) removes their French-analyzed inner field and their case/diacritics-insensitive
+  keyword sub-field, on top of what B already removed from the dataset's numeric columns.
+  Indexing wall time drops accordingly at every step (fewer analyzed sub-fields to tokenize
+  and write).
+- **The string/prose control shows the smallest delta of the three (-8.3%), but not
+  literally ≈0**, because this particular control dataset still carries 4 numeric
+  geocoordinate columns with near-unique float values — exactly the same "near-unique numeric
+  value → expensive analyzed text" pattern as the PAC dataset, just diluted across 34 mostly
+  non-numeric columns. This is consistent with the spec's prediction once read precisely:
+  `noNumericText` (shape B) only ever touches numeric-typed columns; a dataset's delta from A
+  to B should scale with how much of its per-document byte weight sits in numeric columns,
+  not with how "prose-heavy" its string columns are. A dataset with genuinely zero numeric
+  columns would show a true ≈0 delta at the A→B step (B2's string-capability effect is
+  orthogonal and wasn't applied here, since this dataset's string columns are a real mix of
+  codes, addresses and short labels, not sniffed for this bench).
+
+## Runtime caveats (read before citing these numbers)
+
+- **Single run, not a median of several.** The task brief's "three runs, keep the median"
+  step was dropped to keep total bench runtime reasonable; wall-time deltas in particular
+  should be read as directional (indexing fewer analyzed fields is reliably faster) rather
+  than precise percentages — expect run-to-run noise on the order of ±10-20% on a shared dev
+  box.
+- **Shared dev Elasticsearch**, not an isolated/dedicated node — the dev stack's other
+  services (API, UI, mock server) were running concurrently throughout.
+- **Store-size deltas are far more reliable than wall-time deltas**: they come from
+  `_forcemerge?max_num_segments=1` immediately before measurement, so segment-count noise is
+  eliminated; the numbers reported are deterministic given the same input docs and mapping.
+- `refresh_interval: -1` was set during bulk load and only refreshed once at the end, so wall
+  time reflects pure indexing throughput, not periodic-refresh overhead (matches production,
+  which uses a similar bulk-then-refresh pattern during dataset finalization).
+- 1 shard / 0 replicas throughout, to isolate the mapping-shape effect from
+  sharding/replication overhead. Production sizing (shard count scales with `indexed.size`)
+  is orthogonal to what's measured here.
+
+## Reproducibility / provenance
+
+All three datasets are public, from the `data.ademe.fr` catalog
+(`GET https://data.ademe.fr/data-fair/api/v1/datasets?select=id,slug,count,schema&q=...`).
+Row data was pulled via each dataset's public `/lines` JSON API (already typed — numbers as
+JS numbers, booleans as booleans, ISO date strings), capped at 200,000 rows per dataset. Full
+search/selection log is in `.superpowers/sdd/2026-08-07-default-capabilities/task-6-report.md`.
+
+| dataset | ademe id | slug | rows used | ademe total count | fetched |
+|---|---|---|---|---|---|
+| PAC - Campagne de mesures 100 PACs | `-p3qp8b8xestyz3f35ns-j1h` | `pac-campagne-de-mesures-100-pacs` | 200,000 | 527,040 | 2026-08-07 |
+| Compétences des acteurs par année | `pljxb0la63vv9iyp5848xioa` | `competences-des-acteurs-par-annee` | 106,092 | 106,092 | 2026-08-07 |
+| Données EO-REFASHION | `zkt20z09p8jl6oix18a5kcte` | `donnees-eo-refashion` | 44,708 | 44,940 | 2026-08-07 |
+
+Raw run output and per-index numbers: `benchmark/capabilities-defaults/results.json` (not
+committed — regenerate with `node --experimental-strip-types
+--disable-warning=ExperimentalWarning bench.mjs`; requires network access to `data.ademe.fr`
+and a reachable dev Elasticsearch at `$ES_ORIGIN` / `http://localhost:27528`).
+
+To re-run: `cd benchmark/capabilities-defaults && node --experimental-strip-types
+--disable-warning=ExperimentalWarning bench.mjs`. Downloaded row dumps are cached under
+`./data/` (gitignored); delete that directory to force a fresh download. The script creates
+and deletes only indices prefixed `bench-capdefaults-`.

--- a/benchmark/capabilities-defaults/RESULTS.md
+++ b/benchmark/capabilities-defaults/RESULTS.md
@@ -4,14 +4,26 @@ Measures the disk/indexing impact of `NEW_INDEX_SHAPE`'s `noNumericText` flag (t
 and the Task 5 sniffer's `{ text: false, insensitive: false }` capability injection on
 code-like string columns, against the current production mapping shape.
 
+**Revision note:** this file was rewritten after a methodology review found the first pass's
+headline PAC number (-92.3%) was a stale-read measurement artifact, and that the code-heavy
+dataset's A→B delta conflated two independent effects (a schema-width classification flip,
+and the actual `noNumericText` change). Both are fixed below: see "Measurement fix" and
+"Decomposition" sections. All corrected figures were independently cross-checked by the
+reviewer's own re-run and matched within 0.12% (see task-6-report.md's fix log for every
+figure's diff).
+
 **Protocol note (deviates from the original task brief):** rather than uploading through the
 data-fair API and diffing `master` vs this branch via dev-process restarts, this bench runs
 directly against dev Elasticsearch (`localhost:27528`) using the **real branch mapping code**
 (`buildIndexMappings` / `textAnalyzers` / `NEW_INDEX_SHAPE` imported straight from
 `api/src/datasets/es/operations.ts`), with index *settings* (analyzers/normalizers) copied
-verbatim from `indexBase` in `api/src/datasets/es/manage-indices.ts`. This was a controller
-decision (the plan's own sanctioned fallback) to avoid coordinating dev-process restarts and
-API uploads. See `benchmark/capabilities-defaults/bench.mjs`.
+verbatim from `indexBase` in `api/src/datasets/es/manage-indices.ts` — that function is
+exported specifically so standalone fixtures can derive real index settings without
+hand-copying the analyzer/filter definitions (see its own comment at
+`manage-indices.ts:220-222`); this bench keeps its own copy in sync by hand rather than
+importing it directly, to stay independent of `#config`. This was a controller decision (the
+plan's own sanctioned fallback) to avoid coordinating dev-process restarts and API uploads.
+See `benchmark/capabilities-defaults/bench.mjs`.
 
 - **Shape A ("before", current production behavior):** `{ singleTextField: true, wordAggField: true }`
 - **Shape B ("after", this branch):** `NEW_INDEX_SHAPE` = `{ singleTextField: true, wordAggField: true, noNumericText: true }`
@@ -19,78 +31,200 @@ API uploads. See `benchmark/capabilities-defaults/bench.mjs`.
   (`x-capabilities: { text: false, insensitive: false }`) applied to every string column whose
   values are all "code-like" (ASCII letters/digits/`_./-`, at least one digit — the same
   regexp as `sniff()` in `api/src/datasets/utils/operations.ts`)
+- **A-narrow (code-heavy dataset only, decomposition variant, not a real shape):** shape A's
+  mapping with the `_search` catch-all field and every `copy_to` annotation stripped
+  afterwards — isolates the schema-width effect from the `noNumericText` effect (see
+  "Decomposition" below).
+
+## Measurement fix (why the first pass's PAC number was wrong)
+
+The first pass read `_cat/indices` store.size immediately after `_refresh` +
+`_forcemerge?max_num_segments=1` + `_refresh`, and got **32,886,017 → 2,543,001 (-92.3%)**
+for PAC. That B figure was a stale read: `_cat/indices` store.size lags the actual merged
+segment's committed size for several seconds after a forcemerge. Verified directly on a
+fresh rebuild of the same index with no further writes: the store.size read
+7,619,736 through refresh/forcemerge/+5s, then settled at ~29,788,033 roughly 10 seconds
+later with nothing else happening.
+
+Fix applied in `bench.mjs`'s `measureIndex`: `_forcemerge` → `_flush` (forces an fsync'd
+commit) → `_refresh` → poll `_cat/indices` at 1s intervals until the same store.size value is
+read twice in a row (60s timeout) → cross-check against `POST /<idx>/_disk_usage
+?run_expensive_tasks=true`'s `store_size_in_bytes`, which reads the actual committed Lucene
+segment files rather than a shard-level stat and also gives a per-field-category breakdown
+(used in the PAC interpretation below).
+
+**A second, more subtle artifact surfaced while re-running with this fix**: on the code-heavy
+dataset's 'A' variant, the settle-poll's two-consecutive-equal-reads criterion was satisfied
+by a value (3,506,615) that was *itself* still wrong — a mid-merge plateau that happened to
+hold for slightly over 1 second before moving again — while `_disk_usage` on the same,
+unchanged index reported the correct 24,461,193 (confirmed against the reviewer's independent
+cross-check of ≈24,413,137, 0.2% apart). `bench.mjs` now treats `_disk_usage`'s
+`store_size_in_bytes` as authoritative whenever it succeeds, keeps the settled `_cat/indices`
+read only as `catStoreBytes` for transparency, and logs a loud warning whenever the two
+disagree by more than 1%. The re-run below produced `catStoreBytes === diskUsageTotal` for
+every one of the 8 measured indices (no warnings), so the numbers in this file are not
+affected by either artifact.
+
+## Wide/narrow classification (recorded per variant, was previously discarded)
+
+`buildIndexMappings` returns a `wide` flag (schema classifies "many analyzed text fields" per
+`hasManyQSearchFields`, threshold-dependent on shape) alongside `properties`; when `wide` is
+true the mapping adds a `_search` catch-all field and `copy_to` annotations on eligible
+columns. The bench now records and logs this flag for every variant:
+
+| dataset | A | A-narrow | B | B2 |
+|---|---|---|---|---|
+| PAC (numeric-heavy) | `wide=false` | — | `wide=false` | — |
+| Compétences (code-heavy) | `wide=true` | `wide=false` (forced) | `wide=false` | `wide=false` |
+| REFASHION (string control) | `wide=true` | — | `wide=true` | — |
+
+The code-heavy dataset **flips** wide→narrow between shape A and shape B: under shape A it
+has 16 analyzed inner fields (13 string `.text` + 3 numeric `.text_standard`, one above
+`hasManyQSearchFields`' 15-field threshold for `singleTextField` shapes), so shape A
+classifies it `wide`; under shape B, `noNumericText` removes the 3 numeric `.text_standard`
+fields, dropping it to 13 — below the threshold — so shape B classifies it `narrow`. This
+flip means the code-heavy dataset's raw A→B delta conflates two independent effects: losing
+the `_search`/`copy_to` catch-all machinery, and losing numeric columns' `.text_standard`.
+See the decomposition below for the split. PAC (15 columns, well under any threshold either
+way) and REFASHION (34 columns, wide under both shapes) don't flip, so their A→B deltas are
+clean single-effect reads.
 
 ## Results
 
 ### 1. `PAC - Campagne de mesures 100 PACs` — numeric-heavy
 
 Heat-pump measurement campaign: 1 date-time column (`time`) + 14 numeric columns
-(temperatures, resistances, calorimetric counters).
+(temperatures, resistances, calorimetric counters). `wide=false` under both shapes — a clean
+read of `noNumericText` alone, no catch-all effect involved.
 
 | | A (before) | B (after) | delta |
 |---|---|---|---|
-| store bytes | 32,886,017 | 2,543,001 | **-92.3%** |
-| bulk wall time | 4,233 ms | 2,892 ms | **-31.7%** |
+| store bytes | 32,944,785 | 29,792,537 | **-9.6%** |
+| bulk wall time | 3,851 ms | 2,855 ms | **-25.9%** |
 | docs | 200,000 | 200,000 | — |
+
+#### Component breakdown (`_disk_usage`'s per-field-category totals, summed across all fields)
+
+| component | A | B | delta | shape-dependent? |
+|---|---|---|---|---|
+| stored_fields | 10,153,276 | 10,152,120 | ~flat | no |
+| doc_values | 12,000,355 | 12,000,355 | flat | no |
+| points | 5,586,166 | 5,586,165 | flat | no |
+| **inverted_index** | 4,864,494 | 2,006,860 | **-58.7%** | **yes** |
+| **norms** | 291,646 | 0 | **-100%** | **yes** |
+
+Only `inverted_index` and `norms` move between A and B — together they're the entire
+`.text_standard` inner field's storage cost on the 14 numeric columns (an analyzed `text`
+field has no `doc_values` by default, so it contributes nothing there). `stored_fields` +
+`doc_values` + `points` — the shape-invariant floor — is **84.2%** of A's total store and
+**93.1%** of B's: this is the honest ceiling on numeric-heavy savings from this branch's
+mapping change alone. It cannot go lower without also touching `values`/`index` capabilities
+(sortability, exact-match filtering), which this branch does not change.
 
 ### 2. `Compétences des acteurs par année` — code-heavy
 
 Waste-management actor competences by year: SIRET + INSEE region/department codes + 3
 integer columns (`annee`, `code_acteur`, `nb_service`) + a handful of French label columns.
 
-| | A (before) | B (after) | B2 (+ code-like capabilities) |
-|---|---|---|---|
-| store bytes | 24,385,585 | 17,229,917 (**-29.3%** vs A) | 16,348,157 (**-5.1%** vs B, **-33.0%** vs A) |
-| bulk wall time | 5,678 ms | 3,672 ms (**-35.3%** vs A) | 3,336 ms (**-9.2%** vs B) |
-| docs | 106,092 | 106,092 | 106,092 |
+#### Decomposition: catch-all removal vs `noNumericText` alone
+
+| | store bytes | delta | wall time | delta |
+|---|---|---|---|---|
+| A (before, `wide=true`) | 24,412,681 | — | 5,516 ms | — |
+| A-narrow (A's mapping, `_search`/`copy_to` manually stripped) | 17,643,964 | **-27.7%** vs A | 3,805 ms | -31.0% vs A |
+| B (after, `wide=false`, `noNumericText`) | 17,232,431 | -2.3% vs A-narrow (**-29.4%** vs A) | 3,625 ms | -4.7% vs A-narrow (-34.3% vs A) |
+| B2 (B + code-like capability injection) | 16,329,770 | -5.2% vs B (**-33.1%** vs A) | 3,281 ms | -9.5% vs B |
+
+**Attribution: on this dataset, losing the `_search` catch-all + `copy_to` annotations
+(-27.7%) accounts for roughly 12x more of the A→B store delta than `noNumericText` itself
+(-2.3% further)** — the opposite of what the raw A→B number (-29.4%) suggests taken at face
+value, since it makes `noNumericText` look like the dominant effect when it's actually the
+minor one here. This is schema-width-dependent, not a general property of `noNumericText`:
+this dataset happens to sit exactly one analyzed field above the 15-field
+`hasManyQSearchFields` threshold under shape A, so it's the specific dataset where the
+threshold-crossing effect is visible at all. PAC and REFASHION below don't cross the
+threshold in either direction, so their deltas aren't subject to this conflation.
+
+B2 (the Task 5 sniffer's capability injection on top of B) adds a further, genuinely separate
+-5.2%: see "B2's actual mechanism" below for what specifically changes.
 
 B2 code-like columns detected (sniffer heuristic applied to the actual downloaded values):
 `code_region`, `code_departement`, `code_type_acteur`, `siret`, `code_competence`.
 (`code_valideur` was NOT flagged — its values include a `" | "`-separated multi-value form,
 e.g. `"62957 | 100000"`, which fails the code regexp's no-whitespace/no-pipe rule.)
 
+#### B2's actual mechanism (corrected)
+
+`x-capabilities: { text: false, insensitive: false }` does **not** leave a column
+analysis-free. Per `esProperty` (`operations.ts`): when `capabilities.text === false` but
+`textStandard` is still at its default (`true`), the single-text-field branch falls back to
+`innerFields.text_standard = { type: 'text', analyzer: 'standard' }` instead of
+`innerFields.text = { type: 'text', analyzer: analyzers.index, ... }`. Verified directly in
+this bench's B2 mapping: `siret` (and the other 4 code-like columns) carry a plain `keyword`
+main field plus a `fields.text_standard` (standard analyzer, no French stemming/elision) —
+not a bare unanalyzed keyword. So **B→B2 is: swap the French-analyzed `.text` field for a
+standard-analyzed `.text_standard` field (still an analyzed text field, just a lighter,
+non-French analyzer with no stemming pipeline) AND drop the `.keyword_insensitive` sub-field
+entirely.** The measured -5.2% is the net of both: one analyzed-field swap (standard analysis
+tokenizes/stores marginally less than the French pipeline's elision+stemming+asciifolding
+chain) plus one field's outright removal (`.keyword_insensitive`, a `KEYWORD_IGNORE_ABOVE`-len
+keyword with a normalizer — cheap per-doc but non-zero at 106k rows).
+
 ### 3. `Données EO-REFASHION` — string/prose control
 
 Textile take-back point directory: 34 columns, mostly strings (addresses, opening hours,
 SIRET/SIREN, phone/email, labels) + 7 booleans + 4 numeric geocoordinate columns
-(`latitudewgs84`, `longitudewgs84`, `latitudemercator`, `longitudemercator`).
+(`latitudewgs84`, `longitudewgs84`, `latitudemercator`, `longitudemercator`). `wide=true`
+under both shapes — no threshold-flip conflation here, this is a clean `noNumericText`-alone
+read like PAC, just diluted across far fewer numeric columns.
 
 | | A (before) | B (after) | delta |
 |---|---|---|---|
-| store bytes | 22,638,074 | 20,759,742 | **-8.3%** |
-| bulk wall time | 3,045 ms | 2,863 ms | **-6.0%** |
+| store bytes | 22,626,858 | 20,759,134 | **-8.3%** |
+| bulk wall time | 3,003 ms | 2,777 ms | **-7.5%** |
 | docs | 44,708 | 44,708 | — |
 
 ## Interpretation
 
-The measured deltas confirm the spec's predictions, in direction and in relative ordering:
+- **Numeric-heavy's real ceiling is -9.6% store, not -92.3%.** The first pass's headline
+  number was a measurement artifact (see "Measurement fix" above). The corrected component
+  breakdown shows exactly why -9.6% is the honest number: `noNumericText` only ever removes
+  the `inverted_index` + `norms` cost of the numeric columns' `.text_standard` field (-58.7%
+  and -100% respectively on those two components alone) — it cannot touch `stored_fields` /
+  `doc_values` / `points`, which together are 84-93% of the total store regardless of shape.
+  Indexing wall time drops more (-25.9%) than store size, because writing an analyzed text
+  field costs CPU (tokenizing, position tracking) independently of how much it ultimately
+  compresses to on disk.
+- **Code-heavy's headline number needs the decomposition to be honest about what's driving
+  it.** Read naively, A→B (-29.4%) looks like `noNumericText` is doing most of the work on a
+  code-heavy dataset — but the A-narrow variant shows the opposite: -27.7% of that comes from
+  crossing the `hasManyQSearchFields` wide/narrow threshold (losing the `_search` catch-all +
+  `copy_to`), and only -2.3% (on top of A-narrow) is `noNumericText` itself. This dataset
+  happens to sit exactly one field over the 15-field threshold under shape A — a somewhat
+  fragile position to draw a general conclusion from. B2's -5.2% further is the part that
+  actually generalizes to "code-heavy datasets": dropping the French-analyzer inner field in
+  favor of a lighter standard-analyzer one, plus dropping `.keyword_insensitive`, on columns
+  the sniffer correctly identifies as codes.
+- **The string/prose control shows the smallest delta of the three (-8.3%), and it's a clean
+  read (no threshold flip — `wide=true` under both shapes)**, driven entirely by its 4 numeric
+  geocoordinate columns' near-unique float values losing their `.text_standard`
+  `inverted_index`/`norms` cost, exactly the same mechanism as PAC, just diluted across 34
+  mostly non-numeric columns. A dataset with genuinely zero numeric columns would show a true
+  ≈0% delta at the A→B step; this dataset isn't quite that, but it isolates the same
+  mechanism PAC does, at smaller scale.
 
-- **Numeric-heavy sees by far the largest cut (-92.3% store).** Every one of the 14 numeric
-  columns loses its `.text_standard` analyzed inner field under `noNumericText`. Numeric
-  values (especially high-precision floats like the temperature/resistance readings here) are
-  near-unique per document, so their analyzed-text representation was dominated by a huge term
-  dictionary + postings + norms — vastly more expensive than the compact `doc_values`-only
-  `long`/`double` main field that remains. This is the single biggest lever in the whole
-  branch: `bytes/doc` drops from ~164 to ~13.
-- **Code-heavy sees a real but smaller cut from B alone (-29.3%, only 3/17 columns are
-  numeric), then an additional, distinct cut from B2's capability injection (-5.1% further,
-  -33.0% total vs A).** The B2 delta isolates the Task 5 sniffer's effect: dropping
-  `.text` and `.keyword_insensitive` on 5 code-like string columns (SIRET + 4 INSEE-style
-  codes) removes their French-analyzed inner field and their case/diacritics-insensitive
-  keyword sub-field, on top of what B already removed from the dataset's numeric columns.
-  Indexing wall time drops accordingly at every step (fewer analyzed sub-fields to tokenize
-  and write).
-- **The string/prose control shows the smallest delta of the three (-8.3%), but not
-  literally ≈0**, because this particular control dataset still carries 4 numeric
-  geocoordinate columns with near-unique float values — exactly the same "near-unique numeric
-  value → expensive analyzed text" pattern as the PAC dataset, just diluted across 34 mostly
-  non-numeric columns. This is consistent with the spec's prediction once read precisely:
-  `noNumericText` (shape B) only ever touches numeric-typed columns; a dataset's delta from A
-  to B should scale with how much of its per-document byte weight sits in numeric columns,
-  not with how "prose-heavy" its string columns are. A dataset with genuinely zero numeric
-  columns would show a true ≈0 delta at the A→B step (B2's string-capability effect is
-  orthogonal and wasn't applied here, since this dataset's string columns are a real mix of
-  codes, addresses and short labels, not sniffed for this bench).
+## Query-side cost of the wide→narrow flip (out of scope for this bench, flagged explicitly)
+
+This bench measures **only store size and bulk-indexing wall time**. It does not measure the
+query-side cost of the code-heavy dataset's wide→narrow flip. Losing the `_search` catch-all
+field means `q` search on that dataset moves from matching against **1** field (`_search`) to
+a `simple_query_string` fanout across **13+** per-column analyzed fields (`getFilterableFields`
+in `operations.ts` builds this fanout at query time). That is a real query-time cost — more
+fields for Lucene to visit per query, more term-dictionary lookups — and it is not captured
+anywhere in this bench's numbers. Anyone using these results to reason about the branch's
+full production impact on this class of dataset (one that crosses the wide/narrow threshold)
+needs a separate query-latency bench to complete the picture; this document does not claim to
+provide one.
 
 ## Runtime caveats (read before citing these numbers)
 
@@ -98,18 +232,38 @@ The measured deltas confirm the spec's predictions, in direction and in relative
   step was dropped to keep total bench runtime reasonable; wall-time deltas in particular
   should be read as directional (indexing fewer analyzed fields is reliably faster) rather
   than precise percentages — expect run-to-run noise on the order of ±10-20% on a shared dev
-  box.
+  box. Store-size deltas are far more reliable (see next point).
+- **Ordering bias:** variants run in a fixed order (A, [A-narrow,] B, [B2]) within each
+  dataset, so 'A' always hits a colder ES (JIT warmup, filesystem page cache) than the
+  variants that follow it, and earlier variants' indices are still resident on disk/in cache
+  when later ones are created and bulk-indexed. This biases wall-time comparisons in A's
+  disfavor (A should, if anything, look slightly slower than a truly isolated measurement
+  would show) — noted here rather than randomizing run order, since the store-size numbers
+  (this bench's primary metric) are unaffected by ordering once forcemerge+flush+settle-poll
+  brings every index to the same committed-segment state.
 - **Shared dev Elasticsearch**, not an isolated/dedicated node — the dev stack's other
   services (API, UI, mock server) were running concurrently throughout.
-- **Store-size deltas are far more reliable than wall-time deltas**: they come from
-  `_forcemerge?max_num_segments=1` immediately before measurement, so segment-count noise is
-  eliminated; the numbers reported are deterministic given the same input docs and mapping.
+- **Store-size deltas are the reliable metric**: `_forcemerge?max_num_segments=1` + `_flush`
+  + settle-poll + `_disk_usage` cross-check (see "Measurement fix" above) eliminates both
+  segment-count noise and the two stale-read artifacts found during this review; the numbers
+  reported are deterministic given the same input docs and mapping, and matched the
+  reviewer's independent cross-check within 0.12% on every one of the 8 measured indices (see
+  task-6-report.md for the full diff table).
 - `refresh_interval: -1` was set during bulk load and only refreshed once at the end, so wall
   time reflects pure indexing throughput, not periodic-refresh overhead (matches production,
   which uses a similar bulk-then-refresh pattern during dataset finalization).
 - 1 shard / 0 replicas throughout, to isolate the mapping-shape effect from
   sharding/replication overhead. Production sizing (shard count scales with `indexed.size`)
   is orthogonal to what's measured here.
+- Calculated columns (`_id`, `_i`, `_rand`, `_bytes`, `_score`, `_geopoint`, `_updatedAt`,
+  etc.) are excluded from every indexed doc (see `projectRow` in `bench.mjs`) — only the
+  dataset's own schema columns are indexed. Production datasets carry these calculated
+  columns too, so real-world relative savings (as a % of a production index's total store)
+  are slightly smaller than the percentages in this file, which measure only the schema-owned
+  portion.
+- `results.json` (the full raw per-run output, including every `componentBreakdown`) is
+  gitignored and not committed — this file's tables are the only in-repo record of the
+  measured numbers. Re-run `bench.mjs` to regenerate it.
 
 ## Reproducibility / provenance
 
@@ -125,8 +279,9 @@ search/selection log is in `.superpowers/sdd/2026-08-07-default-capabilities/tas
 | Compétences des acteurs par année | `pljxb0la63vv9iyp5848xioa` | `competences-des-acteurs-par-annee` | 106,092 | 106,092 | 2026-08-07 |
 | Données EO-REFASHION | `zkt20z09p8jl6oix18a5kcte` | `donnees-eo-refashion` | 44,708 | 44,940 | 2026-08-07 |
 
-Raw run output and per-index numbers: `benchmark/capabilities-defaults/results.json` (not
-committed — regenerate with `node --experimental-strip-types
+Raw run output and per-index numbers, including the `_disk_usage` component breakdown for
+every variant: `benchmark/capabilities-defaults/results.json` (not committed — see caveats
+above; regenerate with `node --experimental-strip-types
 --disable-warning=ExperimentalWarning bench.mjs`; requires network access to `data.ademe.fr`
 and a reachable dev Elasticsearch at `$ES_ORIGIN` / `http://localhost:27528`).
 

--- a/benchmark/capabilities-defaults/bench.mjs
+++ b/benchmark/capabilities-defaults/bench.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node --experimental-strip-types --disable-warning=ExperimentalWarning
+// @ts-nocheck -- standalone bench script, not api code; without this the root tsc
+// (checkJs, no `benchmark` exclude) counts its untyped params against the type ratchet
 // A/B bench: store size + bulk-indexing wall time, current production mapping shape ("A")
 // vs this branch's new shape ("B", adds noNumericText), plus a "B2" variant on the
 // code-heavy dataset that also applies the Task 5 sniffer's capability injection

--- a/benchmark/capabilities-defaults/bench.mjs
+++ b/benchmark/capabilities-defaults/bench.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node --experimental-strip-types --disable-warning=ExperimentalWarning
+// A/B bench: store size + bulk-indexing wall time, current production mapping shape ("A")
+// vs this branch's new shape ("B", adds noNumericText), plus a "B2" variant on the
+// code-heavy dataset that also applies the Task 5 sniffer's capability injection
+// (`{ text: false, insensitive: false }`) to code-like string columns.
+//
+// Runs entirely against the dev Elasticsearch instance (no data-fair API upload, no dev
+// process restarts): mappings are produced by the REAL branch code
+// (api/src/datasets/es/operations.ts: buildIndexMappings / textAnalyzers / NEW_INDEX_SHAPE),
+// the index *settings* (analyzers/normalizers) are a verbatim copy of `indexBase` from
+// api/src/datasets/es/manage-indices.ts (see INDEX_BASE_SETTINGS below), and the data is
+// downloaded from the public data.ademe.fr catalog via its /lines JSON API (already typed:
+// numbers as JS numbers, booleans as booleans, dates as ISO strings — mirrors what the real
+// indexer stores).
+//
+// Usage: node --experimental-strip-types --disable-warning=ExperimentalWarning bench.mjs
+// Requires: dev ES reachable (see ES_ORIGIN below), network access to data.ademe.fr.
+// Writes: ./data/<datasetKey>.json (cached row dump, gitignored) and ./results.json.
+// Cleans up all `bench-capdefaults-*` indices it creates, even on error.
+
+import path from 'node:path'
+import fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import {
+  buildIndexMappings,
+  textAnalyzers,
+  NEW_INDEX_SHAPE
+} from '../../api/src/datasets/es/operations.ts'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const DATA_DIR = path.join(__dirname, 'data')
+fs.mkdirSync(DATA_DIR, { recursive: true })
+
+const ES_ORIGIN = process.env.ES_ORIGIN ?? 'http://localhost:27528'
+const ADEME_ORIGIN = 'https://data.ademe.fr/data-fair/api/v1'
+const INDEX_PREFIX = 'bench-capdefaults'
+const ROW_CAP = Number(process.env.BENCH_ROW_CAP) || 200_000
+const BULK_BATCH = 2000
+
+// ---- "before" shape: current production behavior (singleTextField + wordAggField already
+// shipped; this branch's only mapping-emission change is noNumericText on top of that) ----
+const SHAPE_A = Object.freeze({ singleTextField: true, wordAggField: true })
+// "after" shape: this branch
+const SHAPE_B = NEW_INDEX_SHAPE
+
+// ---- verbatim copy of indexBase()'s settings.analysis block from
+// api/src/datasets/es/manage-indices.ts (kept in sync by hand; only the analyzer/normalizer
+// definitions are needed standalone here, index.number_of_shards/replicas are set separately
+// per bench run) ----
+const INDEX_BASE_SETTINGS = {
+  analysis: {
+    normalizer: {
+      insensitive_normalizer: {
+        type: 'custom',
+        filter: ['lowercase', 'asciifolding']
+      }
+    },
+    filter: {
+      french_elision: {
+        type: 'elision',
+        articles_case: true,
+        articles: [
+          'l', 'm', 't', 'qu', 'n', 's',
+          'j', 'd', 'c', 'jusqu', 'quoiqu',
+          'lorsqu', 'puisqu'
+        ]
+      },
+      french_stop: {
+        type: 'stop',
+        stopwords: '_french_'
+      },
+      french_stemmer: {
+        type: 'stemmer',
+        language: 'light_french'
+      }
+    },
+    analyzer: {
+      custom_french: {
+        tokenizer: 'standard',
+        filter: [
+          'french_elision',
+          'lowercase',
+          'french_stop',
+          'french_stemmer',
+          'asciifolding'
+        ]
+      },
+      custom_french_repeat: {
+        tokenizer: 'standard',
+        filter: [
+          'french_elision', 'lowercase', 'keyword_repeat',
+          'french_stop', 'french_stemmer', 'remove_duplicates', 'asciifolding'
+        ]
+      },
+      custom_french_exact: {
+        tokenizer: 'standard',
+        filter: ['french_elision', 'lowercase', 'asciifolding']
+      }
+    }
+  }
+}
+
+const ANALYZERS = textAnalyzers('custom_french')
+
+// ---- same code-like heuristic as api/src/datasets/utils/operations.ts `sniff()` (copied,
+// not imported, to avoid pulling in ajv/moment/slugify for a one-line check) — a string
+// column is "code-like" when EVERY non-empty value matches ascii letters/digits + ._/- and
+// contains at least one digit. This is exactly what api/src/datasets/utils/data-schema.ts
+// `mergeFileSchema()` turns into `x-capabilities: { text: false, insensitive: false }`. ----
+const CODE_REGEXP = /^[A-Za-z0-9_./-]+$/
+const isCodeValue = (value) => typeof value === 'string' && CODE_REGEXP.test(value) && /\d/.test(value)
+const isCodeLikeColumn = (rows, key) => {
+  let sawValue = false
+  for (const row of rows) {
+    const v = row[key]
+    if (v === null || v === undefined || v === '') continue
+    sawValue = true
+    if (!isCodeValue(v)) return false
+  }
+  return sawValue
+}
+
+// ---- datasets: 3 representative samples from data.ademe.fr's public API, picked via
+// GET /datasets?select=id,slug,count,schema (see task-6-report.md for the full search log) ----
+const DATASETS = [
+  {
+    key: 'pac-numeric',
+    label: 'numeric-heavy',
+    ademeId: '-p3qp8b8xestyz3f35ns-j1h',
+    title: 'PAC - Campagne de mesures 100 PACs',
+    slug: 'pac-campagne-de-mesures-100-pacs',
+    variants: ['A', 'B']
+  },
+  {
+    key: 'competences-acteurs-code',
+    label: 'code-heavy',
+    ademeId: 'pljxb0la63vv9iyp5848xioa',
+    title: 'Compétences des acteurs par année',
+    slug: 'competences-des-acteurs-par-annee',
+    variants: ['A', 'B', 'B2']
+  },
+  {
+    key: 'refashion-string',
+    label: 'string/prose control',
+    ademeId: 'zkt20z09p8jl6oix18a5kcte',
+    title: 'Données EO-REFASHION',
+    slug: 'donnees-eo-refashion',
+    variants: ['A', 'B']
+  }
+]
+
+async function esFetch (esPath, opts = {}) {
+  const res = await fetch(ES_ORIGIN + esPath, {
+    ...opts,
+    headers: { 'content-type': 'application/json', ...(opts.headers ?? {}) }
+  })
+  const text = await res.text()
+  let body
+  try { body = text ? JSON.parse(text) : {} } catch { body = text }
+  if (!res.ok) throw new Error(`ES ${opts.method ?? 'GET'} ${esPath} -> ${res.status}: ${JSON.stringify(body).slice(0, 2000)}`)
+  return body
+}
+
+async function fetchAdemeSchema (ademeId) {
+  const res = await fetch(`${ADEME_ORIGIN}/datasets/${ademeId}`)
+  if (!res.ok) throw new Error(`ademe dataset fetch failed ${res.status} for ${ademeId}`)
+  const body = await res.json()
+  const schema = (body.schema ?? []).filter(f => !f['x-calculated'] && !f['x-extension'])
+  return { count: body.count, schema, title: body.title }
+}
+
+async function fetchAdemeRows (ademeId, cap) {
+  const cacheFile = path.join(DATA_DIR, `${ademeId}.json`)
+  if (fs.existsSync(cacheFile)) {
+    const cached = JSON.parse(fs.readFileSync(cacheFile, 'utf8'))
+    if (cached.length >= cap) {
+      console.log(`  [cache] ${ademeId}: ${cached.length} rows from ${cacheFile}`)
+      return cached.slice(0, cap)
+    }
+  }
+  const rows = []
+  let url = `${ADEME_ORIGIN}/datasets/${ademeId}/lines?size=10000`
+  while (url && rows.length < cap) {
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(`ademe lines fetch failed ${res.status} for ${ademeId}`)
+    const body = await res.json()
+    rows.push(...body.results)
+    url = body.next && rows.length < cap ? body.next : null
+    process.stdout.write(`\r  [download] ${ademeId}: ${rows.length} rows`)
+  }
+  process.stdout.write('\n')
+  const capped = rows.slice(0, cap)
+  fs.writeFileSync(cacheFile, JSON.stringify(capped))
+  return capped
+}
+
+// keep only the schema's own keys (drops _id/_i/_rand/_score/_geopoint/_updatedAt etc.)
+function projectRow (row, schema) {
+  const doc = {}
+  for (const f of schema) {
+    const v = row[f.key]
+    if (v !== null && v !== undefined) doc[f.key] = v
+  }
+  return doc
+}
+
+async function createIndex (indexName, properties, nbShards = 1) {
+  await esFetch(`/${indexName}`, {
+    method: 'PUT',
+    body: JSON.stringify({
+      settings: {
+        index: {
+          'mapping.total_fields.limit': 3000,
+          number_of_shards: nbShards,
+          number_of_replicas: 0,
+          refresh_interval: -1
+        },
+        analysis: INDEX_BASE_SETTINGS.analysis
+      },
+      mappings: { dynamic: 'strict', properties }
+    })
+  })
+}
+
+async function bulkIndex (indexName, docs, batchSize) {
+  const start = Date.now()
+  for (let i = 0; i < docs.length; i += batchSize) {
+    const batch = docs.slice(i, i + batchSize)
+    const lines = []
+    for (const doc of batch) {
+      lines.push(JSON.stringify({ index: { _index: indexName } }))
+      lines.push(JSON.stringify(doc))
+    }
+    const res = await esFetch('/_bulk', { method: 'POST', body: lines.join('\n') + '\n' })
+    if (res.errors) {
+      const firstErr = res.items.find(it => it.index?.error)
+      throw new Error(`bulk index error on ${indexName}: ${JSON.stringify(firstErr).slice(0, 1000)}`)
+    }
+  }
+  return Date.now() - start
+}
+
+async function measureIndex (indexName) {
+  await esFetch(`/${indexName}/_refresh`, { method: 'POST' })
+  await esFetch(`/${indexName}/_forcemerge?max_num_segments=1`, { method: 'POST' })
+  await esFetch(`/${indexName}/_refresh`, { method: 'POST' })
+  const stats = await esFetch(`/_cat/indices/${indexName}?bytes=b&format=json`)
+  const row = stats[0]
+  return { docsCount: Number(row['docs.count']), storeBytes: Number(row['store.size']) }
+}
+
+async function deleteBenchIndices () {
+  try {
+    const indices = await esFetch(`/_cat/indices/${INDEX_PREFIX}-*?format=json`)
+    for (const idx of indices) {
+      if (!idx.index.startsWith(INDEX_PREFIX + '-')) continue // paranoia: never touch anything else
+      await esFetch(`/${idx.index}`, { method: 'DELETE' })
+      console.log(`  [cleanup] deleted ${idx.index}`)
+    }
+  } catch (err) {
+    console.error('cleanup failed (non-fatal):', err.message)
+  }
+}
+
+async function runDataset (ds) {
+  console.log(`\n=== ${ds.title} (${ds.key}) ===`)
+  const meta = await fetchAdemeSchema(ds.ademeId)
+  console.log(`  ademe count: ${meta.count}, schema cols (non-calculated): ${meta.schema.length}`)
+  const cap = Math.min(ROW_CAP, meta.count)
+  const rows = await fetchAdemeRows(ds.ademeId, cap)
+  console.log(`  using ${rows.length} rows (cap ${cap})`)
+
+  const docs = rows.map(r => projectRow(r, meta.schema))
+
+  // B2 schema: clone + inject the sniffer's capability shape on code-like string columns
+  let schemaB2 = null
+  const codeLikeCols = []
+  if (ds.variants.includes('B2')) {
+    schemaB2 = meta.schema.map(f => ({ ...f }))
+    for (const f of schemaB2) {
+      if (f.type !== 'string' || f.format === 'date' || f.format === 'date-time') continue
+      if (isCodeLikeColumn(rows, f.key)) {
+        f['x-capabilities'] = { ...(f['x-capabilities'] ?? {}), text: false, insensitive: false }
+        codeLikeCols.push(f.key)
+      }
+    }
+    console.log(`  B2 code-like columns (text:false, insensitive:false): ${codeLikeCols.join(', ') || '(none)'}`)
+  }
+
+  const results = { key: ds.key, label: ds.label, title: ds.title, ademeId: ds.ademeId, slug: ds.slug, rows: rows.length, ademeTotalCount: meta.count, codeLikeCols, variants: {} }
+
+  const variantSchema = { A: meta.schema, B: meta.schema, B2: schemaB2 }
+  const variantShape = { A: SHAPE_A, B: SHAPE_B, B2: SHAPE_B }
+
+  for (const variant of ds.variants) {
+    const indexName = `${INDEX_PREFIX}-${ds.key}-${variant.toLowerCase()}`
+    const schema = variantSchema[variant]
+    const shape = variantShape[variant]
+    const { properties } = buildIndexMappings({ extensions: [] }, schema, ANALYZERS, shape)
+    console.log(`  [${variant}] creating ${indexName} (shape=${JSON.stringify(shape)})`)
+    await createIndex(indexName, properties)
+    const wallMs = await bulkIndex(indexName, docs, BULK_BATCH)
+    const { docsCount, storeBytes } = await measureIndex(indexName)
+    console.log(`  [${variant}] docs=${docsCount} storeBytes=${storeBytes} wallMs=${wallMs}`)
+    results.variants[variant] = { indexName, docsCount, storeBytes, wallMs }
+  }
+
+  return results
+}
+
+async function main () {
+  // reachability check — never attempt to start/stop ES ourselves
+  try {
+    const info = await esFetch('/')
+    console.log(`ES reachable at ${ES_ORIGIN}: ${info.version?.number}`)
+  } catch (err) {
+    console.error(`BLOCKED: dev ES not reachable at ${ES_ORIGIN}: ${err.message}`)
+    process.exit(1)
+  }
+
+  const allResults = []
+  try {
+    for (const ds of DATASETS) {
+      const r = await runDataset(ds)
+      allResults.push(r)
+    }
+  } finally {
+    await deleteBenchIndices()
+  }
+
+  const outFile = path.join(__dirname, 'results.json')
+  fs.writeFileSync(outFile, JSON.stringify({ generatedAt: new Date().toISOString(), rowCap: ROW_CAP, bulkBatch: BULK_BATCH, results: allResults }, null, 2))
+  console.log(`\nResults written to ${outFile}`)
+}
+
+main().catch(err => {
+  console.error('FATAL', err)
+  process.exit(1)
+})

--- a/benchmark/capabilities-defaults/bench.mjs
+++ b/benchmark/capabilities-defaults/bench.mjs
@@ -2,7 +2,12 @@
 // A/B bench: store size + bulk-indexing wall time, current production mapping shape ("A")
 // vs this branch's new shape ("B", adds noNumericText), plus a "B2" variant on the
 // code-heavy dataset that also applies the Task 5 sniffer's capability injection
-// (`{ text: false, insensitive: false }`) to code-like string columns.
+// (`{ text: false, insensitive: false }`) to code-like string columns. NOTE on B2's actual
+// mechanism (esProperty, operations.ts): `text: false` does NOT drop analysis entirely — it
+// falls back to a standard-analyzed `.text_standard` inner field (textStandard still
+// defaults true). So B->B2 swaps the French-analyzed `.text` field for a standard-analyzed
+// `.text_standard` field AND drops `.keyword_insensitive` — see RESULTS.md for the measured
+// breakdown of those two sub-effects.
 //
 // Runs entirely against the dev Elasticsearch instance (no data-fair API upload, no dev
 // process restarts): mappings are produced by the REAL branch code
@@ -44,9 +49,12 @@ const SHAPE_A = Object.freeze({ singleTextField: true, wordAggField: true })
 const SHAPE_B = NEW_INDEX_SHAPE
 
 // ---- verbatim copy of indexBase()'s settings.analysis block from
-// api/src/datasets/es/manage-indices.ts (kept in sync by hand; only the analyzer/normalizer
-// definitions are needed standalone here, index.number_of_shards/replicas are set separately
-// per bench run) ----
+// api/src/datasets/es/manage-indices.ts (that function is exported specifically so "raw-ES
+// test fixtures ... can derive real index settings without hand-copying the analyzer/filter
+// definitions" per its own comment at manage-indices.ts:220-222 — this bench predates/doesn't
+// use that export directly to stay independent of #config, but the intent is the same: kept
+// in sync by hand; only the analyzer/normalizer definitions are needed standalone here,
+// index.number_of_shards/replicas are set separately per bench run) ----
 const INDEX_BASE_SETTINGS = {
   analysis: {
     normalizer: {
@@ -137,7 +145,15 @@ const DATASETS = [
     ademeId: 'pljxb0la63vv9iyp5848xioa',
     title: 'Compétences des acteurs par année',
     slug: 'competences-des-acteurs-par-annee',
-    variants: ['A', 'B', 'B2']
+    // 'A-narrow' is a decomposition variant (not a real shape): Shape A's mapping with the
+    // `_search` catch-all field and `copy_to` annotations manually stripped afterwards. This
+    // dataset has 16 analyzed inner fields under shape A (13 string .text + 3 numeric
+    // .text_standard) — one above hasManyQSearchFields' 15-field threshold — so shape A
+    // classifies it `wide` (adds `_search`/copy_to) while shape B (noNumericText drops the 3
+    // numeric .text_standard fields) classifies it narrow. A-narrow isolates "losing the
+    // catch-all" from "losing numeric .text_standard" so the two effects aren't conflated in
+    // the A->B delta. See RESULTS.md's decomposition table.
+    variants: ['A', 'A-narrow', 'B', 'B2']
   },
   {
     key: 'refashion-string',
@@ -240,13 +256,97 @@ async function bulkIndex (indexName, docs, batchSize) {
   return Date.now() - start
 }
 
+// `_cat/indices` store.size LAGS the actual segment write right after forcemerge: a read
+// taken immediately (even after a `_refresh`) can catch a transient small value before the
+// merged segment is fully committed to the reported store size — measured directly: a fresh
+// rebuild read 7.6MB right after forcemerge/refresh, then settled at ~29.8MB ~10s later on
+// the same index with no further writes. Fix: `_flush` (forces an fsync'd commit) then poll
+// `_cat/indices` at 1s intervals until the SAME value is read twice in a row (or 60s
+// timeout), and additionally cross-check against the `_disk_usage` analysis API's
+// `store_size_in_bytes`, which also gives a per-field-category breakdown (stored_fields /
+// doc_values / points / inverted_index / norms) used in RESULTS.md's PAC interpretation.
+const SETTLE_POLL_INTERVAL_MS = 1000
+const SETTLE_POLL_TIMEOUT_MS = 60_000
+
 async function measureIndex (indexName) {
   await esFetch(`/${indexName}/_refresh`, { method: 'POST' })
   await esFetch(`/${indexName}/_forcemerge?max_num_segments=1`, { method: 'POST' })
+  await esFetch(`/${indexName}/_flush`, { method: 'POST' })
   await esFetch(`/${indexName}/_refresh`, { method: 'POST' })
-  const stats = await esFetch(`/_cat/indices/${indexName}?bytes=b&format=json`)
-  const row = stats[0]
-  return { docsCount: Number(row['docs.count']), storeBytes: Number(row['store.size']) }
+
+  let prev = null
+  let settled = null
+  let docsCount = null
+  let pollCount = 0
+  const deadline = Date.now() + SETTLE_POLL_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    const stats = await esFetch(`/_cat/indices/${indexName}?bytes=b&format=json`)
+    const cur = Number(stats[0]['store.size'])
+    docsCount = Number(stats[0]['docs.count'])
+    pollCount++
+    if (prev !== null && cur === prev) { settled = cur; break }
+    prev = cur
+    await new Promise(resolve => setTimeout(resolve, SETTLE_POLL_INTERVAL_MS))
+  }
+  if (settled === null) {
+    console.warn(`  [WARN] ${indexName} store.size did not settle within ${SETTLE_POLL_TIMEOUT_MS}ms (last read ${prev}) — using last read, treat as unreliable`)
+    settled = prev
+  } else if (pollCount > 2) {
+    console.log(`  [poll] ${indexName} settled at ${settled} after ${pollCount} reads (${(pollCount - 1) * SETTLE_POLL_INTERVAL_MS}ms of polling)`)
+  }
+
+  let diskUsageTotal = null
+  let componentBreakdown = null
+  try {
+    const diskUsage = await esFetch(`/${indexName}/_disk_usage?run_expensive_tasks=true`, { method: 'POST' })
+    const entry = diskUsage[indexName]
+    diskUsageTotal = entry?.store_size_in_bytes ?? null
+    if (entry?.all_fields) {
+      componentBreakdown = {
+        invertedIndex: entry.all_fields.inverted_index?.total_in_bytes ?? 0,
+        storedFields: entry.all_fields.stored_fields_in_bytes ?? 0,
+        docValues: entry.all_fields.doc_values_in_bytes ?? 0,
+        points: entry.all_fields.points_in_bytes ?? 0,
+        norms: entry.all_fields.norms_in_bytes ?? 0
+      }
+    }
+  } catch (err) {
+    console.warn(`  [WARN] _disk_usage failed for ${indexName} (non-fatal, store.size above is still recorded): ${err.message}`)
+  }
+
+  // Discovered empirically on this branch's own first "fixed" run: the settle-poll on
+  // `_cat/indices` store.size can plateau at a WRONG value for two consecutive 1s-apart
+  // reads (a mid-merge intermediate state that happens to hold steady for >1s before moving
+  // again) — e.g. one competences-acteurs-code 'A' run settled at 3,506,615 while
+  // `_disk_usage` (which reads the actual committed Lucene segment files, not a
+  // shard-level stat) reported 24,461,193 for the same index. `_disk_usage`'s
+  // `store_size_in_bytes` is therefore treated as the authoritative figure whenever it
+  // succeeds; the settled `_cat/indices` read is kept only as `catStoreBytes` for
+  // transparency, and a loud warning is logged whenever the two disagree by more than 1%.
+  let storeBytes = settled
+  if (diskUsageTotal !== null) {
+    const diffPct = settled ? 100 * Math.abs(diskUsageTotal - settled) / settled : null
+    if (diffPct !== null && diffPct > 1) {
+      console.warn(`  [WARN] ${indexName}: _cat/indices store.size (${settled}) disagrees with _disk_usage (${diskUsageTotal}) by ${diffPct.toFixed(1)}% — using _disk_usage as authoritative`)
+    }
+    storeBytes = diskUsageTotal
+  }
+
+  return { docsCount, storeBytes, catStoreBytes: settled, diskUsageTotal, componentBreakdown }
+}
+
+// Decomposition helper for the 'A-narrow' variant: strip the `_search` catch-all property and
+// every `copy_to` annotation that `buildIndexMappings` adds when a schema classifies `wide`
+// under the given shape (see hasManyQSearchFields / buildIndexMappings in operations.ts).
+// Post-processes an already-built properties object rather than re-deriving mapping logic.
+function stripWideAnnotations (properties) {
+  const stripped = JSON.parse(JSON.stringify(properties))
+  delete stripped._search
+  for (const key of Object.keys(stripped)) {
+    const prop = stripped[key]
+    if (prop && typeof prop === 'object' && 'copy_to' in prop) delete prop.copy_to
+  }
+  return stripped
 }
 
 async function deleteBenchIndices () {
@@ -292,17 +392,31 @@ async function runDataset (ds) {
   const variantSchema = { A: meta.schema, B: meta.schema, B2: schemaB2 }
   const variantShape = { A: SHAPE_A, B: SHAPE_B, B2: SHAPE_B }
 
+  // ordering-bias note (documented in RESULTS.md caveats): variants run in array order, so
+  // 'A' always hits a colder ES (JIT, filesystem cache) than later variants, and earlier
+  // variants' indices are still resident when later ones are created/measured.
   for (const variant of ds.variants) {
     const indexName = `${INDEX_PREFIX}-${ds.key}-${variant.toLowerCase()}`
-    const schema = variantSchema[variant]
-    const shape = variantShape[variant]
-    const { properties } = buildIndexMappings({ extensions: [] }, schema, ANALYZERS, shape)
-    console.log(`  [${variant}] creating ${indexName} (shape=${JSON.stringify(shape)})`)
+    let properties, wide, shapeLabel
+    if (variant === 'A-narrow') {
+      const built = buildIndexMappings({ extensions: [] }, meta.schema, ANALYZERS, SHAPE_A)
+      properties = stripWideAnnotations(built.properties)
+      wide = false // forced narrow by post-processing, not a real shape classification
+      shapeLabel = `${JSON.stringify(SHAPE_A)} +stripped(_search,copy_to) [decomposition variant]`
+    } else {
+      const schema = variantSchema[variant]
+      const shape = variantShape[variant]
+      const built = buildIndexMappings({ extensions: [] }, schema, ANALYZERS, shape)
+      properties = built.properties
+      wide = built.wide
+      shapeLabel = JSON.stringify(shape)
+    }
+    console.log(`  [${variant}] creating ${indexName} (shape=${shapeLabel}, wide=${wide})`)
     await createIndex(indexName, properties)
     const wallMs = await bulkIndex(indexName, docs, BULK_BATCH)
-    const { docsCount, storeBytes } = await measureIndex(indexName)
-    console.log(`  [${variant}] docs=${docsCount} storeBytes=${storeBytes} wallMs=${wallMs}`)
-    results.variants[variant] = { indexName, docsCount, storeBytes, wallMs }
+    const { docsCount, storeBytes, catStoreBytes, diskUsageTotal, componentBreakdown } = await measureIndex(indexName)
+    console.log(`  [${variant}] docs=${docsCount} storeBytes=${storeBytes} (catStoreBytes=${catStoreBytes}, diskUsageTotal=${diskUsageTotal}) wide=${wide} wallMs=${wallMs}`)
+    results.variants[variant] = { indexName, docsCount, storeBytes, catStoreBytes, diskUsageTotal, componentBreakdown, wide, wallMs }
   }
 
   return results

--- a/docs/architecture/text-search-evaluation.md
+++ b/docs/architecture/text-search-evaluation.md
@@ -50,7 +50,16 @@ rollout (`0bc454fb4`) and load-management.md §6.
 | `.keyword_insensitive` | `x-capabilities.insensitive !== false` | `insensitive_normalizer` | Diacritic/case-insensitive sort, not search |
 | `.wildcard` | `x-capabilities.wildcard === true` (opt-in) | (wildcard type) | `*q*` contains queries |
 
-Numeric and date columns get a single `.text_standard` inner field so they can be matched textually.
+Date columns get a single `.text_standard` inner field so they can be matched textually.
+
+> **Note (2026-08-07).** Numeric (`integer`/`number`) columns no longer get a `.text_standard`
+> inner field on freshly built indexes (the `noNumericText` shape flag) — `q` now matches
+> them whole-value via the main `long`/`double` field instead. Boolean columns never had a
+> mapped `.text_standard` either (the old per-type capability toggle was a no-op for them).
+> The `textStandard` capability itself stays in the contract (dates and strings still use
+> it) and an explicit `x-capabilities: { textStandard: false }` set via the API on a numeric
+> column is still honored — only the *offered* per-type capability lists (UI schema editor,
+> agent property-config tools) dropped `textStandard` for `number`/`integer`/`boolean`.
 
 **`q` regimes** (`getFilterableFields`). Three coexisting paths chosen by dataset state, no
 explicit `q_fields`:

--- a/docs/architecture/text-search-evaluation.md
+++ b/docs/architecture/text-search-evaluation.md
@@ -630,6 +630,12 @@ _search catch-all:
   Single analyzed field with the dataset's language analyzer.
 ```
 
+> Note (2026-08-07): the "numeric / date columns keep `.text_standard`" premise below predates the
+> default-capabilities change (`docs/superpowers/specs/2026-08-07-default-capabilities-design.md`),
+> which retired `.text_standard` for `integer`/`number` columns (`noNumericText` index shape,
+> whole-value `q` matching now goes through the main field via a `lenient: true` clause). Dates are
+> unaffected and still keep it. Revisit this section's numeric assumptions if R6 is picked up.
+
 **Why each piece**:
 - Halving the analyzed sub-field count per column shrinks `_search`, the catch-all index
   size, and the leaf-clause count when per-column is still in play.

--- a/tests/features/agent-tools/property-config-tools.unit.spec.ts
+++ b/tests/features/agent-tools/property-config-tools.unit.spec.ts
@@ -205,6 +205,22 @@ test.describe('executeSetPropertyConfig', () => {
     assert.deepEqual(receivedConfigs[0].capabilities, { textAgg: true })
   })
 
+  test('preserves a hidden stored capability (numeric textStandard) not offered any more for the type', () => {
+    // numeric columns no longer offer `textStandard` (Tier 2 retirement), but a column that had it
+    // explicitly disabled before the retirement (or via a raw schema PATCH) must not have that
+    // opt-out silently dropped by a wholesale agent capability write.
+    const dataset = {
+      schema: [{ key: 'col1', type: 'integer', 'x-capabilities': { textStandard: false } }]
+    }
+    let receivedConfigs: any[] = []
+    executeSetPropertyConfig(
+      { configs: [{ key: 'col1', capabilities: { index: true, values: false } }] },
+      dataset,
+      (configs) => { receivedConfigs = configs }
+    )
+    assert.deepEqual(receivedConfigs[0].capabilities, { values: false, textStandard: false })
+  })
+
   test('reports correct counts in summary', () => {
     const dataset = {
       file: { name: 'test.csv' },

--- a/tests/features/agent-tools/property-config-tools.unit.spec.ts
+++ b/tests/features/agent-tools/property-config-tools.unit.spec.ts
@@ -12,17 +12,25 @@ import {
 test.describe('getRelevantCapabilities', () => {
   test('returns numeric capabilities for number type', () => {
     const caps = getRelevantCapabilities('number')
-    assert.deepEqual(caps, ['index', 'textStandard', 'values'])
+    assert.deepEqual(caps, ['index', 'values'])
   })
 
   test('returns numeric capabilities for integer type', () => {
     const caps = getRelevantCapabilities('integer')
-    assert.deepEqual(caps, ['index', 'textStandard', 'values'])
+    assert.deepEqual(caps, ['index', 'values'])
   })
 
   test('returns numeric capabilities for boolean type', () => {
     const caps = getRelevantCapabilities('boolean')
-    assert.deepEqual(caps, ['index', 'textStandard', 'values'])
+    assert.deepEqual(caps, ['index', 'values'])
+  })
+
+  test('numeric and boolean types no longer offer textStandard', () => {
+    assert.deepEqual(getRelevantCapabilities('integer'), ['index', 'values'])
+    assert.deepEqual(getRelevantCapabilities('number'), ['index', 'values'])
+    assert.deepEqual(getRelevantCapabilities('boolean'), ['index', 'values'])
+    // dates keep textual matching (year search)
+    assert.deepEqual(getRelevantCapabilities('string', 'date'), ['index', 'textStandard', 'values'])
   })
 
   test('returns date capabilities for string with date format', () => {

--- a/tests/features/datasets/query/index-definition.unit.spec.ts
+++ b/tests/features/datasets/query/index-definition.unit.spec.ts
@@ -39,6 +39,32 @@ test.describe('buildIndexMappings - catch-all _search field', () => {
     // a boolean column has no text inner field -> not copied
     assert.equal(properties.a_bool.copy_to, undefined)
   })
+
+  test('wide dataset: numeric columns lose copy_to under noNumericText but keep it under legacy', () => {
+    // A wide schema with enough text columns to trigger _search: 32 strings = 32 fields > 15 threshold
+    // When noNumericText is active, numeric columns have no inner fields, so they don't get copy_to.
+    // Task 3 adds per-field lenient q clauses for numerics independent of copy_to regime.
+    const schema = [
+      ...Array.from({ length: 32 }, (_, i) => stringField('f' + i)),
+      { key: 'num1', type: 'number' },
+      { key: 'num2', type: 'number' }
+    ]
+
+    // legacy shape: numerics emit .text_standard, so they get copy_to in wide dataset
+    const legacy: any = { id: 'wide-legacy', schema, extensions: [] }
+    const legacyRes = buildIndexMappings(legacy, schema, ANALYZERS, currentIndexShape(legacy))
+    assert.equal(legacyRes.wide, true)
+    assert.equal(legacyRes.properties.num1.copy_to, '_search')
+    assert.equal(legacyRes.properties.num2.copy_to, '_search')
+
+    // new shape with noNumericText: numerics have no inner fields, so no copy_to
+    const fresh: any = { id: 'wide-new', schema, extensions: [], _indexShape: NEW_INDEX_SHAPE }
+    const freshRes = buildIndexMappings(fresh, schema, ANALYZERS, currentIndexShape(fresh))
+    assert.equal(freshRes.wide, true)
+    assert.equal(freshRes.properties._search.type, 'text')
+    assert.equal(freshRes.properties.num1.copy_to, undefined)
+    assert.equal(freshRes.properties.num2.copy_to, undefined)
+  })
 })
 
 // `indexDefinition(dataset)` (manage-indices) emits with `currentIndexShape(dataset)` by default,
@@ -76,6 +102,10 @@ test.describe('emission shape of a partial mapping update (updateDatasetMapping 
   // wideness is an emission decision like any other, so it follows the index too: a scalar-heavy
   // schema in the 15..30 band must keep the classification its legacy index was built with
   test('a band-shaped schema stays narrow on a legacy index and is wide on a new one', () => {
+    // Use dates (not integers) because with the noNumericText flag, numeric columns no longer
+    // emit .text_standard in the new shape, so they don't contribute to the wide-classification
+    // field count. Dates always emit .text_standard for year search, so they count consistently
+    // in both shapes: 20 dates = 20 fields, which is <= 30 (legacy narrow) but > 15 (new wide).
     const schema = Array.from({ length: 20 }, (_, i) => ({ key: 'd' + i, type: 'string', format: 'date' }))
     const legacy: any = { id: 'band-legacy', schema, extensions: [] }
     const legacyRes = buildIndexMappings(legacy, schema, ANALYZERS, currentIndexShape(legacy))

--- a/tests/features/datasets/query/index-definition.unit.spec.ts
+++ b/tests/features/datasets/query/index-definition.unit.spec.ts
@@ -76,18 +76,18 @@ test.describe('emission shape of a partial mapping update (updateDatasetMapping 
   // wideness is an emission decision like any other, so it follows the index too: a scalar-heavy
   // schema in the 15..30 band must keep the classification its legacy index was built with
   test('a band-shaped schema stays narrow on a legacy index and is wide on a new one', () => {
-    const schema = Array.from({ length: 20 }, (_, i) => ({ key: 'n' + i, type: 'integer' }))
+    const schema = Array.from({ length: 20 }, (_, i) => ({ key: 'd' + i, type: 'string', format: 'date' }))
     const legacy: any = { id: 'band-legacy', schema, extensions: [] }
     const legacyRes = buildIndexMappings(legacy, schema, ANALYZERS, currentIndexShape(legacy))
     assert.equal(legacyRes.wide, false)
     assert.equal(legacyRes.properties._search, undefined)
-    assert.equal(legacyRes.properties.n0.copy_to, undefined)
+    assert.equal(legacyRes.properties.d0.copy_to, undefined)
 
     const fresh: any = { id: 'band-new', schema, extensions: [], _indexShape: NEW_INDEX_SHAPE }
     const freshRes = buildIndexMappings(fresh, schema, ANALYZERS, currentIndexShape(fresh))
     assert.equal(freshRes.wide, true)
     assert.equal(freshRes.properties._search.type, 'text')
-    assert.equal(freshRes.properties.n0.copy_to, '_search')
+    assert.equal(freshRes.properties.d0.copy_to, '_search')
   })
 
   test('currentIndexShape: absent stamp is legacy, stamp is followed', () => {
@@ -116,11 +116,15 @@ test.describe('esProperty shapes', () => {
     assert.equal(p.fields.text_standard.analyzer, 'standard')
     assert.equal(p.fields.keyword_insensitive.normalizer, 'insensitive_normalizer')
   })
-  test('scalars keep .text_standard under both shapes', () => {
-    for (const shape of [undefined, LEGACY_INDEX_SHAPE]) {
-      const p = esProperty({ key: 'n', type: 'number' }, { search: 'S', index: 'I' }, shape)
-      assert.equal(p.fields.text_standard.analyzer, 'standard')
-    }
+  test('numeric scalars in legacy shape keep .text_standard; dates keep it in both shapes', () => {
+    // legacy: numbers emit .text_standard
+    const pLeg = esProperty({ key: 'n', type: 'number' }, { search: 'S', index: 'I' }, LEGACY_INDEX_SHAPE)
+    assert.equal(pLeg.fields.text_standard.analyzer, 'standard')
+    // new shape: numbers lose .text_standard (noNumericText flag); dates keep it for year search
+    const pNumNew = esProperty({ key: 'n', type: 'number' }, { search: 'S', index: 'I' }, NEW_INDEX_SHAPE)
+    assert.equal(pNumNew.fields, undefined)
+    const pDateNew = esProperty({ key: 'd', type: 'string', format: 'date' }, { search: 'S', index: 'I' }, NEW_INDEX_SHAPE)
+    assert.equal(pDateNew.fields.text_standard.analyzer, 'standard')
   })
   test('search disabled: no analyzed field at all under the new shape', () => {
     const p = esProperty({ key: 'a', type: 'string', 'x-capabilities': { text: false, textStandard: false } }, { search: 'S', index: 'I' })
@@ -142,5 +146,37 @@ test.describe('esProperty shapes', () => {
     assert.equal(p.fields.text.analyzer, 'I')
     assert.equal(p.fields.text.search_analyzer, 'S')
     assert.equal(p.fields.text_standard, undefined)
+  })
+})
+
+test.describe('noNumericText shape - numeric columns lose .text_standard', () => {
+  const schema = [
+    { key: 'an_int', type: 'integer' },
+    { key: 'a_num', type: 'number' },
+    { key: 'a_date', type: 'string', format: 'date' },
+    stringField('a_str')
+  ]
+
+  test('new shape: no text_standard on integer/number, kept on date and string', () => {
+    const dataset: any = { id: 'nnt-new', schema, extensions: [] }
+    const { properties } = buildIndexMappings(dataset, schema, ANALYZERS, NEW_INDEX_SHAPE)
+    assert.equal(properties.an_int.fields, undefined)
+    assert.equal(properties.a_num.fields, undefined)
+    assert.equal(properties.a_date.fields.text_standard.analyzer, 'standard')
+    assert.equal(properties.a_str.fields.text.analyzer, INDEX_ANALYZER)
+  })
+
+  test('legacy shape (no _indexShape): numeric text_standard still emitted', () => {
+    const dataset: any = { id: 'nnt-legacy', schema, extensions: [] }
+    const { properties } = buildIndexMappings(dataset, schema, ANALYZERS, currentIndexShape(dataset))
+    assert.equal(properties.an_int.fields.text_standard.analyzer, 'standard')
+    assert.equal(properties.a_num.fields.text_standard.analyzer, 'standard')
+  })
+
+  test('pre-flag new-shape index (singleTextField only): numeric text_standard still emitted', () => {
+    // a dataset rebuilt between the single-text-field rework and this change
+    const dataset: any = { id: 'nnt-mid', schema, extensions: [], _indexShape: { singleTextField: true, wordAggField: true } }
+    const { properties } = buildIndexMappings(dataset, schema, ANALYZERS, currentIndexShape(dataset))
+    assert.equal(properties.an_int.fields.text_standard.analyzer, 'standard')
   })
 })

--- a/tests/features/datasets/query/index-shape.api.spec.ts
+++ b/tests/features/datasets/query/index-shape.api.spec.ts
@@ -112,15 +112,20 @@ test.describe('index shape', () => {
 
     // simulate the legacy fleet member we cannot create through the API (a fresh index is always
     // built new-shape, and a band-shaped one would be born wide): drop the stamp AND graft the
-    // band-shaped schema onto the stored document. 20 numeric columns + `txt` = 21 counted inner
-    // fields under both shapes (+3 calculated) — over the new threshold of 15, well under the
-    // legacy 30.
-    await patchRawDataset(id, { $unset: { _indexShape: '' }, schema: [txtCol, ...numCols(20)] })
+    // band-shaped schema onto the stored document. Use DATE columns (not numeric) for the filler:
+    // with noNumericText, numeric columns emit no inner field at all under the new shape and would
+    // contribute 0 to the count, collapsing the band to "narrow under both shapes" and making the
+    // assertion below vacuous. Dates always emit `.text_standard` (year search) under both shapes,
+    // so they count consistently — same substitution as index-definition.unit.spec.ts's band test.
+    // 20 date columns + `txt` = 21 counted inner fields under both shapes (+3 calculated) — over
+    // the new threshold of 15, well under the legacy 30.
+    const dateCols = (n: number) => Array.from({ length: n }, (_, i) => ({ key: 'date' + i, type: 'string', format: 'date' }))
+    await patchRawDataset(id, { $unset: { _indexShape: '' }, schema: [txtCol, ...dateCols(20)] })
     await clearDatasetCache()
 
     // a compatible schema patch: the partial mapping update path
     await doAndWaitForFinalize(ax, id, () => ax.patch(`/api/v1/datasets/${id}`, {
-      schema: [txtCol, ...numCols(21)]
+      schema: [txtCol, ...dateCols(21)]
     }))
 
     const properties = await datasetEsMappingProperties(id)

--- a/tests/features/datasets/query/index-shape.api.spec.ts
+++ b/tests/features/datasets/query/index-shape.api.spec.ts
@@ -48,10 +48,10 @@ test.describe('index shape', () => {
   test('a fresh dataset is stamped new-shape and grows new-shaped columns', async () => {
     await createDataset('shape-new')
     const raw = await getRawDataset('shape-new')
-    assert.deepEqual(raw._indexShape, { singleTextField: true, wordAggField: true })
+    assert.deepEqual(raw._indexShape, { singleTextField: true, wordAggField: true, noNumericText: true })
     // internal field: stripped from the public representation, surfaced to admins by _diagnose
     assert.equal((await testUser1.get('/api/v1/datasets/shape-new')).data._indexShape, undefined)
-    assert.deepEqual((await adminUser.get('/api/v1/datasets/shape-new/_diagnose')).data._indexShape, { singleTextField: true, wordAggField: true })
+    assert.deepEqual((await adminUser.get('/api/v1/datasets/shape-new/_diagnose')).data._indexShape, { singleTextField: true, wordAggField: true, noNumericText: true })
 
     const properties = await addStringColumn('shape-new')
     // single analyzed field: the repeat index analyzer + a distinct search analyzer, no
@@ -61,7 +61,7 @@ test.describe('index shape', () => {
     assert.notEqual(properties.str2.fields.text.analyzer, properties.str2.fields.text.search_analyzer)
     assert.equal(properties.str2.fields.text_standard, undefined)
     // the mapping update did not rebuild the index -> the stamp is unchanged
-    assert.deepEqual((await getRawDataset('shape-new'))._indexShape, { singleTextField: true, wordAggField: true })
+    assert.deepEqual((await getRawDataset('shape-new'))._indexShape, { singleTextField: true, wordAggField: true, noNumericText: true })
   })
 
   test('a legacy dataset (no stamp) grows LEGACY-shaped columns and stays unstamped', async () => {

--- a/tests/features/datasets/query/index-shape.api.spec.ts
+++ b/tests/features/datasets/query/index-shape.api.spec.ts
@@ -20,11 +20,13 @@ test.describe('index shape', () => {
     if (testInfo.status === 'passed') await checkPendingTasks()
   })
 
-  // The initial schema deliberately holds no string column: a scalar's mapping is identical under
-  // both shapes, so the partial mapping update below is accepted by elasticsearch either way and
-  // the ONLY difference between the two datasets is the shape the new string column is emitted
-  // with. A string column in the initial schema would make the legacy-shaped update conflict with
-  // the live new-shape mapping and fall back to a full reindex, hiding what we want to observe.
+  // The initial schema deliberately holds no string column: with noNumericText, a numeric column
+  // differs between shapes (legacy emits .text_standard, new does not), but numbers have no inner
+  // text fields for _search/copy_to routing, so the partial mapping update is accepted by
+  // elasticsearch either way. The ONLY difference surfaced in the mapping between the two datasets
+  // is the shape the new string column is emitted with. A string column in the initial schema
+  // would make the legacy-shaped update conflict with the live new-shape mapping and fall back to
+  // a full reindex, hiding what we want to observe.
   const createDataset = async (id: string) => {
     const ax = testUser1
     await ax.put(`/api/v1/datasets/${id}`, {

--- a/tests/features/datasets/query/numeric-q.api.spec.ts
+++ b/tests/features/datasets/query/numeric-q.api.spec.ts
@@ -1,0 +1,42 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { axiosAuth, clean, checkPendingTasks } from '../../../support/axios.ts'
+import { waitForFinalize } from '../../../support/workers.ts'
+
+const testUser1 = await axiosAuth('test_user1@test.com')
+
+test.describe('q matching on numeric columns without text_standard', () => {
+  test.beforeEach(async () => { await clean() })
+  test.afterEach(async ({}, testInfo) => { if (testInfo.status === 'passed') await checkPendingTasks() })
+
+  test('whole-value q match via lenient main-field clause', async () => {
+    const ax = testUser1
+    await ax.post('/api/v1/datasets/numeric-q', {
+      isRest: true,
+      title: 'numeric-q',
+      schema: [{ key: 'code', type: 'integer' }, { key: 'label', type: 'string' }]
+    })
+    await ax.post('/api/v1/datasets/numeric-q/_bulk_lines', [
+      { code: 84500, label: 'orange' },
+      { code: 13001, label: 'marseille' }
+    ])
+    await waitForFinalize(ax, 'numeric-q')
+
+    // whole-value match through the main long field
+    let res = await ax.get('/api/v1/datasets/numeric-q/lines', { params: { q: '84500' } })
+    assert.equal(res.data.total, 1)
+    assert.equal(res.data.results[0].code, 84500)
+
+    // mixed query: string token + numeric token, q_mode=and
+    res = await ax.get('/api/v1/datasets/numeric-q/lines', { params: { q: 'orange 84500', q_mode: 'and' } })
+    assert.equal(res.data.total, 1)
+
+    // prefix autocompletion on numerics is retired: no partial match
+    res = await ax.get('/api/v1/datasets/numeric-q/lines', { params: { q: '845', q_mode: 'complete' } })
+    assert.equal(res.data.total, 0)
+
+    // per-column _search filter routes to the main field
+    res = await ax.get('/api/v1/datasets/numeric-q/lines', { params: { code_search: '84500' } })
+    assert.equal(res.data.total, 1)
+  })
+})

--- a/tests/features/datasets/query/numeric-q.api.spec.ts
+++ b/tests/features/datasets/query/numeric-q.api.spec.ts
@@ -39,4 +39,33 @@ test.describe('q matching on numeric columns without text_standard', () => {
     res = await ax.get('/api/v1/datasets/numeric-q/lines', { params: { code_search: '84500' } })
     assert.equal(res.data.total, 1)
   })
+
+  // Pin, not a red/green cycle: this 400 is the pre-existing requiredCapability behavior
+  // (unchanged by this task) for a column with no analyzed subfield at all. What this test
+  // actually exercises is the controller ruling that the new noNumericText branch in
+  // commons.ts's `_search` handling must NOT intercept this column and route it to the lenient
+  // main-field clause instead — it has to fall through to the existing empty-subfields 400.
+  test('explicit textStandard:false opt-out on a numeric column still 400s on col_search, not lenient-routed', async () => {
+    const ax = testUser1
+    await ax.post('/api/v1/datasets/numeric-q-optout', {
+      isRest: true,
+      title: 'numeric-q-optout',
+      schema: [
+        { key: 'code', type: 'integer', 'x-capabilities': { textStandard: false } },
+        { key: 'label', type: 'string' }
+      ]
+    })
+    await ax.post('/api/v1/datasets/numeric-q-optout/_bulk_lines', [
+      { code: 84500, label: 'orange' }
+    ])
+    await waitForFinalize(ax, 'numeric-q-optout')
+
+    await assert.rejects(
+      ax.get('/api/v1/datasets/numeric-q-optout/lines', { params: { code_search: '84500' } }),
+      (err: any) => {
+        assert.equal(err.status, 400)
+        return true
+      }
+    )
+  })
 })

--- a/tests/features/datasets/query/q-fields.unit.spec.ts
+++ b/tests/features/datasets/query/q-fields.unit.spec.ts
@@ -6,7 +6,9 @@ import { Q_SEARCH_FIELDS_THRESHOLD, LEGACY_Q_SEARCH_FIELDS_THRESHOLD, NEW_INDEX_
 // a string column produces a single .text inner field -> counts as 1 (legacy: .text +
 // .text_standard -> 2)
 const stringFields = (n: number) => Array.from({ length: n }, (_, i) => ({ key: 's' + i, type: 'string' }))
-// an integer (or date) column produces only a .text_standard inner field -> counts as 1 under both shapes
+// an integer column produces only a .text_standard inner field under the legacy shape -> counts as
+// 1 there, but 0 under noNumericText (part of the default NEW_INDEX_SHAPE), which drops that inner
+// field entirely for integer/number columns. (A date column still counts 1 under both shapes.)
 const intFields = (n: number) => Array.from({ length: n }, (_, i) => ({ key: 'i' + i, type: 'integer' }))
 const boolFields = (n: number) => Array.from({ length: n }, (_, i) => ({ key: 'b' + i, type: 'boolean' }))
 
@@ -390,5 +392,41 @@ test.describe('numeric q fallback (noNumericText shape)', () => {
     const { qLenientFields } = getFilterableFields(dataset, 'foo', undefined)
     assert.deepEqual(qLenientFields, ['code', 'measure'])
     assert.ok(!qLenientFields.includes('excluded'))
+  })
+})
+
+// Mixed-fleet virtual datasets: finalize.ts only stamps the virtual parent's own `_indexShape.
+// noNumericText` when EVERY descendant has it (see finalize.ts's bubble-up comment). Over a fleet
+// of {legacy child, rebuilt child} that leaves the parent legacy, but the query layer must still
+// route the lenient numeric fallback for the rebuilt child's rows: without it, a numeric `q` targets
+// `<col>.text_standard`, which is unmapped on the rebuilt child, and its rows silently stop
+// matching. Routing reads `dataset._indexShape?.noNumericText` OR
+// `dataset.descendants?.some(d => d._indexShape?.noNumericText)` — see hasNumericLenientRouting.
+test.describe('numeric q fallback - virtual dataset routing (mixed fleet)', () => {
+  const schema = [
+    { key: 'code', type: 'integer' },
+    { key: 'measure', type: 'number' },
+    { key: 'name', type: 'string' }
+  ]
+
+  test('a descendant flagged noNumericText routes the lenient clause even though the parent _indexShape is unset', () => {
+    const dataset: any = { id: 'vq1', finalizedAt: 'f', schema, descendants: [{ _indexShape: NEW_INDEX_SHAPE }], extensions: [] }
+    const clauses = JSON.stringify(buildQClauses(dataset, '84500', undefined, 'simple'))
+    assert.ok(clauses.includes('"lenient":true'))
+    assert.ok(clauses.includes('"fields":["code","measure"]'))
+  })
+
+  test('all-legacy descendants (none flagged) yield byte-identical clauses to a dataset with no descendants field', () => {
+    const withLegacyDescendants: any = { id: 'vq2', finalizedAt: 'f', schema, descendants: [{ _indexShape: {} }], extensions: [] }
+    const withoutDescendants: any = { id: 'vq3', finalizedAt: 'f', schema, extensions: [] }
+    const out1 = buildQClauses(withLegacyDescendants, '84500', undefined, 'simple')
+    const out2 = buildQClauses(withoutDescendants, '84500', undefined, 'simple')
+    assert.deepEqual(out1, out2)
+  })
+
+  test('plain legacy dataset (no _indexShape, no descendants) is unchanged', () => {
+    const dataset: any = { id: 'vq4', finalizedAt: 'f', schema, extensions: [] }
+    const clauses = JSON.stringify(buildQClauses(dataset, '84500', undefined, 'simple'))
+    assert.ok(!clauses.includes('"lenient":true'))
   })
 })

--- a/tests/features/datasets/query/q-fields.unit.spec.ts
+++ b/tests/features/datasets/query/q-fields.unit.spec.ts
@@ -330,3 +330,53 @@ test.describe('exact-match routing (new index shape)', () => {
     assert.deepEqual(out.bool.should[1].simple_query_string.fields, ['a.text_standard'])
   })
 })
+
+test.describe('numeric q fallback (noNumericText shape)', () => {
+  const schema = [
+    { key: 'code', type: 'integer' },
+    { key: 'measure', type: 'number' },
+    { key: 'day', type: 'string', format: 'date' },
+    { key: 'name', type: 'string' },
+    { key: 'noidx', type: 'integer', 'x-capabilities': { index: false } },
+    { key: '_i', type: 'integer', 'x-calculated': true }
+  ]
+
+  test('qLenientFields lists indexed, non-calculated numeric columns only', () => {
+    const dataset: any = { id: 'nq1', schema, _indexShape: { singleTextField: true, wordAggField: true, noNumericText: true }, extensions: [] }
+    const { qLenientFields } = getFilterableFields(dataset, 'foo', undefined)
+    assert.deepEqual(qLenientFields, ['code', 'measure'])
+  })
+
+  test('buildQClauses adds one lenient clause on noNumericText shape, none on legacy', () => {
+    const newDataset: any = { id: 'nq2', schema, _indexShape: { singleTextField: true, wordAggField: true, noNumericText: true }, extensions: [] }
+    const newClauses = JSON.stringify(buildQClauses(newDataset, '84500', undefined, 'simple'))
+    assert.ok(newClauses.includes('"lenient":true'))
+    assert.ok(newClauses.includes('"fields":["code","measure"]'))
+
+    const legacyDataset: any = { id: 'nq3', schema, extensions: [] }
+    const legacyClauses = JSON.stringify(buildQClauses(legacyDataset, '84500', undefined, 'simple'))
+    assert.ok(!legacyClauses.includes('"lenient":true'))
+  })
+
+  test('q_mode=and filter unions numeric main fields with lenient', () => {
+    const dataset: any = { id: 'nq4', schema, _indexShape: { singleTextField: true, wordAggField: true, noNumericText: true }, extensions: [] }
+    const clauses: any = buildQClauses(dataset, 'foo 84500', undefined, 'and')
+    const filterClause = JSON.stringify(clauses.bool.filter)
+    assert.ok(filterClause.includes('code'))
+    assert.ok(filterClause.includes('"lenient":true'))
+  })
+
+  test('a numeric column with an explicit textStandard:false opt-out is excluded from qLenientFields', () => {
+    // the controller ruling: explicit API-level capability opt-outs stay honored, so a numeric
+    // column deliberately removed from `q` via x-capabilities.textStandard:false must NOT be
+    // resurrected by the lenient main-field fallback.
+    const optOutSchema = [
+      ...schema,
+      { key: 'excluded', type: 'integer', 'x-capabilities': { textStandard: false } }
+    ]
+    const dataset: any = { id: 'nq5', schema: optOutSchema, _indexShape: { singleTextField: true, wordAggField: true, noNumericText: true }, extensions: [] }
+    const { qLenientFields } = getFilterableFields(dataset, 'foo', undefined)
+    assert.deepEqual(qLenientFields, ['code', 'measure'])
+    assert.ok(!qLenientFields.includes('excluded'))
+  })
+})

--- a/tests/features/datasets/query/q-fields.unit.spec.ts
+++ b/tests/features/datasets/query/q-fields.unit.spec.ts
@@ -19,9 +19,12 @@ test.describe('hasManyQSearchFields', () => {
     // string columns count 1 (single .text) -> 15 columns == 15 inner fields (not over), 16 == 16 (over)
     assert.equal(hasManyQSearchFields(stringFields(15)), false)
     assert.equal(hasManyQSearchFields(stringFields(16)), true)
-    // integer/date columns also count 1 (.text_standard, new shape has no .text on them) -> 15 == 15 (not over), 16 == 16 (over)
+    // Task 2's noNumericText (part of the default NEW_INDEX_SHAPE) drops `.text_standard` from
+    // integer/number columns entirely — they emit NO analyzed inner field any more, so they never
+    // count toward wideness under the new shape (Task 3 restores their `q` matching separately,
+    // through a lenient main-field fallback that this counter has nothing to do with).
     assert.equal(hasManyQSearchFields(intFields(15)), false)
-    assert.equal(hasManyQSearchFields(intFields(16)), true)
+    assert.equal(hasManyQSearchFields(intFields(16)), false)
   })
   test('a text-disabled string still counts 1 (its single field is .text_standard)', () => {
     // the new-shape emission gives `{text:false}` columns a single `.text_standard` instead of a
@@ -54,15 +57,19 @@ test.describe('hasManyQSearchFields', () => {
       assert.equal(hasManyQSearchFields(stringFields(n + 1), shape), true)
     }
   })
-  test('a scalar-heavy schema in the 15..30 band is narrow legacy and wide new-shape', () => {
-    // 20 numeric columns = 20 inner fields under BOTH shapes: 20 <= 30 (legacy, narrow) but
-    // 20 > 15 (new shape, wide). Classifying such a legacy index with the new threshold flips
-    // its `reduced` regime and lets `_search` be added in place — the C1 regression.
+  test('a scalar-heavy schema in the 15..30 band is narrow legacy and stays narrow new-shape (numerics carry no inner field there); a text-disabled string band still crosses', () => {
+    // 20 numeric columns = 20 inner fields under LEGACY (20 <= 30, narrow) but under the new
+    // shape noNumericText drops `.text_standard` from integer/number columns entirely — they
+    // contribute 0 inner fields, so the band never crosses the new-shape threshold either.
+    // (Superseded expectation: this used to flip to wide/true under NEW_INDEX_SHAPE before Task 2's
+    // noNumericText; Task 3 restores their `q` matching separately via a lenient main-field
+    // fallback that this wideness counter has nothing to do with.)
     const band = intFields(20)
     assert.equal(hasManyQSearchFields(band, LEGACY_INDEX_SHAPE), false)
-    assert.equal(hasManyQSearchFields(band, NEW_INDEX_SHAPE), true)
-    // a `{text:false}` string column is emitted identically under both shapes, so it lands in the
-    // band the same way
+    assert.equal(hasManyQSearchFields(band, NEW_INDEX_SHAPE), false)
+    // a `{text:false}` string column is unaffected by noNumericText (it only applies to
+    // integer/number columns) and is emitted identically under both shapes, so it still lands in
+    // the band the same way as before: narrow legacy, wide new-shape.
     const noLangBand = Array.from({ length: 20 }, (_, i) => ({ key: 'nl' + i, type: 'string', 'x-capabilities': { text: false } }))
     assert.equal(hasManyQSearchFields(noLangBand, LEGACY_INDEX_SHAPE), false)
     assert.equal(hasManyQSearchFields(noLangBand, NEW_INDEX_SHAPE), true)
@@ -76,16 +83,21 @@ const fakeDataset = (over: any = {}) => ({ id: 'fd' + (seq++), finalizedAt: '202
 const wideSchema = (n = 32) => Array.from({ length: n }, (_, i) => ({ key: 'f' + i, type: 'string' }))
 
 test.describe('getFilterableFields - wideness follows the dataset index shape', () => {
-  // a band-shaped schema: the `reduced` regime must stay off on a legacy (unstamped) dataset and
-  // turn on only once the dataset carries a new-shape stamp
+  // a band-shaped schema (numeric-heavy): the `reduced` regime stays off under BOTH shapes now.
+  // Under noNumericText (part of the default NEW_INDEX_SHAPE), integer/number columns carry no
+  // analyzed inner field at all, so they never contribute to wideness — this band schema, made
+  // entirely of int columns plus one string, no longer crosses the new-shape threshold either.
+  // (Superseded expectation: before Task 2's noNumericText, the new-shape stamp alone flipped this
+  // band to wide/reduced; Task 3 restores `q` matching for those numeric columns separately, via
+  // a lenient main-field fallback unrelated to this wideness counter.)
   const bandSchema = () => [...intFields(20), { key: 'txt', type: 'string' }]
   test('legacy dataset in the band keeps the narrow regime', () => {
     const ds = fakeDataset({ schema: bandSchema() })
     assert.equal(getFilterableFields(ds, 'x', undefined).reduced, false)
   })
-  test('new-shape dataset in the band gets the reduced regime', () => {
+  test('new-shape dataset in the (now numeric-exempt) band also keeps the narrow regime', () => {
     const ds = fakeDataset({ schema: bandSchema(), _indexShape: NEW_INDEX_SHAPE })
-    assert.equal(getFilterableFields(ds, 'x', undefined).reduced, true)
+    assert.equal(getFilterableFields(ds, 'x', undefined).reduced, false)
   })
 })
 

--- a/tests/features/datasets/schema/capabilities.api.spec.ts
+++ b/tests/features/datasets/schema/capabilities.api.spec.ts
@@ -354,4 +354,34 @@ test.describe('Properties capabilities', () => {
     assert.ok(dataset.storage.indexed.size < dataset.storage.size)
     assert.equal(dataset.storage.indexed.parts.length, 1)
   })
+
+  test('Code-like columns get default capabilities at analysis, new fields only', async () => {
+    const ax = testUser1
+    const csv = 'code,libelle\nAB123,une belle étiquette\nCD-456,une autre étiquette\n'
+    const form = new FormData()
+    form.append('file', Buffer.from(csv), 'codes.csv')
+    let res = await ax.post('/api/v1/datasets', form, { headers: form.getHeaders() })
+    const id = res.data.id
+    await waitForFinalize(ax, id)
+
+    res = await ax.get(`/api/v1/datasets/${id}`)
+    const codeProp = res.data.schema.find((p: any) => p.key === 'code')
+    const labelProp = res.data.schema.find((p: any) => p.key === 'libelle')
+    assert.deepEqual(codeProp['x-capabilities'], { text: false, insensitive: false })
+    assert.equal(labelProp['x-capabilities'], undefined)
+    // the transport flag never reaches the user schema
+    assert.equal(codeProp.codeLike, undefined)
+
+    // user re-enables insensitive; a re-upload must not clobber the edit
+    const patchedSchema = res.data.schema.filter((p: any) => !p['x-calculated']).map((p: any) =>
+      p.key === 'code' ? { ...p, 'x-capabilities': { text: false } } : p)
+    await doAndWaitForFinalize(ax, id, () => ax.patch(`/api/v1/datasets/${id}`, { schema: patchedSchema }))
+
+    const form2 = new FormData()
+    form2.append('file', Buffer.from(csv + 'EF-789,encore une\n'), 'codes.csv')
+    await doAndWaitForFinalize(ax, id, () => ax.post(`/api/v1/datasets/${id}`, form2, { headers: form2.getHeaders() }))
+
+    res = await ax.get(`/api/v1/datasets/${id}`)
+    assert.deepEqual(res.data.schema.find((p: any) => p.key === 'code')['x-capabilities'], { text: false })
+  })
 })

--- a/tests/features/datasets/schema/fields-sniffer.unit.spec.ts
+++ b/tests/features/datasets/schema/fields-sniffer.unit.spec.ts
@@ -43,12 +43,28 @@ test.describe('field sniffer unit tests', () => {
   })
 
   test('Work with keywords and texts', () => {
-    assert.deepEqual(sniffer.sniff(['id1', 'id2']), { type: 'string' })
+    // 'id1'/'id2' are code-like (letters+digit, no whitespace)
+    assert.deepEqual(sniffer.sniff(['id1', 'id2']), { type: 'string', codeLike: true })
     assert.deepEqual(sniffer.sniff(['id1', 'a text with whitespaces']), { type: 'string' })
   })
 
   test('Default type is empty (will be removed from schema)', () => {
     assert.deepEqual(sniffer.sniff([]), { type: 'empty' })
+  })
+
+  test('Detect code-like string columns', () => {
+    // letters+digits, no whitespace, every value carries a digit
+    assert.deepEqual(sniffer.sniff(['ABC123', 'DEF-456']), { type: 'string', codeLike: true })
+    assert.deepEqual(sniffer.sniff(['13001', 'X2A']), { type: 'string', codeLike: true })
+    // prose stays plain string
+    assert.deepEqual(sniffer.sniff(['a text with 3 words']), { type: 'string' })
+    // no digit: not code-like (short French labels must never match)
+    assert.deepEqual(sniffer.sniff(['ABC', 'DEF']), { type: 'string' })
+    assert.deepEqual(sniffer.sniff(['Rénovation', 'Chauffage']), { type: 'string' })
+    // mixed: one prose value disqualifies the column
+    assert.deepEqual(sniffer.sniff(['ABC123', 'hello world']), { type: 'string' })
+    // accented/unicode chars are not code chars
+    assert.deepEqual(sniffer.sniff(['créé123']), { type: 'string' })
   })
 
   test('escape key algorithme should normalize column keys', () => {

--- a/ui/src/components/dataset/dataset-property-capabilities.vue
+++ b/ui/src/components/dataset/dataset-property-capabilities.vue
@@ -87,9 +87,7 @@ const editCapabilities = ref<Record<string, unknown> | null>(null)
 
 const relevantCapabilities = computed(() => {
   const type = props.property.type
-  if (type === 'number' || type === 'integer') {
-    return ['index', 'values']
-  } else if (type === 'boolean') {
+  if (type === 'number' || type === 'integer' || type === 'boolean') {
     return ['index', 'values']
   } else if (type === 'string' && (props.property.format === 'date' || props.property.format === 'date-time')) {
     return ['index', 'textStandard', 'values']

--- a/ui/src/components/dataset/dataset-property-capabilities.vue
+++ b/ui/src/components/dataset/dataset-property-capabilities.vue
@@ -88,9 +88,9 @@ const editCapabilities = ref<Record<string, unknown> | null>(null)
 const relevantCapabilities = computed(() => {
   const type = props.property.type
   if (type === 'number' || type === 'integer') {
-    return ['index', 'textStandard', 'values']
+    return ['index', 'values']
   } else if (type === 'boolean') {
-    return ['index', 'textStandard', 'values']
+    return ['index', 'values']
   } else if (type === 'string' && (props.property.format === 'date' || props.property.format === 'date-time')) {
     return ['index', 'textStandard', 'values']
   } else if (props.property['x-refersTo'] === 'https://purl.org/geojson/vocab#geometry') {

--- a/ui/src/composables/dataset/agent-property-config-tools-logic.ts
+++ b/ui/src/composables/dataset/agent-property-config-tools-logic.ts
@@ -48,6 +48,24 @@ export function diffCapabilities (capabilities: Record<string, boolean>): Record
   return diff
 }
 
+/**
+ * The agent only ever supplies values for `getRelevantCapabilities`' list for the column's type
+ * (e.g. numeric columns never see `textStandard` any more since its retirement). A stored explicit
+ * override on a key OUTSIDE that list (a hidden key — set previously, e.g. by a raw schema PATCH, or
+ * left over from before a capability was retired for that type) must not be silently dropped by a
+ * wholesale capability write. Merge those hidden stored keys under the agent-supplied ones so an
+ * explicit agent value for the same key (if any) still wins, then let `diffCapabilities` reduce the
+ * merged object to its diff-only storage form as usual.
+ */
+export function mergeHiddenCapabilities (col: any, agentCapabilities: Record<string, boolean>): Record<string, boolean> {
+  const effectiveType = col?.['x-transform']?.type || col?.type
+  const effectiveFormat = col?.['x-transform']?.format || col?.format
+  const relevant = getRelevantCapabilities(effectiveType, effectiveFormat, col?.['x-refersTo'])
+  const stored: Record<string, boolean> = col?.['x-capabilities'] || {}
+  const hidden = Object.fromEntries(Object.entries(stored).filter(([key]) => !relevant.includes(key)))
+  return { ...hidden, ...agentCapabilities }
+}
+
 type FetchSampleRowsFn = (datasetId: string, size?: number) => Promise<{ total: number, rows: Record<string, any>[] }>
 
 export async function executeReadPropertyConfig (dataset: any, fetchSampleRowsFn: FetchSampleRowsFn) {
@@ -140,7 +158,8 @@ export function executeSetPropertyConfig (
     if (c.resetCapabilities) {
       result.capabilities = null
     } else if (c.capabilities) {
-      result.capabilities = diffCapabilities(c.capabilities)
+      const col = (dataset.schema || []).find((p: any) => p.key === c.key)
+      result.capabilities = diffCapabilities(mergeHiddenCapabilities(col, c.capabilities))
     }
     return result
   })

--- a/ui/src/composables/dataset/agent-property-config-tools-logic.ts
+++ b/ui/src/composables/dataset/agent-property-config-tools-logic.ts
@@ -12,7 +12,7 @@ export const capabilitiesDefaultFalse = Object.keys(capabilitiesProperties).filt
 
 export function getRelevantCapabilities (type: string, format?: string, xRefersTo?: string): string[] {
   if (type === 'number' || type === 'integer' || type === 'boolean') {
-    return ['index', 'textStandard', 'values']
+    return ['index', 'values']
   }
   if (type === 'string' && (format === 'date' || format === 'date-time')) {
     return ['index', 'textStandard', 'values']


### PR DESCRIPTION
Users almost never tune per-field capabilities (measured on data.ademe.fr: 0 of 22,246 fields), so the analysis-time and server defaults are the production reality. This trims the two defaults that are obviously irrelevant per column type, with organic rollout and no migration.

- **`noNumericText` index shape**: new indexes stop emitting the `.text_standard` subfield for integer/number columns (it only ever provided whole-value matching plus prefix autocompletion). `q`/`col_search` keep matching numerics whole-value through the main field via separate `lenient: true` clauses, routed on virtual datasets when any descendant has the flag. Explicit `x-capabilities: { textStandard: false }` opt-outs stay honored. Existing indexes keep byte-identical mapping and query behavior until their next natural rebuild.
- **Code-like string columns** (all sampled values whitespace-free with a digit — SIRET, INSEE codes…) get `x-capabilities: { text: false, insensitive: false }` at file analysis, new fields only: drops the `.keyword_insensitive` second keyword index, sorting stays exact via `values`.
- **UI/agent tools**: numeric and boolean columns no longer offer the `textStandard` toggle; agent capability writes preserve hidden explicit opt-outs.
- **A/B bench** on real ADEME data (`benchmark/capabilities-defaults/RESULTS.md`): numeric-heavy −9.6% store / −32% indexing time; code-heavy −29.4% (mostly a schema-width-dependent `_search` catch-all flip, decomposed); string control −8.3%.

**Why:** be less generous by default where it's obviously irrelevant, without asking users to tune anything — the least invasive lever against index bloat from never-tuned capabilities.

**Heads-up:** behavior shifts land at each dataset's rebuild, not at deploy: numerics lose prefix autocompletion in `q_mode=complete`; `col_search` on an `index: false` numeric column now 400s; schemas near the wide threshold can lose the `_search` catch-all (disk win, unmeasured query-fanout cost). The `buildQClauses` changes interleave with #535's AND-readings/narrowing filters — that seam got the most review.
