### PR TITLE
fix(geo): repair the 180 boundary broken by the fixLon hotfix

### DIFF
--- a/api/src/datasets/es/commons.ts
+++ b/api/src/datasets/es/commons.ts
@@ -534,6 +534,11 @@ export const getQueryBBOX = (query: Record<string, any>, _dataset?: any) => {
     bbox = tiles.xyz2bbox(...query.xyz.split(',').map(Number) as [number, number, number])
   }
   if (bbox) {
+    // reject broken coordinates (a client sending its uninitialized bounds as Number.MAX_VALUE, a NaN,
+    // an aberrant xyz reference, etc) rather than letting elasticsearch fail on them
+    if (bbox.length !== 4 || bbox.some(coord => !Number.isFinite(coord)) || Math.abs(bbox[1]) > 90 || Math.abs(bbox[3]) > 90) {
+      throw httpError(400, 'invalid bounding box, expected "left,bottom,right,top" with latitudes between -90 and 90')
+    }
     bbox[0] = geo.fixLon(bbox[0])
     bbox[2] = geo.fixLon(bbox[2])
   }

--- a/api/src/datasets/utils/geo-lon.ts
+++ b/api/src/datasets/utils/geo-lon.ts
@@ -1,5 +1,11 @@
 export const fixLon = (val: number): number => {
+  // an already valid longitude is returned as is: this keeps 180 on the positive side (a world-wide
+  // bbox or the zoom 0 tile would otherwise collapse to a zero-width envelope matching nothing) and
+  // avoids the rounding noise of the modulo below (2.35 -> 2.3500000000000227)
+  if (val >= -180 && val <= 180) return val
   if (!Number.isFinite(val)) return val
   const wrapped = ((val % 360) + 360) % 360
-  return wrapped >= 180 ? wrapped - 360 : wrapped
+  // 180 is the boundary between both ends of the range, keep it on the side it was reached from
+  if (wrapped === 180) return val > 0 ? 180 : -180
+  return wrapped > 180 ? wrapped - 360 : wrapped
 }

--- a/api/src/datasets/utils/geo-lon.ts
+++ b/api/src/datasets/utils/geo-lon.ts
@@ -1,0 +1,5 @@
+export const fixLon = (val: number): number => {
+  if (!Number.isFinite(val)) return val
+  const wrapped = ((val % 360) + 360) % 360
+  return wrapped >= 180 ? wrapped - 360 : wrapped
+}

--- a/api/src/datasets/utils/geo.ts
+++ b/api/src/datasets/utils/geo.ts
@@ -63,12 +63,7 @@ export const geoFieldsKey = (schema: SchemaProperty[]): string => {
   return key
 }
 
-export const fixLon = (val: number): number => {
-  while (val < -180) val += 360
-  while (val > 180) val -= 360
-  return val
-}
-
+export { fixLon } from './geo-lon.ts'
 export const latlon2fields = (dataset: Dataset, doc: Record<string, any>): Record<string, string> => {
   const schema = dataset.schema ?? []
   let lat: any, lon: any

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "data-fair",
-  "version": "6.17.1",
+  "version": "6.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "data-fair",
-      "version": "6.17.1",
+      "version": "6.17.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-fair",
-  "version": "6.17.1",
+  "version": "6.17.2",
   "description": "",
   "main": "server",
   "scripts": {

--- a/tests/features/datasets/es/bbox-query.unit.spec.ts
+++ b/tests/features/datasets/es/bbox-query.unit.spec.ts
@@ -1,0 +1,57 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import path from 'node:path'
+
+// es/commons.ts imports `#config` at module load, so point node-config at the real api/config dir
+// and load the module dynamically afterwards — same pattern as lines-pipeline.unit.spec.ts
+process.env.NODE_CONFIG_DIR ??= path.resolve(import.meta.dirname, '../../../../api/config')
+
+const load = async () => await import('../../../../api/src/datasets/es/commons.ts')
+
+// the bbox a map application sends when its bounds were never initialized
+const maxValueBBOX = [Number.MAX_VALUE, Number.MAX_VALUE, -Number.MAX_VALUE, -Number.MAX_VALUE]
+  .map(c => c.toFixed(6)).join(',')
+
+test.describe('getQueryBBOX', () => {
+  test('parses a valid bbox', async () => {
+    const { getQueryBBOX } = await load()
+    assert.deepEqual(getQueryBBOX({ bbox: '-1,44,3,49' }), [-1, 44, 3, 49])
+    assert.deepEqual(getQueryBBOX({ _c_bbox: '-1,44,3,49' }), [-1, 44, 3, 49])
+  })
+  test('wraps the longitudes of a valid bbox', async () => {
+    const { getQueryBBOX } = await load()
+    assert.deepEqual(getQueryBBOX({ bbox: '-190,44,190,49' }), [170, 44, -170, 49])
+  })
+  test('converts a xyz tile reference', async () => {
+    const { getQueryBBOX } = await load()
+    const bbox = getQueryBBOX({ xyz: '1,1,2' })!
+    assert.equal(bbox.length, 4)
+    assert.ok(bbox.every(c => Number.isFinite(c)))
+  })
+  test('returns undefined without bbox nor xyz', async () => {
+    const { getQueryBBOX } = await load()
+    assert.equal(getQueryBBOX({}), undefined)
+  })
+  test('rejects a bbox with extreme values instead of hanging', async () => {
+    const { getQueryBBOX } = await load()
+    assert.throws(() => getQueryBBOX({ bbox: maxValueBBOX }), (err: any) => err.status === 400)
+    assert.throws(() => getQueryBBOX({ _c_bbox: maxValueBBOX }), (err: any) => err.status === 400)
+  })
+  test('rejects a non numeric bbox', async () => {
+    const { getQueryBBOX } = await load()
+    assert.throws(() => getQueryBBOX({ bbox: 'a,b,c,d' }), (err: any) => err.status === 400)
+  })
+  test('rejects a bbox with a wrong number of coordinates', async () => {
+    const { getQueryBBOX } = await load()
+    assert.throws(() => getQueryBBOX({ bbox: '-1,44,3' }), (err: any) => err.status === 400)
+  })
+  test('rejects out of range latitudes', async () => {
+    const { getQueryBBOX } = await load()
+    assert.throws(() => getQueryBBOX({ bbox: '-1,-91,3,49' }), (err: any) => err.status === 400)
+    assert.throws(() => getQueryBBOX({ bbox: '-1,44,3,91' }), (err: any) => err.status === 400)
+  })
+  test('rejects a xyz reference producing invalid coordinates', async () => {
+    const { getQueryBBOX } = await load()
+    assert.throws(() => getQueryBBOX({ xyz: '1e300,0,-1000' }), (err: any) => err.status === 400)
+  })
+})

--- a/tests/features/datasets/geo-fixlon.unit.spec.ts
+++ b/tests/features/datasets/geo-fixlon.unit.spec.ts
@@ -13,20 +13,25 @@ test.describe('fixLon', () => {
     assert.equal(fixLon(0), 0)
     assert.equal(fixLon(90), 90)
     assert.equal(fixLon(-90), -90)
-    assert.ok(Math.abs(fixLon(180)) === 180)
-    assert.ok(Math.abs(fixLon(-180)) === 180)
+    // exactly, without the rounding noise of a modulo over the whole range
+    assert.equal(fixLon(2.35), 2.35)
+    assert.equal(fixLon(-74.006), -74.006)
+    // 180 must stay positive: it is the right edge of a world-wide bbox and of the zoom 0 tile,
+    // turning it into -180 collapses the ES envelope to zero width and matches nothing
+    assert.equal(fixLon(180), 180)
+    assert.equal(fixLon(-180), -180)
   })
 
   test('wraps longitudes beyond 180', () => {
     assert.equal(fixLon(190), -170)
     assert.equal(fixLon(360), 0)
-    assert.ok(Math.abs(fixLon(540)) === 180)
+    assert.equal(fixLon(540), 180)
   })
 
   test('wraps longitudes below -180', () => {
     assert.equal(fixLon(-190), 170)
     assert.equal(fixLon(-360), 0)
-    assert.ok(Math.abs(fixLon(-540)) === 180)
+    assert.equal(fixLon(-540), -180)
   })
 
   test('handles very large values in O(1) without hanging', () => {
@@ -38,5 +43,19 @@ test.describe('fixLon', () => {
     assert.equal(fixLon(Infinity), Infinity)
     assert.equal(fixLon(-Infinity), -Infinity)
     assert.ok(Number.isNaN(fixLon(NaN)))
+  })
+})
+
+// xyz2bbox builds the right edge of a tile as exactly 180 for the last column of every zoom level,
+// and a world-wide bbox ends with 180 too: both must survive the normalization
+test.describe('fixLon on bbox edges', () => {
+  test('preserves the right edge of a world-wide bbox', () => {
+    const worldBBOX = [-180, -90, 180, 90]
+    assert.deepEqual([fixLon(worldBBOX[0]), fixLon(worldBBOX[2])], [-180, 180])
+  })
+
+  test('preserves the right edge of the zoom 0 tile', () => {
+    const tile2long = (x: number, z: number) => (x / Math.pow(2, z) * 360 - 180)
+    assert.deepEqual([fixLon(tile2long(0, 0)), fixLon(tile2long(1, 0))], [-180, 180])
   })
 })

--- a/tests/features/datasets/geo-fixlon.unit.spec.ts
+++ b/tests/features/datasets/geo-fixlon.unit.spec.ts
@@ -1,0 +1,42 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { fixLon } from '../../../api/src/datasets/utils/geo-lon.ts'
+
+// fixLon normalizes a longitude into [-180, 180]. It must be O(1): the previous
+// implementation used while loops that never terminated for huge values such as
+// Number.MAX_VALUE (~1.8e308), freezing the event loop on malicious bbox queries.
+
+const inRange = (val: number) => val >= -180 && val <= 180
+
+test.describe('fixLon', () => {
+  test('keeps a normal longitude unchanged', () => {
+    assert.equal(fixLon(0), 0)
+    assert.equal(fixLon(90), 90)
+    assert.equal(fixLon(-90), -90)
+    assert.ok(Math.abs(fixLon(180)) === 180)
+    assert.ok(Math.abs(fixLon(-180)) === 180)
+  })
+
+  test('wraps longitudes beyond 180', () => {
+    assert.equal(fixLon(190), -170)
+    assert.equal(fixLon(360), 0)
+    assert.ok(Math.abs(fixLon(540)) === 180)
+  })
+
+  test('wraps longitudes below -180', () => {
+    assert.equal(fixLon(-190), 170)
+    assert.equal(fixLon(-360), 0)
+    assert.ok(Math.abs(fixLon(-540)) === 180)
+  })
+
+  test('handles very large values in O(1) without hanging', () => {
+    assert.ok(inRange(fixLon(Number.MAX_VALUE)))
+    assert.ok(inRange(fixLon(-Number.MAX_VALUE)))
+  })
+
+  test('passes non-finite values through unchanged', () => {
+    assert.equal(fixLon(Infinity), Infinity)
+    assert.equal(fixLon(-Infinity), -Infinity)
+    assert.ok(Number.isNaN(fixLon(NaN)))
+  })
+})


### PR DESCRIPTION
`v6.17.2` was cut and deployed from `fix/fixlon-infinite-loop` and never merged back, so `master` still carries the `fixLon` infinite loop. This branch brings that hotfix in and adds the two follow-ups it needs.

**The hotfix was right about the hang, wrong at exactly one point.** `((180 % 360) + 360) % 360` is `180`, which the `>= 180` branch shifts to `-180`. A sweep of the 400 001 values between -2000 and 2000 finds 6 divergences from the original implementation, all at `180 (mod 360)`. That is not a corner case: `180` is the right edge of a world-wide bbox, and the right edge of the zoom 0 tile built by `xyz2bbox`. When `left` is `-180` too, the ES envelope collapses to zero width and matches nothing. Measured against a scratch index of 5 points:

| request | envelope before | envelope after | hits |
| --- | --- | --- | --- |
| `bbox=-180,-90,180,90` | `-180..180` | `-180..-180` | 5 → **0** |
| `xyz=0,0,0` | `-180..180` | `-180..-180` | 5 → **0** |
| `xyz=1,1,1` | `0..180` | `0..-180` | 4 → 4 |

Tiles from zoom 1 up are unaffected: their `left` is not `-180`, so ES reads the inverted envelope as crossing the antimeridian and covers the same region. Returning an already valid longitude untouched restores the boundary, and incidentally drops the rounding noise the modulo introduced on every value (`2.35` came back as `2.3500000000000227`).

The existing tests missed it because they asserted on `Math.abs(fixLon(x))`, which passes whether the result is `180` or `-180`. They now assert the sign, and cover both bbox edges; all four fail against the released implementation.

**`getQueryBBOX` now validates before wrapping.** This one is hardening, not a fix: `bbox` and `xyz` were parsed with `Number` and handed straight to the envelope, and Elasticsearch already answered `400` on all of it — a `NaN` serialized to a `null` coordinate (`x_content_parse_exception`), a latitude beyond the poles (`query_shard_exception`), an aberrant `xyz` such as `1e300,0,-1000` producing an infinite longitude. What changes is the message the caller gets: `invalid bounding box, expected "left,bottom,right,top" with latitudes between -90 and 90` instead of `Exception creating query on Field [_geoshape] invalid latitude -91.0`, decided once where both parameters converge and without a pointless round-trip to the cluster. Drop the commit if you would rather keep the diff minimal — it stands alone.

**Why:** the incident was a `bbox` whose four coordinates were `±Number.MAX_VALUE` — the signature of a client accumulator left at its `[+∞, +∞, -∞, -∞]` initial value. `MAX_VALUE - 360 === MAX_VALUE`, so `while (val > 180) val -= 360` never terminated and pinned the event loop at 100% CPU. The loop dates from `afa9a2ee` (June 2019), released in `v1.10.0`.

**Heads-up:** the zero-width envelope shipped in `v6.17.2`, and anything cut from `master` before this lands carries the infinite loop instead — Keel is notified with the major tag, so the next `v6.*` build replaces the running image whatever branch it came from. That is why this belongs on `master` before the next release rather than after. The merge carries the version to `6.17.2`, so the next release is `6.17.3` or above. Two behaviour changes beyond the fix, both in the validation commit: a malformed `bbox` that used to surface as an Elasticsearch error now answers `400` with an explicit message, and a `bbox` carrying more than four coordinates — a 6-value 3D bbox, say — is now rejected instead of silently building the envelope from the first four.

`npm run test-unit` is green (672), `eslint` is clean, `check-types` is at baseline (489 errors, no regression). The Playwright `api` project was not run on this branch — it needs the docker dev deps — so `tests/features/datasets/query/search-basic.api.spec.ts`, which covers `lines?bbox=` and `geo_agg?bbox=`, is left to CI.
