### PR TITLE
fix(datasets): rewrite _attachment_url in values_agg and geo_agg hits

### DIFF
--- a/api/src/datasets/es/geo-agg.ts
+++ b/api/src/datasets/es/geo-agg.ts
@@ -56,6 +56,9 @@ export default async (client: Client, dataset: any, query: Record<string, any>, 
 const prepareGeoAggResponse = async (esResponse: any, dataset: any, query: Record<string, any>, publicBaseUrl: string, flatten: any) => {
   const response: any = { total: esResponse.hits.total.value }
   const resultCtx = prepareResultContext(dataset, query)
+  // these hits come straight from ES (like searchStream's), not from the buffered search(), so their
+  // _attachment_url is still raw and must be rewritten by prepareResultItem
+  resultCtx.rewriteAttachmentUrl = true
   response.aggs = []
   // agg_size × size can legally reach 100000 prepared top hits: yield every 500 like the /lines pipeline
   let prepared = 0

--- a/api/src/datasets/es/values-agg.ts
+++ b/api/src/datasets/es/values-agg.ts
@@ -222,6 +222,9 @@ export default async (dataset: any, query: Record<string, any>, addGeoData: any,
   const response: any = { total: esResponse.hits.total.value }
   if (esResponse.timed_out) response.timed_out = true
   const resultCtx = prepareResultContext(dataset, query)
+  // these hits come straight from ES (like searchStream's), not from the buffered search(), so their
+  // _attachment_url is still raw and must be rewritten by prepareResultItem
+  resultCtx.rewriteAttachmentUrl = true
   recurseAggResponse(response, esResponse.aggregations, dataset, query, publicBaseUrl, flatten, 0, valuesFields, resultCtx)
 
   if (aggSizes[0] > 0 && response.aggs?.length === aggSizes[0]) {

--- a/tests/features/datasets/virtual/virtual-datasets-features.api.spec.ts
+++ b/tests/features/datasets/virtual/virtual-datasets-features.api.spec.ts
@@ -330,6 +330,12 @@ test.describe('virtual datasets features', () => {
     assert.ok(res.data.results[0]._thumbnail)
     res = await ax.get(res.data.results[0]._thumbnail)
     assert.equal(res.status, 200)
+
+    // same rewrite (raw child path -> rerouted through the virtual dataset) must apply to hits returned
+    // by values_agg, the documented way to read attachmentsAsImage through an aggregation
+    res = await ax.get(`/api/v1/datasets/${virtualDataset.id}/values_agg?field=attr1&size=1&select=_attachment_url`)
+    assert.equal(res.status, 200)
+    assert.equal(res.data.aggs[0].results[0]._attachment_url, `${config.publicUrl}/api/v1/datasets/${virtualDataset.id}/attachments/${child.id}/${attachmentPath}`)
   })
 
   test('a virtual dataset of a virtual dataset of a dataset with attachments re-expose those attachments', async () => {


### PR DESCRIPTION
`values_agg` and `geo_agg` query Elasticsearch directly and pass their top hits to `prepareResultItem` without setting `ctx.rewriteAttachmentUrl`, so the `_attachment_url` they return keeps its raw stored value. `/lines` and `search()` both rewrite it.

The contract is stated in `routes/lines-pipeline.ts`: hits coming straight from ES still hold the raw URL and must be rewritten, while hits from the buffered `search()` are already rewritten and must not be. Both aggregation endpoints fall in the first case but never set the flag. `routes/master-data.ts` is correctly untouched — it goes through `search()`.

This means three rewrites are skipped on aggregation results: `oldPublicUrl` → `publicUrl`, `publicUrl` → the request's `publicBaseUrl`, and the virtual-dataset path fixup. The last one is not cosmetic: for a virtual dataset the URL points at the *child* dataset's attachment path, which the caller may have no permission on.

**Why:** an application reading images through `values_agg?size=1&select=_attachment_url` — the documented way to use `attachmentsAsImage` in an aggregation — gets the canonical-host URL instead of the requester's. Harmless for a public dataset, broken behind a portal on a custom domain, and broken for virtual datasets regardless.

**Heads-up:** this changes an observable API response — a consumer relying on the raw canonical URL from `values_agg`/`geo_agg` will now see a different one. Double rewriting is not a risk: neither file rewrote before. The added test covers `values_agg` on a virtual dataset; `geo_agg` gets the same one-line fix but no test.
