### PR TITLE
fix(applications): title proxied documents after their application

### DIFF
--- a/.github/workflows/reuse-quality.yml
+++ b/.github/workflows/reuse-quality.yml
@@ -40,8 +40,16 @@ jobs:
     - name: Use localhost as DEV_HOST in CI
       run: sed -i 's/^DEV_HOST=.*/DEV_HOST=localhost/' .env
 
+    # minio-init is a one-shot container: --wait counts it as up while it is still running,
+    # but reports an error if it exits before the last service turns healthy, which is a race
+    # it loses often. Keeping it out of the wait and running it to completion afterwards also
+    # closes the other half of the problem: --wait used to return while the buckets were still
+    # being created, so the tests could start without them.
     - name: Start test services
-      run: docker compose --profile test up -d --wait
+      run: docker compose --profile test up -d --wait --scale minio-init=0
+
+    - name: Create minio buckets
+      run: docker compose --profile test run --rm minio-init
 
     - name: Start mock server
       run: dotenv -- npm run dev-mock &

--- a/api/src/applications/proxy.ts
+++ b/api/src/applications/proxy.ts
@@ -178,6 +178,19 @@ router.all(['/:applicationId/*extraPath', '/:applicationId'], setProxyResource, 
     else head.childNodes.push(node)
   }
 
+  // data-fair owns the title of the served document, for the same reason it owns lang: the
+  // <title> an application declares is the name of its model in the catalog — that document
+  // is fetched directly from the base application URL when importing it, never through this
+  // proxy — not the name of the visualization being served. Leaving it in place titles every
+  // page after its model ("Charts" for a chart of sports facilities), which fails WCAG 2.4.2 /
+  // RGAA 8.6 as soon as the application is opened on its own instead of embedded in a portal.
+  const titleNode = head.childNodes.find((c: any) => c.tagName === 'title')
+  if (titleNode) {
+    titleNode.childNodes = [{ nodeName: '#text', value: application.title, parentNode: titleNode }]
+  } else {
+    pushHeadNode({ nodeName: 'title', tagName: 'title', attrs: [] }, application.title)
+  }
+
   // Data-fair generates a manifest per app
   const manifestUrl = new URL(application.exposedUrl).pathname + '/manifest.json'
   const manifest = head.childNodes.find((c: any) => c.attrs && c.attrs.find((a: any) => a.name === 'rel' && a.value === 'manifest'))

--- a/api/src/applications/proxy.ts
+++ b/api/src/applications/proxy.ts
@@ -184,12 +184,11 @@ router.all(['/:applicationId/*extraPath', '/:applicationId'], setProxyResource, 
   // proxy — not the name of the visualization being served. Leaving it in place titles every
   // page after its model ("Charts" for a chart of sports facilities), which fails WCAG 2.4.2 /
   // RGAA 8.6 as soon as the application is opened on its own instead of embedded in a portal.
-  const titleNode = head.childNodes.find((c: any) => c.tagName === 'title')
-  if (titleNode) {
-    titleNode.childNodes = [{ nodeName: '#text', value: application.title, parentNode: titleNode }]
-  } else {
-    pushHeadNode({ nodeName: 'title', tagName: 'title', attrs: [] }, application.title)
-  }
+  // Every declared title is dropped, not just the first: some applications declare several,
+  // one per language (base-applications/service.ts picks between them at import time), and
+  // leaving the extras would keep the model name in the document behind the browser's pick.
+  head.childNodes = head.childNodes.filter((c: any) => c.tagName !== 'title')
+  pushHeadNode({ nodeName: 'title', tagName: 'title', attrs: [] }, application.title)
 
   // Data-fair generates a manifest per app
   const manifestUrl = new URL(application.exposedUrl).pathname + '/manifest.json'

--- a/dev/mock-server.ts
+++ b/dev/mock-server.ts
@@ -18,11 +18,12 @@ geocoderApi.servers = [{ url: `${mockOrigin}/geocoder`, description: 'Mock serve
 const sireneApi = JSON.parse(readFileSync(resolve(__dirname, '../tests/resources/sirene-api.json'), 'utf8'))
 sireneApi.servers = [{ url: `${mockOrigin}/sirene`, description: 'Mock server' }]
 
-// lang is deliberately wrong here: the proxy owns the language of the served document
-// and must replace whatever the application declares (see applications/proxy.ts)
+// lang and title are deliberately wrong here: the proxy owns the language and the title of
+// the served document and must replace whatever the application declares (see applications/proxy.ts)
 const html = `
   <html lang="zz">
     <head>
+      <title>Base app model name</title>
       <meta name="application-name" content="test">
       <script type="text/javascript">window.APPLICATION=%APPLICATION%;</script>
     </head>

--- a/dev/mock-server.ts
+++ b/dev/mock-server.ts
@@ -19,11 +19,13 @@ const sireneApi = JSON.parse(readFileSync(resolve(__dirname, '../tests/resources
 sireneApi.servers = [{ url: `${mockOrigin}/sirene`, description: 'Mock server' }]
 
 // lang and title are deliberately wrong here: the proxy owns the language and the title of
-// the served document and must replace whatever the application declares (see applications/proxy.ts)
+// the served document and must replace whatever the application declares (see applications/proxy.ts).
+// Two titles, as some applications declare one per language, so the test covers dropping them all.
 const html = `
   <html lang="zz">
     <head>
       <title>Base app model name</title>
+      <title lang="fr">Nom du modèle</title>
       <meta name="application-name" content="test">
       <script type="text/javascript">window.APPLICATION=%APPLICATION%;</script>
     </head>
@@ -37,6 +39,9 @@ const html = `
     </script>
   </html>
 `
+
+// monapp3 declares no title at all, so the proxy has to insert one rather than replace it
+const htmlNoTitle = html.split('\n').filter(line => !line.includes('<title')).join('\n')
 
 const monapp1ConfigSchema = {
   type: 'object',
@@ -161,7 +166,7 @@ const staticRoutes: Record<string, () => RouteResult> = {
   '/monapp2/config-schema.json': () => ({ status: 200, body: {} }),
 
   // App test3
-  '/monapp3/index.html': () => ({ status: 200, body: html, contentType: 'text/html' }),
+  '/monapp3/index.html': () => ({ status: 200, body: htmlNoTitle, contentType: 'text/html' }),
   '/monapp3/config-schema.json': () => ({ status: 200, body: monapp3ConfigSchema }),
 }
 

--- a/tests/features/applications/applications.api.spec.ts
+++ b/tests/features/applications/applications.api.spec.ts
@@ -238,12 +238,15 @@ test.describe('Applications', () => {
     assert.ok(/<html[^>]*\slang="(fr|en)"/.test(res.data), 'the html element carries the served locale')
     assert.ok(!res.data.includes('lang="zz"'), 'the language declared by the application is replaced')
 
-    // Same for the title: the one declared by the application names its model in the catalog,
+    // Same for the title: the ones declared by the application name its model in the catalog,
     // the served document must be titled after the application itself (WCAG 2.4.2 / RGAA 8.6).
-    // It keeps naming the model in the base app metadata, which is why only the element is checked.
+    // The mock declares two of them (one per language) and none must survive.
     assert.ok(res.data.includes('<title>Répartition des équipements sportifs</title>'), 'the document is titled after the application')
+    assert.equal((res.data.match(/<title[ >]/g) || []).length, 1, 'the document declares a single title')
     assert.ok(!res.data.includes('<title>Base app model name</title>'), 'the title declared by the application is replaced')
-    assert.equal(application.baseApp.meta.title, 'Base app model name', 'the base app metadata still names the model')
+    assert.ok(!res.data.includes('<title lang="fr">'), 'the other language variant is dropped too')
+    // The model keeps naming itself in the base app metadata, which the proxy does not touch
+    assert.equal(application.baseApp.meta.title, 'Nom du modèle', 'the base app metadata still names the model')
 
     // A link to the manifest is injected
     assert.ok(res.data.includes(`<link rel="manifest" crossorigin="use-credentials" href="/data-fair/app/${appId}/manifest.json">`))
@@ -256,6 +259,15 @@ test.describe('Applications', () => {
     await adminAx.post('/api/v1/limits/user/test_user1', { hide_brand: { limit: 1 }, lastUpdate: new Date().toISOString() }, { params: { key: config.secretKeys.limits } })
     res = await ax.get('/app/' + appId)
     assert.equal(res.data.includes('<div>application embed</div>'), false)
+  })
+
+  test('Title a proxied application that declares no title', async () => {
+    const ax = testUser1
+    // monapp3 serves an index.html without any title element
+    let res = await ax.post('/api/v1/applications', { url: mockAppUrl('monapp3'), title: 'Consommation énergétique' })
+    res = await ax.get(`/app/${res.data.id}`)
+    assert.equal(res.status, 200)
+    assert.ok(res.data.includes('<title>Consommation énergétique</title>'), 'the title element is inserted')
   })
 
   test('Read base app info of an application', async () => {

--- a/tests/features/applications/applications.api.spec.ts
+++ b/tests/features/applications/applications.api.spec.ts
@@ -239,9 +239,11 @@ test.describe('Applications', () => {
     assert.ok(!res.data.includes('lang="zz"'), 'the language declared by the application is replaced')
 
     // Same for the title: the one declared by the application names its model in the catalog,
-    // the served document must be titled after the application itself (WCAG 2.4.2 / RGAA 8.6)
+    // the served document must be titled after the application itself (WCAG 2.4.2 / RGAA 8.6).
+    // It keeps naming the model in the base app metadata, which is why only the element is checked.
     assert.ok(res.data.includes('<title>Répartition des équipements sportifs</title>'), 'the document is titled after the application')
-    assert.ok(!res.data.includes('Base app model name'), 'the title declared by the application is replaced')
+    assert.ok(!res.data.includes('<title>Base app model name</title>'), 'the title declared by the application is replaced')
+    assert.equal(application.baseApp.meta.title, 'Base app model name', 'the base app metadata still names the model')
 
     // A link to the manifest is injected
     assert.ok(res.data.includes(`<link rel="manifest" crossorigin="use-credentials" href="/data-fair/app/${appId}/manifest.json">`))

--- a/tests/features/applications/applications.api.spec.ts
+++ b/tests/features/applications/applications.api.spec.ts
@@ -199,6 +199,7 @@ test.describe('Applications', () => {
 
     let res = await ax.post('/api/v1/applications', {
       url: mockAppUrl('monapp1'),
+      title: 'Répartition des équipements sportifs',
       configuration: {
         datasets: [
           { id: dataset.id, href: datasetRefInit.href },
@@ -236,6 +237,11 @@ test.describe('Applications', () => {
     // language, or with a wrong one, fails WCAG 3.1.1 / RGAA 8.3-8.4
     assert.ok(/<html[^>]*\slang="(fr|en)"/.test(res.data), 'the html element carries the served locale')
     assert.ok(!res.data.includes('lang="zz"'), 'the language declared by the application is replaced')
+
+    // Same for the title: the one declared by the application names its model in the catalog,
+    // the served document must be titled after the application itself (WCAG 2.4.2 / RGAA 8.6)
+    assert.ok(res.data.includes('<title>Répartition des équipements sportifs</title>'), 'the document is titled after the application')
+    assert.ok(!res.data.includes('Base app model name'), 'the title declared by the application is replaced')
 
     // A link to the manifest is injected
     assert.ok(res.data.includes(`<link rel="manifest" crossorigin="use-credentials" href="/data-fair/app/${appId}/manifest.json">`))


### PR DESCRIPTION
The application proxy already parses each application's `index.html` to replace the `lang` attribute (#537), inject the manifest link, the `referrer` meta and the service worker — but it never touched the `<title>`, so every application was served under the title declared by its base application.

- **The proxy now owns the title of the served document**: every `<title>` declared by the base application is dropped and a single one carrying the application title is inserted. All of them, because some applications declare one per language, and leaving the extras would keep the model name in the document behind the one the browser picks.
- **The mock application declares two titles** (one per language), so the test covers dropping them all rather than only the first; another mock application declares none, covering the insertion branch.

**Why:** that title names the *model* in the catalog — `Charts`, `Dashboards` — never the visualization being served. Verified in production, a visualization titled « Graphiques divers » was served as a document titled `data-fair-charts`. The browser tab, the history entry, the bookmark and the title announced by screen readers all named the model instead of the content, which is a WCAG 2.4.2 / RGAA 8.6 failure as soon as the application is opened on its own rather than embedded in a portal — which portals do offer, through their "open in a new tab" links. Same class of problem as the `lang` attribute in #537, and closed the same way: in the proxy rather than in each application.

The catalog is unaffected: base application metadata is read from the `index.html` fetched directly at the base application URL, never through this proxy, so the `<title>` of an application repository keeps its other role of naming the model at import time.

**Heads-up:** an application that assigns `document.title` at runtime still wins, since it runs after the document is parsed. None of ours do, and the application guidelines say they should not.

**Unrelated CI fix carried here**, because it was blocking this branch: `docker compose up --wait` counts the one-shot `minio-init` as up while it is still running, but errors with `container exited (0)` when it finishes before the last service turns healthy — a race it lost on three of the four runs on this PR, always before any test started. It is now scaled out of the wait and run to completion afterwards. That also closes the other half of the problem: on the runs that passed, `--wait` returned while the buckets were still being created, so the tests could start without them.

`tests/features/applications/applications.api.spec.ts` passes in full (19 tests), as do the three application e2e specs (18 tests); `eslint` is clean and `check-types-ratchet` is at baseline (489 errors, baseline 489 — no regression).
