### PR TITLE
feat(datasets): honor _action on POST single line like _bulk_lines

### DIFF
--- a/api/contract/dataset-private-api-docs.ts
+++ b/api/contract/dataset-private-api-docs.ts
@@ -541,23 +541,32 @@ Pour utiliser cette API dans un programme vous aurez besoin d'une clé que vous 
       ...api.paths['/lines'],
       post: {
         summary: 'Ajouter une ligne',
-        description: 'Ajouter une nouvelle ligne au jeu de données.',
+        description: "Ajouter une nouvelle ligne au jeu de données. Le corps peut contenir `_action` pour effectuer une opération unitaire équivalente à une ligne de `_bulk_lines` (create, update, createOrUpdate, patch, delete) ; sans `_action` le comportement est createOrUpdate. Pour update, patch et delete l'identifiant de ligne est `_id` ou déduit de la clé primaire, et la permission correspondant à l'action est requise.",
         operationId: 'createLine',
         'x-permissionClass': 'write',
         tags: ['Données éditables'],
         requestBody: {
-          description: "Le contenu d'une ligne de données.",
+          description: "Le contenu d'une ligne de données, avec `_action` optionnelle.",
           required: true,
           content: {
-            'application/json': { schema: writeLineSchema }
+            'application/json': { schema: bulkLineSchema }
           }
         },
         responses: {
+          200: {
+            description: 'La ligne de données modifiée (identifiant défini ou déduit de la clé primaire).',
+            content: {
+              'application/json': { schema: readLineSchema }
+            }
+          },
           201: {
             description: 'La ligne de données ajoutée.',
             content: {
               'application/json': { schema: readLineSchema }
             }
+          },
+          204: {
+            description: 'La ligne de données a été supprimée (`_action: delete`).'
           },
           ...errorResponses,
           413: textPlainResponse('Quota de stockage dépassé ou fichier trop volumineux.')

--- a/api/contract/dataset-private-api-docs.ts
+++ b/api/contract/dataset-private-api-docs.ts
@@ -541,7 +541,7 @@ Pour utiliser cette API dans un programme vous aurez besoin d'une clé que vous 
       ...api.paths['/lines'],
       post: {
         summary: 'Ajouter une ligne',
-        description: "Ajouter une nouvelle ligne au jeu de données. Le corps peut contenir `_action` pour effectuer une opération unitaire équivalente à une ligne de `_bulk_lines` (create, update, createOrUpdate, patch, delete) ; sans `_action` le comportement est createOrUpdate. Pour update, patch et delete l'identifiant de ligne est `_id` ou déduit de la clé primaire, et la permission correspondant à l'action est requise.",
+        description: "Ajouter une nouvelle ligne au jeu de données. Le corps peut contenir `_action` pour effectuer une opération unitaire équivalente à une ligne de `_bulk_lines` (create, update, createOrUpdate, patch, delete) ; sans `_action` le comportement est createOrUpdate. Pour update, patch et delete l'identifiant de ligne est `_id` ou déduit de la clé primaire, et la permission correspondant à l'action est requise, en plus de la permission de création portée par la route.",
         operationId: 'createLine',
         'x-permissionClass': 'write',
         tags: ['Données éditables'],

--- a/api/src/datasets/utils/rest.ts
+++ b/api/src/datasets/utils/rest.ts
@@ -40,7 +40,7 @@ import { internalError } from '@data-fair/lib-node/observer.js'
 import type { DatasetLineAction, DatasetLine, RestDataset, DatasetLineRevision, RestActionsSummary, HistorizeContextHint, WhoHint } from '#types'
 import { whoFromReq } from '../../integrity/who.ts'
 import type { NextFunction, Response, RequestHandler } from 'express'
-import { reqSessionAuthenticated, reqUserAuthenticated, type Account, type SessionStateAuthenticated } from '@data-fair/lib-express'
+import { reqSession, reqSessionAuthenticated, reqUserAuthenticated, type Account, type SessionStateAuthenticated } from '@data-fair/lib-express'
 import { type ValidateFunction } from 'ajv'
 import { type RequestWithRestDataset } from '#types/dataset/index.ts'
 import type { AnyBulkWriteOperation, Collection, Filter, UpdateFilter } from 'mongodb'
@@ -48,7 +48,8 @@ import iterHits from '../es/iter-hits.ts'
 import { pipeline } from 'node:stream/promises'
 import { isInFilesStorage } from '../../files-storage/utils.ts'
 import { computeModified } from './compute-modified.ts'
-import { defineReqContext, reqRestDataset, reqLinesOwnerOptional } from '../../misc/utils/req-context.ts'
+import { defineReqContext, reqRestDataset, reqLinesOwnerOptional, reqResource, reqResourceType, reqBypassPermissions } from '../../misc/utils/req-context.ts'
+import { can } from '../../misc/utils/permissions.ts'
 import { reqPublicBaseUrl } from '../../misc/utils/public-base-url.ts'
 
 type Operation = {
@@ -1058,6 +1059,25 @@ export const deleteLine = async (req: RequestWithRestDataset & { params: { lineI
   storageUtils.updateStorage(dataset).catch((err) => console.error('failed to update storage after deleteLine', err))
 }
 
+// the write routes are gated by their default operation (createLine / updateLine and Own
+// variants). A body _action requesting different semantics through POST must also hold the
+// matching permission — checked here rather than in a middleware because for multipart
+// requests the body is not parsed yet when the permissions middleware runs.
+const alternateActionOperations: Record<string, { operationId: string, ownOperationId: string }> = {
+  update: { operationId: 'updateLine', ownOperationId: 'updateOwnLine' },
+  patch: { operationId: 'patchLine', ownOperationId: 'patchOwnLine' },
+  delete: { operationId: 'deleteLine', ownOperationId: 'deleteOwnLine' }
+}
+const checkAlternateActionPermission = (req: RequestWithRestDataset, _action: string) => {
+  if (req.params.lineId) return // PUT: replace-shaped actions are covered by the route's updateLine gate
+  const actionOperation = alternateActionOperations[_action]
+  if (!actionOperation) return // create / createOrUpdate are covered by the route's createLine gate
+  const operationId = reqLinesOwnerOptional(req) ? actionOperation.ownOperationId : actionOperation.operationId
+  if (!can(reqResourceType(req), reqResource(req), operationId, reqSession(req), reqBypassPermissions(req))) {
+    throw httpError(403, `Permission manquante pour l'opération "${operationId}".`)
+  }
+}
+
 export const createOrUpdateLine = async (req: RequestWithRestDataset, res: Response, next: NextFunction) => {
   const dataset = reqRestDataset(req)
   const linesOwner = reqLinesOwnerOptional(req)
@@ -1069,6 +1089,7 @@ export const createOrUpdateLine = async (req: RequestWithRestDataset, res: Respo
   if (req.params.lineId && (_action === 'patch' || _action === 'delete')) {
     throw httpError(400, `action "${_action}" non supportée sur cette route, utilisez POST /lines`)
   }
+  checkAlternateActionPermission(req, _action)
 
   const definedId = req.params.lineId || req.body._id || getLineId(req.body, dataset, true)
   if (!definedId && _action !== 'create' && _action !== 'createOrUpdate') {

--- a/api/src/datasets/utils/rest.ts
+++ b/api/src/datasets/utils/rest.ts
@@ -1084,6 +1084,9 @@ export const createOrUpdateLine = async (req: RequestWithRestDataset, res: Respo
   if (linesOwner) Object.assign(req.body, linesOwnerCols(linesOwner))
 
   const _action: string = req.body._action ?? 'createOrUpdate'
+  // this duplicates a check inside applyTransactions, but it is load-bearing here: without it an
+  // unknown action would run manageAttachment below, then applyTransactions would throw (not set
+  // operation._error), skipping rollbackUploadedAttachment and orphaning a stored attachment.
   if (!actions.includes(_action)) throw httpError(400, `action "${_action}" is unknown, use one of ${JSON.stringify(actions)}`)
   // PUT .../lines/:lineId means "replace the line at this id", patch/delete only make sense through POST .../lines
   if (req.params.lineId && (_action === 'patch' || _action === 'delete')) {
@@ -1132,7 +1135,7 @@ export const createOrUpdateLine = async (req: RequestWithRestDataset, res: Respo
 
 export const patchLine = async (req: RequestWithRestDataset, res: Response, next: NextFunction) => {
   const dataset = reqRestDataset(req)
-  if (req.body._action !== undefined && req.body._action !== 'patch') {
+  if (req.body._action != null && req.body._action !== 'patch') {
     throw httpError(400, `action "${req.body._action}" non supportée sur cette route, utilisez POST /lines`)
   }
   const { rawBody, uploadedAttachmentPath } = await manageAttachment({ dataset, body: req.body, file: req.file, isMultipart: !!req.is('multipart/form-data'), fixedFormBody: !!reqFixedFormBodyOptional(req), lineId: req.params.lineId }, true)

--- a/api/src/datasets/utils/rest.ts
+++ b/api/src/datasets/utils/rest.ts
@@ -1062,11 +1062,28 @@ export const createOrUpdateLine = async (req: RequestWithRestDataset, res: Respo
   const dataset = reqRestDataset(req)
   const linesOwner = reqLinesOwnerOptional(req)
   if (linesOwner) Object.assign(req.body, linesOwnerCols(linesOwner))
-  const definedId = req.params.lineId || req.body._id || getLineId(req.body, dataset, true)
-  req.body._id = definedId || nanoid()
-  const { rawBody, uploadedAttachmentPath } = await manageAttachment({ dataset, body: req.body, file: req.file, isMultipart: !!req.is('multipart/form-data'), fixedFormBody: !!reqFixedFormBodyOptional(req), lineId: req.params.lineId }, false)
 
-  const fullLine = { _action: 'createOrUpdate', ...req.body }
+  const _action: string = req.body._action ?? 'createOrUpdate'
+  if (!actions.includes(_action)) throw httpError(400, `action "${_action}" is unknown, use one of ${JSON.stringify(actions)}`)
+  // PUT .../lines/:lineId means "replace the line at this id", patch/delete only make sense through POST .../lines
+  if (req.params.lineId && (_action === 'patch' || _action === 'delete')) {
+    throw httpError(400, `action "${_action}" non supportée sur cette route, utilisez POST /lines`)
+  }
+
+  const definedId = req.params.lineId || req.body._id || getLineId(req.body, dataset, true)
+  if (!definedId && _action !== 'create' && _action !== 'createOrUpdate') {
+    throw httpError(400, 'failed to determine required _id from primary key')
+  }
+  req.body._id = definedId || nanoid()
+
+  let rawBody: Record<string, any> | undefined
+  let uploadedAttachmentPath: string | undefined
+  if (_action !== 'delete') {
+    // patch keeps the existing attachment unless a new one is uploaded (parity with patchLine)
+    ({ rawBody, uploadedAttachmentPath } = await manageAttachment({ dataset, body: req.body, file: req.file, isMultipart: !!req.is('multipart/form-data'), fixedFormBody: !!reqFixedFormBodyOptional(req), lineId: req.params.lineId }, _action === 'patch'))
+  }
+
+  const fullLine = { ...req.body, _action }
   formatLine(fullLine, dataset.schema)
 
   const [operation] = (await applyReqTransactions(req, [fullLine], compileSchema(dataset, !!reqUserAuthenticated(req).adminMode))).operations
@@ -1076,16 +1093,27 @@ export const createOrUpdateLine = async (req: RequestWithRestDataset, res: Respo
   }
   await commitLines(dataset, [fullLine._id])
 
-  await import('@data-fair/lib-express/events-log.js')
-    .then((eventsLog) => eventsLog.default.info('df.datasets.rest.createOrUpdateLine', `updated or created line ${operation._id} from dataset ${dataset.slug} (${dataset.id})`, { req, account: dataset.owner as Account }))
-
-  const line = getLineFromOperation(operation, rawBody ?? req.body)
-  res.status(operation._status || (definedId ? 200 : 201)).send(cleanLine(line))
-  storageUtils.updateStorage(dataset).catch((err) => console.error('failed to update storage after updateLine', err))
+  const eventsLog = (await import('@data-fair/lib-express/events-log.js')).default
+  if (_action === 'delete') {
+    eventsLog.info('df.datasets.rest.deleteLine', `deleted line ${operation._id} from dataset ${dataset.slug} (${dataset.id})`, { req, account: dataset.owner as Account })
+    res.status(204).send()
+  } else {
+    if (_action === 'patch') {
+      eventsLog.info('df.datasets.rest.patchLine', `patched line ${operation._id} from dataset ${dataset.slug} (${dataset.id})`, { req, account: dataset.owner as Account })
+    } else {
+      eventsLog.info('df.datasets.rest.createOrUpdateLine', `updated or created line ${operation._id} from dataset ${dataset.slug} (${dataset.id})`, { req, account: dataset.owner as Account })
+    }
+    const line = getLineFromOperation(operation, rawBody ?? req.body)
+    res.status(operation._status || (definedId ? 200 : 201)).send(cleanLine(line))
+  }
+  storageUtils.updateStorage(dataset).catch((err) => console.error('failed to update storage after createOrUpdateLine', err))
 }
 
 export const patchLine = async (req: RequestWithRestDataset, res: Response, next: NextFunction) => {
   const dataset = reqRestDataset(req)
+  if (req.body._action !== undefined && req.body._action !== 'patch') {
+    throw httpError(400, `action "${req.body._action}" non supportée sur cette route, utilisez POST /lines`)
+  }
   const { rawBody, uploadedAttachmentPath } = await manageAttachment({ dataset, body: req.body, file: req.file, isMultipart: !!req.is('multipart/form-data'), fixedFormBody: !!reqFixedFormBodyOptional(req), lineId: req.params.lineId }, true)
   const fullLine = { _action: 'patch', _id: req.params.lineId, ...req.body }
   formatLine(fullLine, dataset.schema)

--- a/tests/features/datasets/rest/rest-datasets-line-actions.api.spec.ts
+++ b/tests/features/datasets/rest/rest-datasets-line-actions.api.spec.ts
@@ -1,0 +1,121 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { axiosAuth, clean, checkPendingTasks } from '../../../support/axios.ts'
+import { waitForFinalize } from '../../../support/workers.ts'
+
+const testUser1 = await axiosAuth('test_user1@test.com')
+
+test.describe('REST datasets - single line _action', () => {
+  test.beforeEach(async () => {
+    await clean()
+  })
+
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === 'passed') await checkPendingTasks()
+  })
+
+  test('POST a single line with _action delete and patch by _id', async () => {
+    const ax = testUser1
+    await ax.post('/api/v1/datasets/restaction1', {
+      isRest: true,
+      title: 'restaction1',
+      schema: [{ key: 'attr1', type: 'string' }, { key: 'attr2', type: 'string' }]
+    })
+    let res = await ax.post('/api/v1/datasets/restaction1/lines', { _id: 'line1', attr1: 'test1', attr2: 'test1' })
+    assert.equal(res.status, 200) // caller-defined _id -> 200, generated id -> 201 (existing behavior)
+    await waitForFinalize(ax, 'restaction1')
+
+    // patch merges with the existing line
+    res = await ax.post('/api/v1/datasets/restaction1/lines', { _action: 'patch', _id: 'line1', attr1: 'test2' })
+    assert.equal(res.status, 200)
+    assert.equal(res.data.attr1, 'test2')
+    assert.equal(res.data.attr2, 'test1')
+    await waitForFinalize(ax, 'restaction1')
+    res = await ax.get('/api/v1/datasets/restaction1/lines/line1')
+    assert.equal(res.data.attr1, 'test2')
+    assert.equal(res.data.attr2, 'test1')
+
+    // patch of a missing line -> 404
+    await assert.rejects(ax.post('/api/v1/datasets/restaction1/lines', { _action: 'patch', _id: 'missing', attr1: 'x' }), (err: any) => err.status === 404)
+
+    // delete responds 204 with no content
+    res = await ax.post('/api/v1/datasets/restaction1/lines', { _action: 'delete', _id: 'line1' })
+    assert.equal(res.status, 204)
+    assert.equal(res.data, '')
+    await waitForFinalize(ax, 'restaction1')
+    await assert.rejects(ax.get('/api/v1/datasets/restaction1/lines/line1'), (err: any) => err.status === 404)
+
+    // delete of a missing line -> 404
+    await assert.rejects(ax.post('/api/v1/datasets/restaction1/lines', { _action: 'delete', _id: 'line1' }), (err: any) => err.status === 404)
+
+    // unknown action -> 400
+    await assert.rejects(ax.post('/api/v1/datasets/restaction1/lines', { _action: 'nope', _id: 'line1' }), (err: any) => err.status === 400)
+  })
+
+  test('POST a single line with _action resolved by primary key', async () => {
+    const ax = testUser1
+    await ax.post('/api/v1/datasets/restaction2', {
+      isRest: true,
+      title: 'restaction2',
+      primaryKey: ['attr1'],
+      schema: [{ key: 'attr1', type: 'string' }, { key: 'attr2', type: 'string' }]
+    })
+    let res = await ax.post('/api/v1/datasets/restaction2/lines', { attr1: 'key1', attr2: 'test1' })
+    await waitForFinalize(ax, 'restaction2')
+    const lineId = res.data._id
+    assert.ok(lineId)
+
+    // patch by primary key, no _id in the body
+    res = await ax.post('/api/v1/datasets/restaction2/lines', { _action: 'patch', attr1: 'key1', attr2: 'test2' })
+    assert.equal(res.status, 200)
+    assert.equal(res.data._id, lineId)
+    assert.equal(res.data.attr2, 'test2')
+    await waitForFinalize(ax, 'restaction2')
+
+    // update by primary key
+    res = await ax.post('/api/v1/datasets/restaction2/lines', { _action: 'update', attr1: 'key1', attr2: 'test3' })
+    assert.equal(res.status, 200)
+    assert.equal(res.data._id, lineId)
+    await waitForFinalize(ax, 'restaction2')
+
+    // delete by primary key
+    res = await ax.post('/api/v1/datasets/restaction2/lines', { _action: 'delete', attr1: 'key1' })
+    assert.equal(res.status, 204)
+    await waitForFinalize(ax, 'restaction2')
+    await assert.rejects(ax.get('/api/v1/datasets/restaction2/lines/' + lineId), (err: any) => err.status === 404)
+  })
+
+  test('POST _action without resolvable _id is rejected', async () => {
+    const ax = testUser1
+    await ax.post('/api/v1/datasets/restaction3', {
+      isRest: true,
+      title: 'restaction3',
+      schema: [{ key: 'attr1', type: 'string' }]
+    })
+    // no primary key and no _id -> impossible to target a line
+    for (const _action of ['patch', 'update', 'delete']) {
+      await assert.rejects(ax.post('/api/v1/datasets/restaction3/lines', { _action, attr1: 'x' }), (err: any) => err.status === 400)
+    }
+  })
+
+  test('PUT and PATCH line routes refuse out-of-place actions', async () => {
+    const ax = testUser1
+    await ax.post('/api/v1/datasets/restaction4', {
+      isRest: true,
+      title: 'restaction4',
+      schema: [{ key: 'attr1', type: 'string' }]
+    })
+    await ax.post('/api/v1/datasets/restaction4/lines', { _id: 'line1', attr1: 'test1' })
+    await waitForFinalize(ax, 'restaction4')
+
+    // PUT keeps replace-shaped actions (see rest-datasets-crud.api.spec.ts) but refuses patch/delete
+    await assert.rejects(ax.put('/api/v1/datasets/restaction4/lines/line1', { _action: 'patch', attr1: 'x' }), (err: any) => err.status === 400)
+    await assert.rejects(ax.put('/api/v1/datasets/restaction4/lines/line1', { _action: 'delete' }), (err: any) => err.status === 400)
+    // PATCH refuses any action but patch
+    await assert.rejects(ax.patch('/api/v1/datasets/restaction4/lines/line1', { _action: 'delete' }), (err: any) => err.status === 400)
+    await assert.rejects(ax.patch('/api/v1/datasets/restaction4/lines/line1', { _action: 'createOrUpdate', attr1: 'x' }), (err: any) => err.status === 400)
+    // the line survived all of the above
+    const res = await ax.get('/api/v1/datasets/restaction4/lines/line1')
+    assert.equal(res.data.attr1, 'test1')
+  })
+})

--- a/tests/features/datasets/rest/rest-datasets-line-actions.api.spec.ts
+++ b/tests/features/datasets/rest/rest-datasets-line-actions.api.spec.ts
@@ -1,7 +1,9 @@
 import { test } from '@playwright/test'
 import assert from 'node:assert/strict'
+import fs from 'fs-extra'
+import FormData from 'form-data'
 import { axiosAuth, clean, checkPendingTasks } from '../../../support/axios.ts'
-import { waitForFinalize } from '../../../support/workers.ts'
+import { waitForFinalize, lsAttachments } from '../../../support/workers.ts'
 
 const testUser1 = await axiosAuth('test_user1@test.com')
 const testUser2 = await axiosAuth('test_user2@test.com')
@@ -184,5 +186,41 @@ test.describe('REST datasets - single line _action', () => {
     assert.equal(res.status, 204)
     await waitForFinalize(ax, dataset.id)
     await assert.rejects(testUser3.get(`/api/v1/datasets/${dataset.id}/own/user:test_user3/lines/ownline1`), (err: any) => err.status === 404)
+  })
+
+  test('multipart _action patch keeps the existing attachment', async () => {
+    const ax = testUser1
+    await ax.post('/api/v1/datasets/restaction6', {
+      isRest: true,
+      title: 'restaction6',
+      schema: [
+        { key: 'attr1', type: 'string' },
+        { key: 'attachmentPath', type: 'string', 'x-refersTo': 'http://schema.org/DigitalDocument' }
+      ]
+    })
+    const form = new FormData()
+    const attachmentContent = fs.readFileSync('./tests/resources/datasets/files/dir1/test.pdf')
+    form.append('attachment', attachmentContent, 'dir1/test.pdf')
+    form.append('_id', 'line1')
+    form.append('attr1', 'test1')
+    let res = await ax.post('/api/v1/datasets/restaction6/lines', form, { headers: { 'Content-Length': form.getLengthSync(), ...form.getHeaders() } })
+    assert.equal(res.status, 200)
+    const attachmentPath = res.data.attachmentPath
+    assert.ok(attachmentPath.startsWith('line1/'))
+    await waitForFinalize(ax, 'restaction6')
+
+    // multipart patch without a new attachment must not destroy the stored one
+    const patchForm = new FormData()
+    patchForm.append('_action', 'patch')
+    patchForm.append('_id', 'line1')
+    patchForm.append('attr1', 'test2')
+    res = await ax.post('/api/v1/datasets/restaction6/lines', patchForm, { headers: { 'Content-Length': patchForm.getLengthSync(), ...patchForm.getHeaders() } })
+    assert.equal(res.status, 200)
+    assert.equal(res.data.attr1, 'test2')
+    assert.equal(res.data.attachmentPath, attachmentPath)
+    await waitForFinalize(ax, 'restaction6')
+    const attachments = await lsAttachments('restaction6')
+    assert.equal(attachments.length, 1)
+    assert.equal(attachments[0], attachmentPath)
   })
 })

--- a/tests/features/datasets/rest/rest-datasets-line-actions.api.spec.ts
+++ b/tests/features/datasets/rest/rest-datasets-line-actions.api.spec.ts
@@ -4,6 +4,7 @@ import { axiosAuth, clean, checkPendingTasks } from '../../../support/axios.ts'
 import { waitForFinalize } from '../../../support/workers.ts'
 
 const testUser1 = await axiosAuth('test_user1@test.com')
+const testUser2 = await axiosAuth('test_user2@test.com')
 
 test.describe('REST datasets - single line _action', () => {
   test.beforeEach(async () => {
@@ -117,5 +118,40 @@ test.describe('REST datasets - single line _action', () => {
     // the line survived all of the above
     const res = await ax.get('/api/v1/datasets/restaction4/lines/line1')
     assert.equal(res.data.attr1, 'test1')
+  })
+
+  test('_action requires the matching per-action permission', async () => {
+    const ax = testUser1
+    await ax.post('/api/v1/datasets/restaction5', {
+      isRest: true,
+      title: 'restaction5',
+      schema: [{ key: 'attr1', type: 'string' }]
+    })
+    await ax.post('/api/v1/datasets/restaction5/lines', { _id: 'line1', attr1: 'test1' })
+    await waitForFinalize(ax, 'restaction5')
+
+    // user2 may only create lines
+    await ax.put('/api/v1/datasets/restaction5/permissions', [
+      { type: 'user', id: 'test_user2', operations: ['createLine', 'readLine'] }
+    ])
+
+    let res = await testUser2.post('/api/v1/datasets/restaction5/lines', { _id: 'line2', attr1: 'test2' })
+    assert.equal(res.status, 200)
+    await waitForFinalize(ax, 'restaction5')
+
+    // but not delete/patch/update lines through _action
+    for (const _action of ['delete', 'patch', 'update']) {
+      await assert.rejects(testUser2.post('/api/v1/datasets/restaction5/lines', { _action, _id: 'line1', attr1: 'x' }), (err: any) => err.status === 403)
+    }
+    res = await testUser2.get('/api/v1/datasets/restaction5/lines/line1')
+    assert.equal(res.data.attr1, 'test1')
+
+    // granting deleteLine unlocks _action delete
+    await ax.put('/api/v1/datasets/restaction5/permissions', [
+      { type: 'user', id: 'test_user2', operations: ['createLine', 'readLine', 'deleteLine'] }
+    ])
+    res = await testUser2.post('/api/v1/datasets/restaction5/lines', { _action: 'delete', _id: 'line1' })
+    assert.equal(res.status, 204)
+    await waitForFinalize(ax, 'restaction5')
   })
 })

--- a/tests/features/datasets/rest/rest-datasets-line-actions.api.spec.ts
+++ b/tests/features/datasets/rest/rest-datasets-line-actions.api.spec.ts
@@ -5,6 +5,8 @@ import { waitForFinalize } from '../../../support/workers.ts'
 
 const testUser1 = await axiosAuth('test_user1@test.com')
 const testUser2 = await axiosAuth('test_user2@test.com')
+const testUser1Org = await axiosAuth('test_user1@test.com', 'test_org1')
+const testUser3 = await axiosAuth('test_user3@test.com')
 
 test.describe('REST datasets - single line _action', () => {
   test.beforeEach(async () => {
@@ -153,5 +155,34 @@ test.describe('REST datasets - single line _action', () => {
     res = await testUser2.post('/api/v1/datasets/restaction5/lines', { _action: 'delete', _id: 'line1' })
     assert.equal(res.status, 204)
     await waitForFinalize(ax, 'restaction5')
+  })
+
+  test('own-lines POST honors _action within the manageOwnLines class', async () => {
+    const ax = testUser1Org
+    let res = await ax.post('/api/v1/datasets', {
+      isRest: true,
+      title: 'rest own actions',
+      rest: { lineOwnership: true },
+      schema: [{ key: 'attr1', type: 'string' }]
+    })
+    const dataset = res.data
+    await ax.put(`/api/v1/datasets/${dataset.id}/permissions`, [
+      { type: 'user', id: 'test_user3', classes: ['manageOwnLines'], operations: ['readSafeSchema'] }
+    ])
+
+    await testUser3.post(`/api/v1/datasets/${dataset.id}/own/user:test_user3/lines`, { _id: 'ownline1', attr1: 'test1' })
+    await waitForFinalize(ax, dataset.id)
+
+    // patch own line through POST + _action
+    res = await testUser3.post(`/api/v1/datasets/${dataset.id}/own/user:test_user3/lines`, { _action: 'patch', _id: 'ownline1', attr1: 'test2' })
+    assert.equal(res.status, 200)
+    assert.equal(res.data.attr1, 'test2')
+    await waitForFinalize(ax, dataset.id)
+
+    // delete own line through POST + _action
+    res = await testUser3.post(`/api/v1/datasets/${dataset.id}/own/user:test_user3/lines`, { _action: 'delete', _id: 'ownline1' })
+    assert.equal(res.status, 204)
+    await waitForFinalize(ax, dataset.id)
+    await assert.rejects(testUser3.get(`/api/v1/datasets/${dataset.id}/own/user:test_user3/lines/ownline1`), (err: any) => err.status === 404)
   })
 })

--- a/tests/features/datasets/rest/rest-datasets-line-actions.api.spec.ts
+++ b/tests/features/datasets/rest/rest-datasets-line-actions.api.spec.ts
@@ -30,6 +30,12 @@ test.describe('REST datasets - single line _action', () => {
     assert.equal(res.status, 200) // caller-defined _id -> 200, generated id -> 201 (existing behavior)
     await waitForFinalize(ax, 'restaction1')
 
+    // strict create: 201 on a fresh id, 409 on an existing one
+    res = await ax.post('/api/v1/datasets/restaction1/lines', { _action: 'create', _id: 'line2', attr1: 'test1' })
+    assert.equal(res.status, 201)
+    await waitForFinalize(ax, 'restaction1')
+    await assert.rejects(ax.post('/api/v1/datasets/restaction1/lines', { _action: 'create', _id: 'line1', attr1: 'x' }), (err: any) => err.status === 409)
+
     // patch merges with the existing line
     res = await ax.post('/api/v1/datasets/restaction1/lines', { _action: 'patch', _id: 'line1', attr1: 'test2' })
     assert.equal(res.status, 200)


### PR DESCRIPTION
POST `/datasets/:id/lines` (and own-lines POST) now honors a body `_action` (`create`, `update`, `createOrUpdate`, `patch`, `delete`) like a single line of `_bulk_lines`, with patch/update/delete by `_id` or derived from the primary key. Responses mirror the dedicated endpoints: delete → 204, patch/update → 200 + line, create → 201/409. Behavior without `_action` is strictly unchanged.

**Why:** single-line clients needed per-line actions (delete, patch by primary key) without switching to the bulk endpoint and its summary-shaped response.

- non-create actions require the matching permission (`deleteLine`/`patchLine`/`updateLine`, Own variants), checked in-handler since multipart bodies aren't parsed at middleware time
- closes the accidental `_action` passthrough: PATCH rejects foreign actions (delete-via-PATCH was an escalation for `patchLine`-only clients), PUT keeps only replace-shaped actions, multipart patch no longer deletes the stored attachment
- OpenAPI contract documents `_action` and the 200/201/204 responses; new API test suite `rest-datasets-line-actions.api.spec.ts`

**Heads-up (breaking for clients of the old undocumented leak):** POST `_action: delete` now answers 204 and requires `deleteLine`; foreign `_action` on PUT/PATCH now 400; patch/update/delete with no `_id` nor primary key now 400 instead of creating a stray line.
