### PR TITLE
fix(applications): declare the language of proxied application documents

### DIFF
--- a/api/src/applications/proxy.ts
+++ b/api/src/applications/proxy.ts
@@ -150,6 +150,15 @@ router.all(['/:applicationId/*extraPath', '/:applicationId'], setProxyResource, 
   const document = parse5.parse(rawHtml.replace(/%APPLICATION%/, JSON.stringify(application)))
   const html = document.childNodes.find((c: any) => c.tagName === 'html') as any
   if (!html) throw new Error(req.__('errors.brokenHTML'))
+
+  // data-fair owns the language of the served document: applications are not expected to
+  // declare one, and any value they do declare is replaced here, so the attribute always
+  // matches the locale actually served. Without it the document has no language at all,
+  // which is a WCAG 3.1.1 / RGAA 8.3 failure — and it stays its own document when embedded
+  // in a portal iframe, so it cannot inherit the language of the embedding page.
+  html.attrs = (html.attrs ?? []).filter((attr: any) => attr.name !== 'lang')
+  html.attrs.push({ name: 'lang', value: req.getLocale() })
+
   const head = html.childNodes.find((c: any) => c.tagName === 'head')
   const body = html.childNodes.find((c: any) => c.tagName === 'body')
   if (!head || !body) throw new Error(req.__('errors.brokenHTML'))

--- a/dev/mock-server.ts
+++ b/dev/mock-server.ts
@@ -18,8 +18,10 @@ geocoderApi.servers = [{ url: `${mockOrigin}/geocoder`, description: 'Mock serve
 const sireneApi = JSON.parse(readFileSync(resolve(__dirname, '../tests/resources/sirene-api.json'), 'utf8'))
 sireneApi.servers = [{ url: `${mockOrigin}/sirene`, description: 'Mock server' }]
 
+// lang is deliberately wrong here: the proxy owns the language of the served document
+// and must replace whatever the application declares (see applications/proxy.ts)
 const html = `
-  <html>
+  <html lang="zz">
     <head>
       <meta name="application-name" content="test">
       <script type="text/javascript">window.APPLICATION=%APPLICATION%;</script>

--- a/tests/features/applications/applications.api.spec.ts
+++ b/tests/features/applications/applications.api.spec.ts
@@ -231,6 +231,12 @@ test.describe('Applications', () => {
     assert.deepEqual(Object.keys(application.configuration.datasets[0]).sort(), ['finalizedAt', 'href', 'id', 'schema', 'slug', 'title', 'userPermissions'])
     assert.deepEqual(Object.keys(application.configuration.datasets[1]).sort(), ['applicationKeyPermissions', 'finalizedAt', 'href', 'id', 'schema', 'slug', 'title', 'userPermissions'])
 
+    // The language of the served document is set from the request locale and replaces
+    // whatever the application declares (the mock serves lang="zz"): a document without a
+    // language, or with a wrong one, fails WCAG 3.1.1 / RGAA 8.3-8.4
+    assert.ok(/<html[^>]*\slang="(fr|en)"/.test(res.data), 'the html element carries the served locale')
+    assert.ok(!res.data.includes('lang="zz"'), 'the language declared by the application is replaced')
+
     // A link to the manifest is injected
     assert.ok(res.data.includes(`<link rel="manifest" crossorigin="use-credentials" href="/data-fair/app/${appId}/manifest.json">`))
     // The app reference a service worker


### PR DESCRIPTION
The application proxy already parses each application's `index.html` to inject the manifest link, the `referrer` meta and the service worker, but it never touched the `lang` attribute — applications were served with whatever they declared, which for most of ours is nothing at all.

- **The proxy now owns the language of the served document**: any `lang` an application declares is stripped and replaced by `req.getLocale()`, so the attribute always matches the locale actually served.
- **The mock application serves `lang="zz"`**, so the test covers the replacement and not only the insertion.

**Why:** a frame is its own document — `lang` is not inherited across a browsing context, so an application embedded in a portal iframe ends up with an *unknown* language rather than the language of the embedding page. Verified in Chrome: with a parent in `lang="fr"`, content inside a frame that declares no language matches neither `:lang(fr)` nor `:lang(en)`. There is no `Content-Language` header to fall back on either, so screen readers announce it with the user's default voice — French metrics read by an English synthesizer. That is a WCAG 3.1.1 / RGAA 8.3 failure, surfaced by an accessibility audit of a customer portal.

Owning the attribute here rather than fixing each application also closes the class of problems for good: a stale or wrong `lang` can no longer leak through, and a wrong one is worse than none — it forces an incorrect pronunciation instead of falling back to a neutral default. Applications no longer need to declare a language at all.

**Heads-up:** an application that deliberately serves content in a language other than the request locale would now be relabeled. None of ours do — they are monolingual with hardcoded strings — and the locale comes from the same `i18n_lang` cookie the portal uses, so a frame and its host now agree by construction.

The Playwright suite was not run on this branch (it needs the docker dev deps); `eslint` and `check-types-ratchet` are clean (489 errors, baseline 489 — no regression).
