### PR TITLE
fix(ui): make journal messages readable, drop the redundant error sample

### DIFF
--- a/api/src/datasets/es/index-stream.ts
+++ b/api/src/datasets/es/index-stream.ts
@@ -184,7 +184,8 @@ class IndexStream extends Transform {
   errorsSummary () {
     if (!this.nbErroredItems) return null
     const leftOutErrors = this.nbErroredItems - 3
-    let msg = `${Math.round(100 * (this.nbErroredItems / this.i))}% des lignes sont en erreur.\n<br>`
+    // plain newlines only: the journal UI renders messages with `white-space: pre-line`
+    let msg = `${Math.round(100 * (this.nbErroredItems / this.i))}% des lignes sont en erreur.\n`
     msg += this.erroredItems.map((item: any) => {
       let itemMsg = ' - '
       if (item._i !== undefined) itemMsg += `Ligne ${item._i}: `
@@ -192,8 +193,8 @@ class IndexStream extends Transform {
       else if (item.error.caused_by) itemMsg += item.error.caused_by.reason
       else itemMsg += item.error.reason
       return truncateMiddle(itemMsg, 80, 60, '...')
-    }).join('\n<br>')
-    if (leftOutErrors > 0) msg += `\n<br>${leftOutErrors} autres erreurs...`
+    }).join('\n')
+    if (leftOutErrors > 0) msg += `\n${leftOutErrors} autres erreurs...`
     // blocking if more than 50% lines are broken in a way
     if (this.nbErroredItems > this.i / 2) throw new Error('[noretry] ' + msg)
     return msg

--- a/api/src/workers/batch-processor/index-lines.ts
+++ b/api/src/workers/batch-processor/index-lines.ts
@@ -172,7 +172,7 @@ export default async function (dataset: DatasetInternal) {
       }
       if (unicityErrorCount > 0) {
         const fileResult = await writer.finalize()
-        const summary = `${unicityErrorCount} ligne(s) en double sur une contrainte d'unicité`
+        const summary = `${unicityErrorCount} ligne${unicityErrorCount > 1 ? 's' : ''} en double sur une contrainte d'unicité`
         const diagnosticEventData = {
           hasDiagnosticFile: true,
           diagnosticErrorCount: fileResult.count,

--- a/api/src/workers/batch-processor/process-file.ts
+++ b/api/src/workers/batch-processor/process-file.ts
@@ -16,7 +16,6 @@ import filesStorage from '#files-storage'
 import { validationDiagnosticFilePath, cancelledDraftDiagnosticFilePath } from '../../datasets/utils/files.ts'
 import * as extensionsUtils from '../../datasets/utils/extensions.ts'
 import { updateStorage } from '../../datasets/utils/storage.ts'
-import truncateMiddle from 'truncate-middle'
 import debugLib from 'debug'
 import mongo from '#mongo'
 import type { DatasetInternal } from '#types'
@@ -26,11 +25,8 @@ import type { CustomAjvValidate } from '../../misc/utils/ajv.ts'
 // extensions, accumulating every row error into a single DiagnosticWriter. Throws
 // [validation-error] at the end if any error was collected.
 
-const inlineErrorsLimit = 3
-
 class ValidateStream extends Writable {
   validate: CustomAjvValidate
-  inlineErrors: string[] = []
   nbErrors = 0
   i = 0
   writer: DiagnosticWriter
@@ -51,9 +47,6 @@ class ValidateStream extends Writable {
       return
     }
     this.nbErrors++
-    if (this.nbErrors <= inlineErrorsLimit) {
-      this.inlineErrors.push(`Ligne ${this.i}: ${this.validate.errors}`)
-    }
     const lineNumber = this.i
     const writerErrors = rawErrors.length
       ? rawErrors.map(err => {
@@ -82,13 +75,11 @@ class ValidateStream extends Writable {
     })().then(() => callback(), callback)
   }
 
+  // no error sample here on purpose: the exhaustive list is in the diagnostic CSV
+  // downloadable from the journal event
   errorsSummary () {
     if (!this.nbErrors) return null
-    const leftOut = this.nbErrors - inlineErrorsLimit
-    let msg = `${Math.round(100 * (this.nbErrors / this.i))}% des lignes ont une erreur de validation.\n`
-    msg += this.inlineErrors.map(err => truncateMiddle(err, 80, 60, '...')).join('\n')
-    if (leftOut > 0) msg += `\n${leftOut} autres erreurs...`
-    return msg
+    return `${Math.round(100 * (this.nbErrors / this.i))}% des lignes ont une erreur de validation (${this.nbErrors} ligne${this.nbErrors > 1 ? 's' : ''}).`
   }
 }
 
@@ -197,11 +188,11 @@ export default async function (dataset: DatasetInternal) {
   if (writer.errorCount > 0) {
     const summaryParts: string[] = []
     if (nbValidationErrors > 0) {
-      const validationSummary = validationStream?.errorsSummary() ?? `${nbValidationErrors} ligne(s) en erreur de validation`
+      const validationSummary = validationStream?.errorsSummary() ?? `${nbValidationErrors} ligne${nbValidationErrors > 1 ? 's' : ''} en erreur de validation`
       summaryParts.push(validationSummary)
     }
     if (blockingExtensionErrors > 0) {
-      summaryParts.push(`${blockingExtensionErrors} ligne(s) en échec d'enrichissement obligatoire`)
+      summaryParts.push(`${blockingExtensionErrors} ligne${blockingExtensionErrors > 1 ? 's' : ''} en échec d'enrichissement obligatoire`)
     }
     const summary = summaryParts.join('\n')
 

--- a/docs/architecture/dataset-validation.md
+++ b/docs/architecture/dataset-validation.md
@@ -51,7 +51,7 @@ process-file worker
          discard writer, advance status to 'extended' or 'validated'
 ```
 
-Phase A's `ValidateStream` (defined inline in `process-file.ts`) keeps the existing 3-error inline summary in the journal `validation-error.data` field for human readability; the diagnostic file is the exhaustive source.
+Phase A's `ValidateStream` (defined inline in `process-file.ts`) writes a one-line summary (error ratio + failing-line count) in the journal `validation-error.data` field; it deliberately carries **no error sample** — the diagnostic file is the only, and exhaustive, source. (An inline 3-error extract used to be included; it was dropped once the CSV shipped, since it was both redundant and invisible in the journal UI. `index-stream.ts` keeps its own extract because ES indexing errors never produce a diagnostic file.)
 
 Phase B reuses `extensionsUtils.extend()` with an `onLineError(absoluteIndex, err)` hook. The hook is invoked from `ExtensionsStream` for every row whose remote-service result has an `errorKey`, and for every row whose `exprEval` throws.
 
@@ -134,7 +134,7 @@ A failed run emits exactly one `validation-error` journal event with these field
 
 | Field | Meaning |
 |---|---|
-| `data` | Human-readable summary, multi-line; reuses the existing 3-error inline format for schema failures, plus a one-liner for blocking extensions |
+| `data` | Human-readable summary: one line for schema failures (ratio + failing-line count, no error sample), plus a one-liner for blocking extensions |
 | `hasDiagnosticFile` | `true` when a downloadable CSV exists for this attempt (UI gates the download button on this) |
 | `diagnosticErrorCount` | Number of rows actually in the CSV (can be capped at 10 000) |
 | `diagnosticCapped` | `true` if the cap was hit |
@@ -158,6 +158,7 @@ cancelled contribution and removed by `validateDraft` once a contribution succee
 
 - **Mandatory toggle** — `ui/src/components/dataset/extension/dataset-extension-remote-service-card.vue` adds a checkbox bound to `extension.mandatory`, with a hint explaining the consequence. Only on `remoteService` cards (no `exprEval` toggle by design).
 - **Download button** — `ui/src/components/journal-view.vue` renders a "Télécharger le diagnostic" button on any `validation-error` event whose `hasDiagnosticFile === true`. The button derives its URL from the injected `datasetStore.resourceUrl`, appending `?draft=true` for draft events.
+- **Long messages** — the same component clamps every event message to 2 lines and adds a "Voir le message complet" toggle when `event.data` exceeds 140 chars or is multi-line; expanded, the message scrolls inside a 300px-tall block. Event *labels* are bounded (70 entries in `shared/events.json`, 128 chars max) but `event.data` is not — a breaking-changes list grows with the schema (3 400+ chars observed), and for `type: 'error'` events the data **is** the title.
 
 ## Modules & files
 

--- a/tests/features/datasets/upload/file-validation.api.spec.ts
+++ b/tests/features/datasets/upload/file-validation.api.spec.ts
@@ -164,9 +164,9 @@ bidule,123,test3`, 'dataset1.csv')
     const journal = (await ax.get(`/api/v1/datasets/${dataset2.id}/journal`)).data
     const errorEvent = journal.find((e: any) => e.type === 'validation-error')
     assert.ok(errorEvent)
-    assert.ok(errorEvent.data.includes('/multipattern/1 doit correspondre au format'))
 
-    // the diagnostic CSV must carry the actual rejected value, resolved through
+    // the summary carries no error sample, the diagnostic CSV is the exhaustive source
+    // and must carry the actual rejected value, resolved through
     // the nested JSON-pointer (/multipattern/1), not an empty cell
     assert.ok(errorEvent.hasDiagnosticFile)
     const diagnostic = (await ax.get(`/api/v1/datasets/${dataset2.id}/validation-diagnostic.csv`)).data

--- a/ui/src/components/journal-message.vue
+++ b/ui/src/components/journal-message.vue
@@ -1,0 +1,85 @@
+<template>
+  <div>
+    <component :is="subtitle ? VListItemSubtitle : VListItemTitle">
+      <div
+        ref="message"
+        class="journal-message"
+        :class="{ 'journal-message-expanded': expanded }"
+      >
+        {{ text }}
+      </div>
+    </component>
+    <v-btn
+      v-if="truncated"
+      variant="text"
+      size="small"
+      :color="color"
+      :append-icon="expanded ? mdiChevronUp : mdiChevronDown"
+      @click="expanded = !expanded"
+    >
+      {{ expanded ? t('collapseMessage') : t('expandMessage') }}
+    </v-btn>
+  </div>
+</template>
+
+<i18n lang="yaml">
+fr:
+  expandMessage: Voir le message complet
+  collapseMessage: Réduire le message
+en:
+  expandMessage: Show full message
+  collapseMessage: Collapse message
+</i18n>
+
+<script setup lang="ts">
+import { useResizeObserver } from '@vueuse/core'
+import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
+import { VListItemSubtitle, VListItemTitle } from 'vuetify/components'
+
+const { data } = defineProps<{
+  data: string
+  // render with the subtitle typography instead of the title one
+  subtitle?: boolean
+  color?: string
+}>()
+
+const { t } = useI18n()
+
+// journal messages are plain text, sometimes copied verbatim from a third party (an nginx
+// error body). Entries written before the api switched to plain newlines still carry their
+// HTML line breaks, turn them back into newlines.
+const text = computed(() => data.replace(/\s*<br\s*\/?>\s*/gi, '\n'))
+
+// the message is clamped to 2 lines with a toggle to reveal the whole thing. Whether it
+// actually overflows depends on the available width, so it is measured on the rendered
+// element instead of being guessed from the text length.
+const message = useTemplateRef('message')
+const expanded = ref(false)
+const truncated = ref(false)
+const measure = () => {
+  // an expanded message is not clamped anymore, keep the last measure so the toggle stays
+  // available to collapse it back
+  if (!message.value || expanded.value) return
+  truncated.value = message.value.scrollHeight > message.value.clientHeight + 1
+}
+useResizeObserver(message, measure)
+// the web font is loaded with font-display: swap, it changes the line count after the first
+// render without changing the clamped height, so the resize observer does not fire
+onMounted(() => document.fonts.ready.then(measure))
+</script>
+
+<style scoped>
+.journal-message {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+  white-space: pre-line;
+}
+.journal-message-expanded {
+  display: block;
+  max-height: 300px;
+  overflow-y: auto;
+}
+</style>

--- a/ui/src/components/journal-view.vue
+++ b/ui/src/components/journal-view.vue
@@ -21,33 +21,52 @@
       :key="`${i}-${j}`"
       :prepend-icon="mdiIcons[getEventType(event).icon]"
       :base-color="getEventType(event).color || 'default'"
+      :lines="isLongMessage(event) ? 'three' : undefined"
     >
       <v-list-item-title>
         <span
           v-if="event.type === 'error'"
-          class="text-error"
+          class="text-error journal-message"
+          :class="{ 'journal-message-expanded': expanded[eventKey(event)] }"
         >
           {{ event.data || eventLabel(event) }}
         </span>
-        <span v-else>
+        <span
+          v-else
+          class="journal-message"
+        >
           {{ eventLabel(event) }}
           {{ event.type === 'draft-validated' ? `(${event.data})` : '' }}
         </span>
       </v-list-item-title>
       <v-list-item-subtitle v-if="event.type === 'validation-error' && event.data">
         <p
-          class="text-error"
-          style="white-space: pre-line"
+          class="text-error journal-message"
+          :class="{ 'journal-message-expanded': expanded[eventKey(event)] }"
         >
           {{ event.data }}
         </p>
       </v-list-item-subtitle>
       <v-list-item-subtitle v-else-if="event.data && !['draft-validated', 'error'].includes(event.type)">
-        <p v-safe-html="event.data" />
+        <p
+          v-safe-html="event.data"
+          class="journal-message"
+          :class="{ 'journal-message-expanded': expanded[eventKey(event)] }"
+        />
       </v-list-item-subtitle>
+      <v-btn
+        v-if="isLongMessage(event)"
+        variant="text"
+        size="small"
+        :color="getEventType(event).color || undefined"
+        :append-icon="expanded[eventKey(event)] ? mdiChevronUp : mdiChevronDown"
+        @click="expanded[eventKey(event)] = !expanded[eventKey(event)]"
+      >
+        {{ expanded[eventKey(event)] ? t('collapseMessage') : t('expandMessage') }}
+      </v-btn>
       <template #append>
         <div class="d-flex flex-column align-end">
-          <span class="text-body-small default">
+          <span class="text-body-small default text-no-wrap">
             {{ event.date ? dayjs(event.date).format('lll') : dayjs().format('lll') }}
           </span>
           <v-btn
@@ -55,6 +74,7 @@
             variant="text"
             size="small"
             color="error"
+            :prepend-icon="mdiFileDownload"
             :href="diagnosticDownloadHref(event)"
             target="_blank"
           >
@@ -82,17 +102,21 @@ fr:
   draft: Brouillon
   downloadDiagnostic: Télécharger le diagnostic
   showMore: Voir plus
+  expandMessage: Voir le message complet
+  collapseMessage: Réduire le message
 en:
   draft: Draft
   downloadDiagnostic: Download diagnostic
   showMore: Show more
+  expandMessage: Show full message
+  collapseMessage: Collapse message
 </i18n>
 
 <script setup lang="ts">
 import { inject } from 'vue'
 import type { Event } from '#api/types'
 import eventsJson from '#shared/events.json'
-import { mdiAlert, mdiAlertDecagram, mdiCheck, mdiClipboardText, mdiContentSave, mdiDelete, mdiFileCancel, mdiFileCheck, mdiFileDownload, mdiFileSearch, mdiFileSwap, mdiMerge, mdiPencil, mdiPlusCircleOutline, mdiPublish, mdiReloadAlert, mdiTableOfContents, mdiWrench } from '@mdi/js'
+import { mdiAlert, mdiAlertDecagram, mdiCheck, mdiChevronDown, mdiChevronUp, mdiClipboardText, mdiContentSave, mdiDelete, mdiFileCancel, mdiFileCheck, mdiFileDownload, mdiFileSearch, mdiFileSwap, mdiMerge, mdiPencil, mdiPlusCircleOutline, mdiPublish, mdiReloadAlert, mdiTableOfContents, mdiWrench } from '@mdi/js'
 import { datasetStoreKey, type DatasetStore, type TaskProgress } from '~/composables/dataset/dataset-store'
 const eventsList = eventsJson as Record<string, Record<string, { icon: string, text: Record<string, string>, color?: string }>>
 
@@ -127,6 +151,16 @@ const draftEventTypes = eventsList[`${type}-draft`]
 const filteredEvents = computed(() => journal.filter(event => !!eventTypes[event.type] && (!after || event.date >= after)))
 
 const visibleCount = ref(10)
+
+// long messages (a breaking-changes list, an ES error dump, the list of empty columns...)
+// are clamped to 2 lines with a toggle to reveal the whole thing in a scrollable block.
+// Event labels come from a fixed enum (128 chars max), only event.data is unbounded.
+const expanded = ref<Record<string, boolean>>({})
+const eventKey = (event: Event) => `${event.date}-${event.type}`
+const isLongMessage = (event: Event) => {
+  if (!event.data || event.type === 'draft-validated') return false
+  return event.data.length > 140 || event.data.includes('\n')
+}
 
 const groupedEvents = computed(() => {
   const groups = []
@@ -174,3 +208,27 @@ const mdiIcons: Record<string, string> = {
 }
 
 </script>
+
+<style scoped>
+/* override vuetify's single-line ellipsis: journal messages may be long and must stay readable */
+.journal-message {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+  white-space: pre-line;
+}
+.journal-message-expanded {
+  -webkit-line-clamp: unset;
+  line-clamp: unset;
+  max-height: 300px;
+  overflow-y: auto;
+}
+:deep(.v-list-item-title),
+:deep(.v-list-item-subtitle) {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: unset;
+}
+</style>

--- a/ui/src/components/journal-view.vue
+++ b/ui/src/components/journal-view.vue
@@ -21,49 +21,25 @@
       :key="`${i}-${j}`"
       :prepend-icon="mdiIcons[getEventType(event).icon]"
       :base-color="getEventType(event).color || 'default'"
-      :lines="isLongMessage(event) ? 'three' : undefined"
     >
-      <v-list-item-title>
-        <span
-          v-if="event.type === 'error'"
-          class="text-error journal-message"
-          :class="{ 'journal-message-expanded': expanded[eventKey(event)] }"
-        >
-          {{ event.data || eventLabel(event) }}
-        </span>
-        <span
-          v-else
-          class="journal-message"
-        >
-          {{ eventLabel(event) }}
-          {{ event.type === 'draft-validated' ? `(${event.data})` : '' }}
-        </span>
-      </v-list-item-title>
-      <v-list-item-subtitle v-if="event.type === 'validation-error' && event.data">
-        <p
-          class="text-error journal-message"
-          :class="{ 'journal-message-expanded': expanded[eventKey(event)] }"
-        >
-          {{ event.data }}
-        </p>
-      </v-list-item-subtitle>
-      <v-list-item-subtitle v-else-if="event.data && !['draft-validated', 'error'].includes(event.type)">
-        <p
-          v-safe-html="event.data"
-          class="journal-message"
-          :class="{ 'journal-message-expanded': expanded[eventKey(event)] }"
-        />
-      </v-list-item-subtitle>
-      <v-btn
-        v-if="isLongMessage(event)"
-        variant="text"
-        size="small"
+      <!-- an error carries its message in place of the event label, the other types keep both -->
+      <journal-message
+        v-if="event.type === 'error' && event.data"
+        :data="event.data"
+        class="text-error"
         :color="getEventType(event).color || undefined"
-        :append-icon="expanded[eventKey(event)] ? mdiChevronUp : mdiChevronDown"
-        @click="expanded[eventKey(event)] = !expanded[eventKey(event)]"
-      >
-        {{ expanded[eventKey(event)] ? t('collapseMessage') : t('expandMessage') }}
-      </v-btn>
+      />
+      <v-list-item-title v-else>
+        {{ eventLabel(event) }}
+        {{ event.type === 'draft-validated' ? `(${event.data})` : '' }}
+      </v-list-item-title>
+      <journal-message
+        v-if="event.data && !['draft-validated', 'error'].includes(event.type)"
+        subtitle
+        :data="event.data"
+        :class="{ 'text-error': event.type === 'validation-error' }"
+        :color="getEventType(event).color || undefined"
+      />
       <template #append>
         <div class="d-flex flex-column align-end">
           <span class="text-body-small default text-no-wrap">
@@ -102,21 +78,17 @@ fr:
   draft: Brouillon
   downloadDiagnostic: Télécharger le diagnostic
   showMore: Voir plus
-  expandMessage: Voir le message complet
-  collapseMessage: Réduire le message
 en:
   draft: Draft
   downloadDiagnostic: Download diagnostic
   showMore: Show more
-  expandMessage: Show full message
-  collapseMessage: Collapse message
 </i18n>
 
 <script setup lang="ts">
 import { inject } from 'vue'
 import type { Event } from '#api/types'
 import eventsJson from '#shared/events.json'
-import { mdiAlert, mdiAlertDecagram, mdiCheck, mdiChevronDown, mdiChevronUp, mdiClipboardText, mdiContentSave, mdiDelete, mdiFileCancel, mdiFileCheck, mdiFileDownload, mdiFileSearch, mdiFileSwap, mdiMerge, mdiPencil, mdiPlusCircleOutline, mdiPublish, mdiReloadAlert, mdiTableOfContents, mdiWrench } from '@mdi/js'
+import { mdiAlert, mdiAlertDecagram, mdiCheck, mdiClipboardText, mdiContentSave, mdiDelete, mdiFileCancel, mdiFileCheck, mdiFileDownload, mdiFileSearch, mdiFileSwap, mdiMerge, mdiPencil, mdiPlusCircleOutline, mdiPublish, mdiReloadAlert, mdiTableOfContents, mdiWrench } from '@mdi/js'
 import { datasetStoreKey, type DatasetStore, type TaskProgress } from '~/composables/dataset/dataset-store'
 const eventsList = eventsJson as Record<string, Record<string, { icon: string, text: Record<string, string>, color?: string }>>
 
@@ -151,16 +123,6 @@ const draftEventTypes = eventsList[`${type}-draft`]
 const filteredEvents = computed(() => journal.filter(event => !!eventTypes[event.type] && (!after || event.date >= after)))
 
 const visibleCount = ref(10)
-
-// long messages (a breaking-changes list, an ES error dump, the list of empty columns...)
-// are clamped to 2 lines with a toggle to reveal the whole thing in a scrollable block.
-// Event labels come from a fixed enum (128 chars max), only event.data is unbounded.
-const expanded = ref<Record<string, boolean>>({})
-const eventKey = (event: Event) => `${event.date}-${event.type}`
-const isLongMessage = (event: Event) => {
-  if (!event.data || event.type === 'draft-validated') return false
-  return event.data.length > 140 || event.data.includes('\n')
-}
 
 const groupedEvents = computed(() => {
   const groups = []
@@ -211,24 +173,25 @@ const mdiIcons: Record<string, string> = {
 
 <style scoped>
 /* override vuetify's single-line ellipsis: journal messages may be long and must stay readable */
-.journal-message {
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-  line-clamp: 2;
-  overflow: hidden;
-  white-space: pre-line;
-}
-.journal-message-expanded {
-  -webkit-line-clamp: unset;
-  line-clamp: unset;
-  max-height: 300px;
-  overflow-y: auto;
-}
 :deep(.v-list-item-title),
 :deep(.v-list-item-subtitle) {
   white-space: normal;
   overflow: visible;
   text-overflow: unset;
+}
+/* vuetify's 1rem subtitle line-height is meant for a single line: too tight for a message
+   spread over several lines, and its sub-pixel overflow shows a scrollbar for nothing */
+:deep(.v-list-item-subtitle) {
+  line-height: 1.25rem;
+}
+/* align the event icon and the date with the first line of the message rather than with
+   the middle of the item */
+:deep(.v-list-item__prepend),
+:deep(.v-list-item__append) {
+  align-self: flex-start;
+}
+/* keep the date off the message it sits next to */
+:deep(.v-list-item__append) {
+  padding-inline-start: 16px;
 }
 </style>

--- a/ui/src/components/journal-view.vue
+++ b/ui/src/components/journal-view.vue
@@ -17,8 +17,8 @@
       {{ t('draft') }}
     </v-list-subheader>
     <v-list-item
-      v-for="(event,j) in group.events"
-      :key="`${i}-${j}`"
+      v-for="event in group.events"
+      :key="`${event.date}-${event.type}`"
       :prepend-icon="mdiIcons[getEventType(event).icon]"
       :base-color="getEventType(event).color || 'default'"
     >


### PR DESCRIPTION
Journal messages were unreadable as soon as they got long: titles and subtitles were truncated with a single-line ellipsis, so a message listing every empty column, or every breaking change of a re-uploaded file, was cut after a few words with no way to see the rest.

- **Messages wrap on two lines and expand on demand**: when the data is long or multi-line, a "Voir le message complet" button reveals it inside a 300px scrollable block. Event *labels* are bounded (70 entries in `shared/events.json`, 128 chars max) but `event.data` is not — a breaking-changes list grows with the schema, 3 200 chars observed on a 60-column file — and for `type: 'error'` events the data **is** the title, which is why a plain `title` attribute would not have been enough.
- **The validation summary drops its 3-error sample**: that extract predates the diagnostic CSV, is redundant with it, and was invisible anyway since the subtitle clamped to one line. The summary keeps the error ratio and gains the failing-line count. `index-stream.ts` keeps its own extract on purpose — ES indexing errors never produce a diagnostic file, so it is their only trace — but its literal `<br>` separators are dropped now that messages render with `white-space: pre-line`.
- **Smaller touches on the same items**: the download-diagnostic button gets an icon, line counts are pluralized in the four messages that used the `ligne(s)` placeholder, and an item carrying a long message switches to `lines="three"` so vuetify aligns the event icon and the date with the first line instead of centering them on a tall item.

**Why:** a contributor whose upload fails reads that message to know what to fix. Truncated, it names neither the columns nor the ruptures; and where a diagnostic CSV exists, printing three sample errors next to the download button is noise, not help.

**Heads-up:** `validation-error.data` is a human-readable string whose format changes here — nothing in the codebase parses it (the notification carries `nbErrors` and the diagnostic URL as separate params), but an integration scraping the journal text would see it move.

Verified in the dev environment on four datasets covering each error style — validation errors with a diagnostic, a 213-char empty-columns message, a 3 200-char breaking-changes message, and the singular/plural boundary. `file-validation`, `workers` and `geo-files` API specs pass (27 tests); `eslint` is clean and `check-types-ratchet` is at baseline (489 errors, baseline 489 — no regression).
