### PR TITLE
fix(datasets): stop the task progress bar from freezing at 99%

### DIFF
--- a/api/src/datasets/es/index-stream.ts
+++ b/api/src/datasets/es/index-stream.ts
@@ -22,9 +22,14 @@ interface IndexStreamOptions {
   // (markIndexedStream); file datasets pipe into a no-op sink, so skipping the
   // re-emit avoids a full per-line object copy.
   reemit?: boolean
-  // optional task progress reporter, used to name the index refresh happening after the
-  // whole stream was consumed (the only part of the work not covered by the read progress)
-  progress?: { step: (step: string) => Promise<void> }
+  // optional task progress reporter. acknowledged() is called with the running number of
+  // documents ES has accepted, the only faithful unit of work here: the reader consumes the
+  // whole source long before the first bulk lands whenever it fits in the pipeline buffers.
+  // step() names the phases that follow the stream and have no measurable progress.
+  progress?: {
+    step: (step: string, count?: number) => Promise<void>
+    acknowledged: (nbAcknowledged: number) => Promise<void>
+  }
 }
 
 // remove some properties that must not be indexed
@@ -51,6 +56,8 @@ class IndexStream extends Transform {
   lineBytesSpec: { prefixes: Set<string>, nbCols: number }
   bulkChars: number
   i: number
+  // documents ES has accepted, the numerator of the task progress bar
+  nbAcknowledged: number
   nbErroredItems: number
   erroredItems: any[]
 
@@ -65,6 +72,7 @@ class IndexStream extends Transform {
     this.items = []
     this.bulkChars = 0
     this.i = 0
+    this.nbAcknowledged = 0
     this.nbErroredItems = 0
     this.erroredItems = []
   }
@@ -121,9 +129,12 @@ class IndexStream extends Transform {
 
   async finalPromise () {
     await this.sendBulk()
+    // the last sendBulk can be a no-op (an exactly-full previous batch), so publish the final
+    // count unconditionally rather than leaving the bar short of the real total
+    await this.options.progress?.acknowledged(this.nbAcknowledged)
     if (this.options.refresh) return
-    // the read progress is at 100% here but the refresh alone can take minutes on a large
-    // index: hand the bar back to an indeterminate state naming this step
+    // every document is indexed at this point, but the refresh alone can take minutes on a
+    // large index: hand the bar back to an indeterminate state naming this step
     await this.options.progress?.step('refresh')
     try {
       await es.client.indices.refresh({ index: this.options.indexName })
@@ -182,6 +193,7 @@ class IndexStream extends Transform {
           }
         }
       }
+      this.nbAcknowledged += this.items.length
       this.body = []
       this.items = []
       this.bulkChars = 0
@@ -189,6 +201,9 @@ class IndexStream extends Transform {
       internalError('es-bulk-index', err)
       throw new Error('Échec pendant l\'indexation d\'un paquet de données.')
     }
+    // outside the try: ES acknowledged this batch, and a failure to publish the progress
+    // must not be reported as an indexing failure
+    await this.options.progress?.acknowledged(this.nbAcknowledged)
   }
 
   errorsSummary () {

--- a/api/src/datasets/es/index-stream.ts
+++ b/api/src/datasets/es/index-stream.ts
@@ -22,9 +22,8 @@ interface IndexStreamOptions {
   // (markIndexedStream); file datasets pipe into a no-op sink, so skipping the
   // re-emit avoids a full per-line object copy.
   reemit?: boolean
-  // optional task progress reporter: acknowledged() is called with the running number of
-  // documents ES has accepted (the unit driving the bar, cf index-lines.ts), step() names
-  // the phases that follow the stream and have no measurable progress.
+  // optional task progress reporter: acknowledged() receives the running count of documents
+  // ES accepted, step() names the phases that follow the stream
   progress?: {
     step: (step: string, count?: number) => Promise<void>
     acknowledged: (nbAcknowledged: number) => Promise<void>
@@ -128,12 +127,10 @@ class IndexStream extends Transform {
 
   async finalPromise () {
     await this.sendBulk()
-    // the last sendBulk can be a no-op (an exactly-full previous batch), so publish the final
-    // count unconditionally rather than leaving the bar short of the real total
+    // the last sendBulk can be a no-op (exactly-full previous batch): always publish the final count
     await this.options.progress?.acknowledged(this.nbAcknowledged)
     if (this.options.refresh) return
-    // every document is indexed at this point, but the refresh alone can take minutes on a
-    // large index: hand the bar back to an indeterminate state naming this step
+    // the refresh alone can take minutes on a large index
     await this.options.progress?.step('refresh')
     try {
       await es.client.indices.refresh({ index: this.options.indexName })
@@ -200,8 +197,7 @@ class IndexStream extends Transform {
       internalError('es-bulk-index', err)
       throw new Error('Échec pendant l\'indexation d\'un paquet de données.')
     }
-    // outside the try: ES acknowledged this batch, and a failure to publish the progress
-    // must not be reported as an indexing failure
+    // outside the try: a progress publication failure is not an indexing failure
     await this.options.progress?.acknowledged(this.nbAcknowledged)
   }
 

--- a/api/src/datasets/es/index-stream.ts
+++ b/api/src/datasets/es/index-stream.ts
@@ -22,6 +22,9 @@ interface IndexStreamOptions {
   // (markIndexedStream); file datasets pipe into a no-op sink, so skipping the
   // re-emit avoids a full per-line object copy.
   reemit?: boolean
+  // optional task progress reporter, used to name the index refresh happening after the
+  // whole stream was consumed (the only part of the work not covered by the read progress)
+  progress?: { step: (step: string) => Promise<void> }
 }
 
 // remove some properties that must not be indexed
@@ -116,22 +119,29 @@ class IndexStream extends Transform {
     this.transformPromise(item, encoding).then(() => cb(), cb)
   }
 
+  async finalPromise () {
+    await this.sendBulk()
+    if (this.options.refresh) return
+    // the read progress is at 100% here but the refresh alone can take minutes on a large
+    // index: hand the bar back to an indeterminate state naming this step
+    await this.options.progress?.step('refresh')
+    try {
+      await es.client.indices.refresh({ index: this.options.indexName })
+    } catch {
+      // refresh can take some time on large datasets, try one more time
+      await new Promise(resolve => setTimeout(resolve, 30000))
+      try {
+        await es.client.indices.refresh({ index: this.options.indexName })
+      } catch (err) {
+        internalError('es-refresh-index', err)
+        throw new Error('Échec pendant le rafraichissement de la donnée après indexation.')
+      }
+    }
+  }
+
   _final (cb: (error?: Error | null) => void) {
     // use then syntax cf https://github.com/nodejs/node/issues/39535
-    this.sendBulk()
-      .then(() => {
-        if (this.options.refresh) return
-        return es.client.indices.refresh({ index: this.options.indexName }).catch(() => {
-          // refresh can take some time on large datasets, try one more time
-          return new Promise(resolve => setTimeout(resolve, 30000)).finally(() => {
-            return es.client.indices.refresh({ index: this.options.indexName }).catch(err => {
-              internalError('es-refresh-index', err)
-              throw new Error('Échec pendant le rafraichissement de la donnée après indexation.')
-            })
-          })
-        })
-      })
-      .then(() => cb(), cb)
+    this.finalPromise().then(() => cb(), cb)
   }
 
   async sendBulk () {

--- a/api/src/datasets/es/index-stream.ts
+++ b/api/src/datasets/es/index-stream.ts
@@ -22,10 +22,9 @@ interface IndexStreamOptions {
   // (markIndexedStream); file datasets pipe into a no-op sink, so skipping the
   // re-emit avoids a full per-line object copy.
   reemit?: boolean
-  // optional task progress reporter. acknowledged() is called with the running number of
-  // documents ES has accepted, the only faithful unit of work here: the reader consumes the
-  // whole source long before the first bulk lands whenever it fits in the pipeline buffers.
-  // step() names the phases that follow the stream and have no measurable progress.
+  // optional task progress reporter: acknowledged() is called with the running number of
+  // documents ES has accepted (the unit driving the bar, cf index-lines.ts), step() names
+  // the phases that follow the stream and have no measurable progress.
   progress?: {
     step: (step: string, count?: number) => Promise<void>
     acknowledged: (nbAcknowledged: number) => Promise<void>

--- a/api/src/datasets/utils/task-progress.ts
+++ b/api/src/datasets/utils/task-progress.ts
@@ -21,24 +21,35 @@ export default (datasetId: string, task: string, nbSteps?: number, progressCallb
   let doneSteps = 0
   let lastProgress = -1
   let lastTime = new Date().getTime() - 1000
-  // name of the current sub-step, only set for the phases that are not covered by inc()
+  // name and count of the current sub-step, only set for the phases that are not covered by inc()
   let currentStep: string | undefined
+  let currentCount: number | undefined
 
   return {
     async start () {
       await updateProgress(datasetId, task, -1)
     },
-    // switch to an indeterminate bar labelled with a named sub-step, optionally carrying a
-    // running count of units done. Used for the phases with no honest percentage to show:
-    // the tail of a task (index refresh, alias switch) and the indexing itself, whose total
-    // is unknown while it runs. Repeated calls for the same step are throttled like inc().
-    async step (step: string, count?: number) {
+    // switch the bar to a named sub-step, optionally carrying a running count of units done
+    // and a percentage. Without a percent the bar is indeterminate: the phases with no honest
+    // percentage to show (index refresh, alias switch, and the indexing itself when its total
+    // line count is unknown). With a percent the bar is determinate: the indexing when the
+    // total IS known (REST collection count, re-index of unchanged data). Repeated calls for
+    // the same step are throttled like inc(); a step change is never throttled.
+    async step (step: string, count?: number, percent?: number) {
       const time = new Date().getTime()
       if (step === currentStep && (time - lastTime) < 250) return
+      let progress = -1
+      if (percent !== undefined) {
+        // same epsilon as inc(): the percent is a quotient and can land just under an integer
+        progress = Math.min(Math.floor(percent + 1e-9), 100)
+        // the total can be a live count (REST partial updates): never show a receding bar
+        if (step === currentStep && progress < lastProgress) progress = lastProgress
+      }
       currentStep = step
-      lastProgress = -1
+      currentCount = count
+      lastProgress = progress
       lastTime = time
-      await updateProgress(datasetId, task, -1, step, count)
+      await updateProgress(datasetId, task, progress, step, count)
     },
     async inc (inc = 1) {
       if (nbSteps === undefined) throw new Error('incrementing progress requires setting nbSteps')
@@ -67,8 +78,9 @@ export default (datasetId: string, task: string, nbSteps?: number, progressCallb
     },
     async end (error = false, finalTask = false) {
       if (error) {
-        // keep the step so the UI shows which phase of the task actually failed
-        const taskProgress = { task, progress: lastProgress, error, ...(currentStep ? { step: currentStep } : {}) }
+        // keep the step (and its count) so the UI shows which phase of the task actually
+        // failed and how far it got
+        const taskProgress = { task, progress: lastProgress, error, ...(currentStep ? { step: currentStep } : {}), ...(currentCount !== undefined ? { count: currentCount } : {}) }
         await wsEmitter.emit('datasets/' + datasetId + '/task-progress', taskProgress)
         await mongo.db.collection('journals').updateOne({ type: 'dataset', id: datasetId }, { $set: { taskProgress } })
       } else if (task === 'finalize' || finalTask) {

--- a/api/src/datasets/utils/task-progress.ts
+++ b/api/src/datasets/utils/task-progress.ts
@@ -1,9 +1,10 @@
 import * as wsEmitter from '@data-fair/lib-node/ws-emitter.js'
 import mongo from '#mongo'
 
-const updateProgress = async (datasetId: string, task: string, progress: number, step?: string) => {
-  const taskProgress: { task: string, progress: number, step?: string } = { task, progress }
+const updateProgress = async (datasetId: string, task: string, progress: number, step?: string, count?: number) => {
+  const taskProgress: { task: string, progress: number, step?: string, count?: number } = { task, progress }
   if (step) taskProgress.step = step
+  if (count !== undefined) taskProgress.count = count
   await wsEmitter.emit('datasets/' + datasetId + '/task-progress', taskProgress)
   await mongo.db.collection('journals').updateOne({ type: 'dataset', id: datasetId }, { $set: { taskProgress } })
 }
@@ -27,15 +28,17 @@ export default (datasetId: string, task: string, nbSteps?: number, progressCallb
     async start () {
       await updateProgress(datasetId, task, -1)
     },
-    // switch back to an indeterminate bar labelled with a named sub-step: the work that
-    // happens once the data stream is fully consumed (index refresh, alias switch, ...) has
-    // no measurable progress, and leaving the bar frozen at its last percentage makes the
-    // task look stuck for what can be minutes on a large dataset
-    async step (step: string) {
+    // switch to an indeterminate bar labelled with a named sub-step, optionally carrying a
+    // running count of units done. Used for the phases with no honest percentage to show:
+    // the tail of a task (index refresh, alias switch) and the indexing itself, whose total
+    // is unknown while it runs. Repeated calls for the same step are throttled like inc().
+    async step (step: string, count?: number) {
+      const time = new Date().getTime()
+      if (step === currentStep && (time - lastTime) < 250) return
       currentStep = step
       lastProgress = -1
-      lastTime = new Date().getTime()
-      await updateProgress(datasetId, task, -1, step)
+      lastTime = time
+      await updateProgress(datasetId, task, -1, step, count)
     },
     async inc (inc = 1) {
       if (nbSteps === undefined) throw new Error('incrementing progress requires setting nbSteps')

--- a/api/src/datasets/utils/task-progress.ts
+++ b/api/src/datasets/utils/task-progress.ts
@@ -1,9 +1,11 @@
 import * as wsEmitter from '@data-fair/lib-node/ws-emitter.js'
 import mongo from '#mongo'
 
-const updateProgress = async (datasetId: string, task: string, progress: number) => {
-  await wsEmitter.emit('datasets/' + datasetId + '/task-progress', { task, progress })
-  await mongo.db.collection('journals').updateOne({ type: 'dataset', id: datasetId }, { $set: { taskProgress: { task, progress } } })
+const updateProgress = async (datasetId: string, task: string, progress: number, step?: string) => {
+  const taskProgress: { task: string, progress: number, step?: string } = { task, progress }
+  if (step) taskProgress.step = step
+  await wsEmitter.emit('datasets/' + datasetId + '/task-progress', taskProgress)
+  await mongo.db.collection('journals').updateOne({ type: 'dataset', id: datasetId }, { $set: { taskProgress } })
 }
 
 // a failed task keeps its taskProgress (with error flag) so that the UI can show which task
@@ -15,24 +17,44 @@ export const clearTaskProgress = async (datasetId: string) => {
 }
 
 export default (datasetId: string, task: string, nbSteps?: number, progressCallback?: (progress: number) => void) => {
-  let step = 0
+  let doneSteps = 0
   let lastProgress = -1
   let lastTime = new Date().getTime() - 1000
+  // name of the current sub-step, only set for the phases that are not covered by inc()
+  let currentStep: string | undefined
 
   return {
     async start () {
       await updateProgress(datasetId, task, -1)
     },
+    // switch back to an indeterminate bar labelled with a named sub-step: the work that
+    // happens once the data stream is fully consumed (index refresh, alias switch, ...) has
+    // no measurable progress, and leaving the bar frozen at its last percentage makes the
+    // task look stuck for what can be minutes on a large dataset
+    async step (step: string) {
+      currentStep = step
+      lastProgress = -1
+      lastTime = new Date().getTime()
+      await updateProgress(datasetId, task, -1, step)
+    },
     async inc (inc = 1) {
       if (nbSteps === undefined) throw new Error('incrementing progress requires setting nbSteps')
-      step += inc
-      const progress = Math.min(Math.floor((step / nbSteps) * 100), 100)
+      doneSteps += inc
+      // the epsilon absorbs the float drift accumulated by summing fractional incs (both
+      // stream callers divide: 100/count per REST line, chunk/size per file byte range).
+      // The final sum lands on 99.999999999998 about as often as on 100.000000000002, and
+      // a bare floor() would turn a fully consumed stream into a permanent 99%.
+      const progress = Math.min(Math.floor((doneSteps / nbSteps) * 100 + 1e-9), 100)
       const time = new Date().getTime()
       if (progressCallback && progress > lastProgress) {
         progressCallback(progress)
       }
-      // send message on websocket at least every 250ms or on every percent change
-      if ((time - lastTime) < 250) return
+      // send message on websocket at least every 250ms or on every percent change, except
+      // for the terminal 100% which must never be throttled away: the last inc of a stream
+      // almost always lands less than 250ms after the previous one, and none of the progress
+      // instances created inside the workers calls end() (only the outer one in workers/index.ts
+      // does, once the whole task is over), so there is nothing to write the 100 afterwards.
+      if (progress !== 100 && (time - lastTime) < 250) return
       // send message on websocket at least every 30s or on every percent change
       if (progress > lastProgress || (time - lastTime) > 30000) {
         lastProgress = progress
@@ -42,7 +64,8 @@ export default (datasetId: string, task: string, nbSteps?: number, progressCallb
     },
     async end (error = false, finalTask = false) {
       if (error) {
-        const taskProgress = { task, progress: lastProgress, error }
+        // keep the step so the UI shows which phase of the task actually failed
+        const taskProgress = { task, progress: lastProgress, error, ...(currentStep ? { step: currentStep } : {}) }
         await wsEmitter.emit('datasets/' + datasetId + '/task-progress', taskProgress)
         await mongo.db.collection('journals').updateOne({ type: 'dataset', id: datasetId }, { $set: { taskProgress } })
       } else if (task === 'finalize' || finalTask) {

--- a/api/src/datasets/utils/task-progress.ts
+++ b/api/src/datasets/utils/task-progress.ts
@@ -29,12 +29,8 @@ export default (datasetId: string, task: string, nbSteps?: number, progressCallb
     async start () {
       await updateProgress(datasetId, task, -1)
     },
-    // switch the bar to a named sub-step, optionally carrying a running count of units done
-    // and a percentage. Without a percent the bar is indeterminate: the phases with no honest
-    // percentage to show (index refresh, alias switch, and the indexing itself when its total
-    // line count is unknown). With a percent the bar is determinate: the indexing when the
-    // total IS known (REST collection count, re-index of unchanged data). Repeated calls for
-    // the same step are throttled like inc(); a step change is never throttled.
+    // switch the bar to a named sub-step, optionally with a running count and a percentage
+    // (indeterminate without one). Same-step repeats are throttled, a step change never is.
     async step (step: string, count?: number, percent?: number) {
       const time = new Date().getTime()
       if (step === currentStep && (time - lastTime) < 250) return
@@ -54,20 +50,16 @@ export default (datasetId: string, task: string, nbSteps?: number, progressCallb
     async inc (inc = 1) {
       if (nbSteps === undefined) throw new Error('incrementing progress requires setting nbSteps')
       doneSteps += inc
-      // the epsilon absorbs the float drift accumulated by summing fractional incs (both
-      // stream callers divide: 100/count per REST line, chunk/size per file byte range).
-      // The final sum lands on 99.999999999998 about as often as on 100.000000000002, and
-      // a bare floor() would turn a fully consumed stream into a permanent 99%.
+      // the epsilon absorbs the float drift of summing fractional incs, which lands just
+      // below 100 half the time — a bare floor() would leave a consumed stream at 99%
       const progress = Math.min(Math.floor((doneSteps / nbSteps) * 100 + 1e-9), 100)
       const time = new Date().getTime()
       if (progressCallback && progress > lastProgress) {
         progressCallback(progress)
       }
-      // send message on websocket at least every 250ms or on every percent change, except
-      // for the terminal 100% which must never be throttled away: the last inc of a stream
-      // almost always lands less than 250ms after the previous one, and none of the progress
-      // instances created inside the workers calls end() (only the outer one in workers/index.ts
-      // does, once the whole task is over), so there is nothing to write the 100 afterwards.
+      // send message on websocket at least every 250ms, except the terminal 100% which must
+      // never be throttled away: the last tick of a stream lands inside the window and no
+      // worker-created instance calls end() to rewrite it afterwards
       if (progress !== 100 && (time - lastTime) < 250) return
       // send message on websocket at least every 30s or on every percent change
       if (progress > lastProgress || (time - lastTime) > 30000) {
@@ -78,8 +70,7 @@ export default (datasetId: string, task: string, nbSteps?: number, progressCallb
     },
     async end (error = false, finalTask = false) {
       if (error) {
-        // keep the step (and its count) so the UI shows which phase of the task actually
-        // failed and how far it got
+        // keep the step and count so the UI shows which phase failed and how far it got
         const taskProgress = { task, progress: lastProgress, error, ...(currentStep ? { step: currentStep } : {}), ...(currentCount !== undefined ? { count: currentCount } : {}) }
         await wsEmitter.emit('datasets/' + datasetId + '/task-progress', taskProgress)
         await mongo.db.collection('journals').updateOne({ type: 'dataset', id: datasetId }, { $set: { taskProgress } })

--- a/api/src/workers/batch-processor/index-lines.ts
+++ b/api/src/workers/batch-processor/index-lines.ts
@@ -89,14 +89,26 @@ export default async function (dataset: DatasetInternal) {
     debug(`Initialize new dataset index ${indexName}`)
   }
 
-  // the callback only runs while the stream is being consumed, well after indexStream is assigned
-  const progress = taskProgress(dataset.id, eventsPrefix, 100, (progress) => {
-    debugHeap('progress ' + progress, indexStream)
-  })
+  const progress = taskProgress(dataset.id, eventsPrefix)
+
+  // This task reports documents indexed, not a percentage. A percentage needs a total, and the
+  // line count is unknown while indexing runs: `dataset.count` is written by this very task and
+  // `analyze` only samples the file. The source-bytes ratio that used to stand in for it is not
+  // a measure of the work — the reader runs far ahead of the indexer whenever the source fits in
+  // the pipeline buffers (measured on a 737KB / 6k lines csv: all 12 read chunks land, and the
+  // bar reached 100%, before the first of the 13 bulks was acknowledged), so the bar showed a
+  // completed task while the whole of the real indexing was still ahead.
+  const indexProgress = {
+    step: (step: string, count?: number) => progress.step(step, count),
+    acknowledged: async (nbAcknowledged: number) => {
+      debugHeap('indexed ' + nbAcknowledged, indexStream)
+      await progress.step('indexing', nbAcknowledged)
+    }
+  }
 
   // only the REST path consumes the re-emitted lines (markIndexedStream); for file
   // datasets the sink is a no-op, so skip the per-line copy on the readable side
-  const indexStream = getIndexStream({ indexName, dataset, attachments: !!attachmentsProperty, reemit: isRestDataset(dataset), progress })
+  const indexStream = getIndexStream({ indexName, dataset, attachments: !!attachmentsProperty, reemit: isRestDataset(dataset), progress: indexProgress })
 
   if (!dataset.extensions || dataset.extensions.filter(e => e.active).length === 0) {
     if (dataset.file && await filesStorage.fileExists(datasetUtils.fullFilePath(dataset))) {
@@ -108,15 +120,15 @@ export default async function (dataset: DatasetInternal) {
 
   debug('Run index stream')
   let readStreams, writeStream
-  await progress.inc(0)
+  await progress.step('indexing', 0)
   debugHeap('before-stream')
   if (isRestDataset(dataset)) {
-    readStreams = await restDatasetsUtils.readStreams(dataset, partialUpdate ? { _needsIndexing: true } : {}, progress)
+    readStreams = await restDatasetsUtils.readStreams(dataset, partialUpdate ? { _needsIndexing: true } : {})
     writeStream = restDatasetsUtils.markIndexedStream(dataset)
   } else {
     const extended = dataset.extensions && dataset.extensions.some(e => e.active)
     if (!extended) await filesStorage.removeFile(datasetUtils.fullFilePath(dataset))
-    readStreams = await getReadStreams(dataset, false, extended, dataset.validateDraft, progress)
+    readStreams = await getReadStreams(dataset, false, extended, dataset.validateDraft)
     writeStream = new Writable({ objectMode: true, write (chunk, encoding, cb) { cb() } })
   }
   await pump(...readStreams, indexStream, writeStream)

--- a/api/src/workers/batch-processor/index-lines.ts
+++ b/api/src/workers/batch-processor/index-lines.ts
@@ -89,9 +89,14 @@ export default async function (dataset: DatasetInternal) {
     debug(`Initialize new dataset index ${indexName}`)
   }
 
+  // the callback only runs while the stream is being consumed, well after indexStream is assigned
+  const progress = taskProgress(dataset.id, eventsPrefix, 100, (progress) => {
+    debugHeap('progress ' + progress, indexStream)
+  })
+
   // only the REST path consumes the re-emitted lines (markIndexedStream); for file
   // datasets the sink is a no-op, so skip the per-line copy on the readable side
-  const indexStream = getIndexStream({ indexName, dataset, attachments: !!attachmentsProperty, reemit: isRestDataset(dataset) })
+  const indexStream = getIndexStream({ indexName, dataset, attachments: !!attachmentsProperty, reemit: isRestDataset(dataset), progress })
 
   if (!dataset.extensions || dataset.extensions.filter(e => e.active).length === 0) {
     if (dataset.file && await filesStorage.fileExists(datasetUtils.fullFilePath(dataset))) {
@@ -103,9 +108,6 @@ export default async function (dataset: DatasetInternal) {
 
   debug('Run index stream')
   let readStreams, writeStream
-  const progress = taskProgress(dataset.id, eventsPrefix, 100, (progress) => {
-    debugHeap('progress ' + progress, indexStream)
-  })
   await progress.inc(0)
   debugHeap('before-stream')
   if (isRestDataset(dataset)) {
@@ -149,6 +151,7 @@ export default async function (dataset: DatasetInternal) {
       const writer = new DiagnosticWriter(dataset)
       let unicityErrorCount = 0
       if (uniqueConstraints.length) {
+        await progress.step('checkConstraints')
         await esClient.client.indices.refresh({ index: indexName })
         for (const constraint of uniqueConstraints) {
           const remaining = DIAGNOSTIC_FILE_CAP - unicityErrorCount
@@ -223,6 +226,7 @@ export default async function (dataset: DatasetInternal) {
     // only in this branch: a partial REST update reuses the index, whose stamp must not change
     result._indexShape = NEW_INDEX_SHAPE
     debug('Switch alias to point to new datasets index')
+    await progress.step('switchAlias')
     await switchAlias(dataset, indexName)
     result.count = indexStream.i
   }

--- a/api/src/workers/batch-processor/index-lines.ts
+++ b/api/src/workers/batch-processor/index-lines.ts
@@ -95,13 +95,13 @@ export default async function (dataset: DatasetInternal) {
   }
 
   // The bar is driven by the documents ES acknowledged, the only faithful measure of the work:
-  // the source-bytes ratio that used to drive it is not one — the reader runs far ahead of the
-  // indexer whenever the source fits in the pipeline buffers (measured on a 737KB / 6k lines
-  // csv: all 12 read chunks land, and the bar reached 100%, before the first of the 13 bulks
-  // was acknowledged). A percentage also needs a total, exact without an extra read pass in
-  // two cases only: a REST dataset counts its mongo collection, and a re-index of unchanged
-  // data (config change on an already finalized dataset) reuses the count written by the
-  // previous run — `dataUpdatedAt` only moves when a new file or attachment is loaded.
+  // the reader runs far ahead of the indexer whenever the source fits in the pipeline buffers,
+  // so the source-bytes ratio that used to drive it is not one (measured — see
+  // docs/architecture/dataset-processing.md). A percentage also needs a total, exact without
+  // an extra read pass in two cases only: a REST dataset counts its mongo collection, and a
+  // re-index of unchanged data (config change on an already finalized dataset) reuses the
+  // count written by the previous run — `dataUpdatedAt` only moves when a new file or
+  // attachment is loaded.
   let totalLines: number | undefined
   if (isRestDataset(dataset)) {
     totalLines = await restDatasetsUtils.count(dataset, partialUpdate ? { _needsIndexing: true } : {})

--- a/api/src/workers/batch-processor/index-lines.ts
+++ b/api/src/workers/batch-processor/index-lines.ts
@@ -49,8 +49,7 @@ export default async function (dataset: DatasetInternal) {
   const partialUpdate = dataset._partialRestStatus === 'updated' || dataset._partialRestStatus === 'extended'
 
   const progress = taskProgress(dataset.id, eventsPrefix)
-  // the outer worker already published an unnamed indeterminate bar for this task; name the
-  // phase that prepares the index (attachments sync, index creation) before the stream starts
+  // name the phase preparing the index (attachments sync, index creation)
   await progress.step('start')
 
   const attachmentsProperty = dataset.schema?.find(f => f['x-refersTo'] === 'http://schema.org/DigitalDocument')
@@ -94,27 +93,17 @@ export default async function (dataset: DatasetInternal) {
     debug(`Initialize new dataset index ${indexName}`)
   }
 
-  // The bar is driven by the documents ES acknowledged, the only faithful measure of the work:
-  // the reader runs far ahead of the indexer whenever the source fits in the pipeline buffers,
-  // so the source-bytes ratio that used to drive it is not one (measured — see
-  // docs/architecture/dataset-processing.md). A percentage also needs a total, exact without
-  // an extra read pass in two cases only: a REST dataset counts its mongo collection, and a
-  // re-index of unchanged data (config change on an already finalized dataset) reuses the
-  // count written by the previous run — `dataUpdatedAt` only moves when a new file or
-  // attachment is loaded.
+  // the bar is driven by the documents ES acknowledged, not the source-bytes ratio (the reader
+  // runs far ahead of the indexer, see docs/architecture/dataset-processing.md). An exact total
+  // is only known here for a REST dataset and for a re-index of unchanged data.
   let totalLines: number | undefined
   if (isRestDataset(dataset)) {
     totalLines = await restDatasetsUtils.count(dataset, partialUpdate ? { _needsIndexing: true } : {})
   } else if (!dataset.draftReason && dataset.count !== undefined && dataset.dataUpdatedAt && dataset.finalizedAt && dataset.dataUpdatedAt <= dataset.finalizedAt) {
     totalLines = dataset.count
   }
-  // A first indexing of a file has no exact total, but the reader position gives a good
-  // estimate: lines parsed so far / fraction of source bytes consumed. Both are measured at
-  // the reader, so the pipeline buffering that made the source ratio dishonest as a direct
-  // percentage only makes the estimated total slightly low (bounded by the objectMode
-  // buffers), and it converges to the exact count once the source is fully read — which
-  // happens early precisely in the buffered case. Only skipped when the draft limit truncates
-  // the parse (the reader then consumes bytes the parser never turns into lines).
+  // a first file indexing has no exact total: estimate it at the reader position (lines parsed
+  // so far / fraction of source bytes consumed), unless the draft limit truncates the parse
   const estimateTotal = totalLines === undefined && !isRestDataset(dataset) && (!dataset.draftReason || dataset.validateDraft)
   let sourceBytesRatio = 0
   const indexProgress = {

--- a/api/src/workers/batch-processor/index-lines.ts
+++ b/api/src/workers/batch-processor/index-lines.ts
@@ -98,23 +98,38 @@ export default async function (dataset: DatasetInternal) {
   // the source-bytes ratio that used to drive it is not one — the reader runs far ahead of the
   // indexer whenever the source fits in the pipeline buffers (measured on a 737KB / 6k lines
   // csv: all 12 read chunks land, and the bar reached 100%, before the first of the 13 bulks
-  // was acknowledged). A percentage also needs a total, knowable without an extra read pass in
+  // was acknowledged). A percentage also needs a total, exact without an extra read pass in
   // two cases only: a REST dataset counts its mongo collection, and a re-index of unchanged
   // data (config change on an already finalized dataset) reuses the count written by the
-  // previous run — `dataUpdatedAt` only moves when a new file or attachment is loaded. A first
-  // indexing of a file has no honest total (extrapolating one from the source ratio inherits
-  // the buffering bias above) and keeps an indeterminate bar carrying the acknowledged count.
+  // previous run — `dataUpdatedAt` only moves when a new file or attachment is loaded.
   let totalLines: number | undefined
   if (isRestDataset(dataset)) {
     totalLines = await restDatasetsUtils.count(dataset, partialUpdate ? { _needsIndexing: true } : {})
   } else if (!dataset.draftReason && dataset.count !== undefined && dataset.dataUpdatedAt && dataset.finalizedAt && dataset.dataUpdatedAt <= dataset.finalizedAt) {
     totalLines = dataset.count
   }
+  // A first indexing of a file has no exact total, but the reader position gives a good
+  // estimate: lines parsed so far / fraction of source bytes consumed. Both are measured at
+  // the reader, so the pipeline buffering that made the source ratio dishonest as a direct
+  // percentage only makes the estimated total slightly low (bounded by the objectMode
+  // buffers), and it converges to the exact count once the source is fully read — which
+  // happens early precisely in the buffered case. Only skipped when the draft limit truncates
+  // the parse (the reader then consumes bytes the parser never turns into lines).
+  const estimateTotal = totalLines === undefined && !isRestDataset(dataset) && (!dataset.draftReason || dataset.validateDraft)
+  let sourceBytesRatio = 0
   const indexProgress = {
     step: (step: string, count?: number) => progress.step(step, count),
     acknowledged: async (nbAcknowledged: number) => {
       debugHeap('indexed ' + nbAcknowledged, indexStream)
-      await progress.step('indexing', nbAcknowledged, totalLines ? (nbAcknowledged / totalLines) * 100 : undefined)
+      let percent: number | undefined
+      if (totalLines) {
+        percent = (nbAcknowledged / totalLines) * 100
+      } else if (estimateTotal && sourceBytesRatio > 0 && indexStream.i > 0) {
+        const estimatedTotal = Math.max(indexStream.i / Math.min(sourceBytesRatio, 1), nbAcknowledged, 1)
+        // capped at 99: the estimate is not a claim, only the exact totals may show 100
+        percent = Math.min((nbAcknowledged / estimatedTotal) * 100, 99)
+      }
+      await progress.step('indexing', nbAcknowledged, percent)
     }
   }
 
@@ -132,7 +147,7 @@ export default async function (dataset: DatasetInternal) {
 
   debug('Run index stream')
   let readStreams, writeStream
-  await progress.step('indexing', 0, totalLines ? 0 : undefined)
+  await progress.step('indexing', 0, (totalLines !== undefined || estimateTotal) ? 0 : undefined)
   debugHeap('before-stream')
   if (isRestDataset(dataset)) {
     readStreams = await restDatasetsUtils.readStreams(dataset, partialUpdate ? { _needsIndexing: true } : {})
@@ -140,7 +155,7 @@ export default async function (dataset: DatasetInternal) {
   } else {
     const extended = dataset.extensions && dataset.extensions.some(e => e.active)
     if (!extended) await filesStorage.removeFile(datasetUtils.fullFilePath(dataset))
-    readStreams = await getReadStreams(dataset, false, extended, dataset.validateDraft)
+    readStreams = await getReadStreams(dataset, false, extended, dataset.validateDraft, estimateTotal ? { inc: (i) => { sourceBytesRatio += i / 100 } } : undefined)
     writeStream = new Writable({ objectMode: true, write (chunk, encoding, cb) { cb() } })
   }
   await pump(...readStreams, indexStream, writeStream)

--- a/api/src/workers/batch-processor/index-lines.ts
+++ b/api/src/workers/batch-processor/index-lines.ts
@@ -48,6 +48,11 @@ export default async function (dataset: DatasetInternal) {
 
   const partialUpdate = dataset._partialRestStatus === 'updated' || dataset._partialRestStatus === 'extended'
 
+  const progress = taskProgress(dataset.id, eventsPrefix)
+  // the outer worker already published an unnamed indeterminate bar for this task; name the
+  // phase that prepares the index (attachments sync, index creation) before the stream starts
+  await progress.step('start')
+
   const attachmentsProperty = dataset.schema?.find(f => f['x-refersTo'] === 'http://schema.org/DigitalDocument')
 
   const newRestAttachments = dataset._newRestAttachments
@@ -89,20 +94,27 @@ export default async function (dataset: DatasetInternal) {
     debug(`Initialize new dataset index ${indexName}`)
   }
 
-  const progress = taskProgress(dataset.id, eventsPrefix)
-
-  // This task reports documents indexed, not a percentage. A percentage needs a total, and the
-  // line count is unknown while indexing runs: `dataset.count` is written by this very task and
-  // `analyze` only samples the file. The source-bytes ratio that used to stand in for it is not
-  // a measure of the work — the reader runs far ahead of the indexer whenever the source fits in
-  // the pipeline buffers (measured on a 737KB / 6k lines csv: all 12 read chunks land, and the
-  // bar reached 100%, before the first of the 13 bulks was acknowledged), so the bar showed a
-  // completed task while the whole of the real indexing was still ahead.
+  // The bar is driven by the documents ES acknowledged, the only faithful measure of the work:
+  // the source-bytes ratio that used to drive it is not one — the reader runs far ahead of the
+  // indexer whenever the source fits in the pipeline buffers (measured on a 737KB / 6k lines
+  // csv: all 12 read chunks land, and the bar reached 100%, before the first of the 13 bulks
+  // was acknowledged). A percentage also needs a total, knowable without an extra read pass in
+  // two cases only: a REST dataset counts its mongo collection, and a re-index of unchanged
+  // data (config change on an already finalized dataset) reuses the count written by the
+  // previous run — `dataUpdatedAt` only moves when a new file or attachment is loaded. A first
+  // indexing of a file has no honest total (extrapolating one from the source ratio inherits
+  // the buffering bias above) and keeps an indeterminate bar carrying the acknowledged count.
+  let totalLines: number | undefined
+  if (isRestDataset(dataset)) {
+    totalLines = await restDatasetsUtils.count(dataset, partialUpdate ? { _needsIndexing: true } : {})
+  } else if (!dataset.draftReason && dataset.count !== undefined && dataset.dataUpdatedAt && dataset.finalizedAt && dataset.dataUpdatedAt <= dataset.finalizedAt) {
+    totalLines = dataset.count
+  }
   const indexProgress = {
     step: (step: string, count?: number) => progress.step(step, count),
     acknowledged: async (nbAcknowledged: number) => {
       debugHeap('indexed ' + nbAcknowledged, indexStream)
-      await progress.step('indexing', nbAcknowledged)
+      await progress.step('indexing', nbAcknowledged, totalLines ? (nbAcknowledged / totalLines) * 100 : undefined)
     }
   }
 
@@ -120,7 +132,7 @@ export default async function (dataset: DatasetInternal) {
 
   debug('Run index stream')
   let readStreams, writeStream
-  await progress.step('indexing', 0)
+  await progress.step('indexing', 0, totalLines ? 0 : undefined)
   debugHeap('before-stream')
   if (isRestDataset(dataset)) {
     readStreams = await restDatasetsUtils.readStreams(dataset, partialUpdate ? { _needsIndexing: true } : {})

--- a/docs/architecture/dataset-processing.md
+++ b/docs/architecture/dataset-processing.md
@@ -139,20 +139,29 @@ loader (`GET /datasets/{id}/task-progress`, shown in the right-hand navigation, 
 and the journal view).
 
 - State lives in a single `taskProgress` field on the dataset's `journals` document
-  (`{ task, progress, step?, error? }`) — one per dataset, shared between draft and published
-  processing. Every update is also pushed on the `datasets/{id}/task-progress` websocket
-  channel (`api/src/datasets/utils/task-progress.ts`).
+  (`{ task, progress, step?, count?, error? }`) — one per dataset, shared between draft and
+  published processing. Every update is also pushed on the `datasets/{id}/task-progress`
+  websocket channel (`api/src/datasets/utils/task-progress.ts`).
 - `progress` is `-1` (indeterminate) right after a task starts, then a 0-100 percentage,
   throttled to at most one write per 250ms. The terminal `100` is exempt from that throttle:
   the last `inc()` of a stream almost always lands inside the window, and no instance created
   inside a worker calls `end()` to rewrite it afterwards. `inc()` also rounds with an epsilon,
   because both stream callers feed it fractional increments (`100/count` per REST line,
   `chunk/size` per file byte range) whose sum drifts just below 100 half the time.
-- `step` names a sub-phase that has no measurable progress and puts the bar back to `-1`
-  (indeterminate) while keeping the task named. It covers the tail of `index`, which the read
-  progress does not describe at all: `refresh` (the ES index refresh, in `index-stream.ts`),
-  `checkConstraints` (the unicity gate) and `switchAlias`. The UI renders the translated step
-  in place of the percentage (`steps.*` in `dataset-task-progress.vue`).
+- `step` names a sub-phase that has no honest percentage to show and puts the bar back to `-1`
+  (indeterminate) while keeping the task named; `count` optionally carries a running number of
+  units done. Repeated calls for the same step are throttled like `inc()`, a step change never
+  is. The UI renders the translated step in place of the percentage (`steps.*` in
+  `dataset-task-progress.vue`, `{n}` interpolating `count`).
+- **`index` reports counts, not a percentage**, through the whole task: `indexing` (documents ES
+  has acknowledged), then `refresh` (the ES index refresh, in `index-stream.ts`),
+  `checkConstraints` (the unicity gate) and `switchAlias`. A percentage would need a total, and
+  the line count is unknown while the task runs — `dataset.count` is written by this very task
+  and `analyze` only samples the file. The source-bytes ratio that used to stand in for it does
+  not measure the work: the reader runs far ahead of the indexer whenever the source fits in the
+  pipeline buffers (measured on a 737KB / 6k lines csv, all 12 read chunks land before the first
+  of 13 bulks is acknowledged), so the bar sat at 100% for the whole of the real indexing.
+  Documents acknowledged by ES is the one faithful unit, and it needs no denominator.
 - On success a non-final task leaves `{ task, progress: 100 }`, immediately superseded when the
   next task starts. `finalize` — or any task flagged `finalTask`, such as the validate step of
   a draft cancelled by the worker itself — clears the field entirely.

--- a/docs/architecture/dataset-processing.md
+++ b/docs/architecture/dataset-processing.md
@@ -148,24 +148,32 @@ and the journal view).
   inside a worker calls `end()` to rewrite it afterwards. `inc()` also rounds with an epsilon,
   because both stream callers feed it fractional increments (`100/count` per REST line,
   `chunk/size` per file byte range) whose sum drifts just below 100 half the time.
-- `step` names a sub-phase that has no honest percentage to show and puts the bar back to `-1`
-  (indeterminate) while keeping the task named; `count` optionally carries a running number of
-  units done. Repeated calls for the same step are throttled like `inc()`, a step change never
-  is. The UI renders the translated step in place of the percentage (`steps.*` in
-  `dataset-task-progress.vue`, `{n}` interpolating `count`).
-- **`index` reports counts, not a percentage**, through the whole task: `indexing` (documents ES
-  has acknowledged), then `refresh` (the ES index refresh, in `index-stream.ts`),
-  `checkConstraints` (the unicity gate) and `switchAlias`. A percentage would need a total, and
-  the line count is unknown while the task runs — `dataset.count` is written by this very task
-  and `analyze` only samples the file. The source-bytes ratio that used to stand in for it does
-  not measure the work: the reader runs far ahead of the indexer whenever the source fits in the
-  pipeline buffers (measured on a 737KB / 6k lines csv, all 12 read chunks land before the first
-  of 13 bulks is acknowledged), so the bar sat at 100% for the whole of the real indexing.
-  Documents acknowledged by ES is the one faithful unit, and it needs no denominator.
+- `step` names a sub-phase while keeping the task named; `count` optionally carries a running
+  number of units done, and an optional percent makes the bar determinate (without one it goes
+  back to `-1`, indeterminate). A step percent is clamped monotone: the total can be a live
+  count and the bar must never recede. Repeated calls for the same step are throttled like
+  `inc()`, a step change never is. The UI label shows the percentage when determinate and the
+  translated step when one is set, both when applicable — "64% · 12 345 lignes indexées"
+  (`steps.*` in `dataset-task-progress.vue`, `{n}` interpolating `count`).
+- **`index` is driven by the documents ES acknowledged**, the one faithful measure of the work,
+  through the steps `start` (attachments sync, index creation), `indexing`, then `refresh` (the
+  ES index refresh, in `index-stream.ts`), `checkConstraints` (the unicity gate) and
+  `switchAlias`. The source-bytes ratio that used to drive the bar does not measure the work:
+  the reader runs far ahead of the indexer whenever the source fits in the pipeline buffers
+  (measured on a 737KB / 6k lines csv, all 12 read chunks land before the first of 13 bulks is
+  acknowledged), so the bar sat at 100% for the whole of the real indexing.
+- `indexing` shows a real percentage whenever the total is knowable without an extra read pass:
+  a REST dataset counts its mongo collection (`_needsIndexing` filter on partial updates), and
+  a re-index of unchanged data (config change on an already finalized dataset) reuses the
+  count written by the previous run — trusted because `dataUpdatedAt` only moves when a new
+  file or attachment is loaded. A **first** indexing of a file has no honest total
+  (`dataset.count` is written by this very task, `analyze` only samples the file, and
+  extrapolating a total from the source ratio inherits the buffering bias above): it keeps an
+  indeterminate bar carrying the acknowledged count.
 - On success a non-final task leaves `{ task, progress: 100 }`, immediately superseded when the
   next task starts. `finalize` — or any task flagged `finalTask`, such as the validate step of
   a draft cancelled by the worker itself — clears the field entirely.
-- **On failure the field is intentionally kept**, as `{ task, progress, step?, error: true }`: while
+- **On failure the field is intentionally kept**, as `{ task, progress, step?, count?, error: true }`: while
   the dataset sits in `error` status the UI shows which task failed (red bar) and how far it
   got. It is overwritten as soon as reprocessing starts (constraint dropped, new file
   uploaded, retry...).

--- a/docs/architecture/dataset-processing.md
+++ b/docs/architecture/dataset-processing.md
@@ -139,15 +139,24 @@ loader (`GET /datasets/{id}/task-progress`, shown in the right-hand navigation, 
 and the journal view).
 
 - State lives in a single `taskProgress` field on the dataset's `journals` document
-  (`{ task, progress, error? }`) — one per dataset, shared between draft and published
+  (`{ task, progress, step?, error? }`) — one per dataset, shared between draft and published
   processing. Every update is also pushed on the `datasets/{id}/task-progress` websocket
   channel (`api/src/datasets/utils/task-progress.ts`).
 - `progress` is `-1` (indeterminate) right after a task starts, then a 0-100 percentage,
-  throttled to at most one write per 250ms.
+  throttled to at most one write per 250ms. The terminal `100` is exempt from that throttle:
+  the last `inc()` of a stream almost always lands inside the window, and no instance created
+  inside a worker calls `end()` to rewrite it afterwards. `inc()` also rounds with an epsilon,
+  because both stream callers feed it fractional increments (`100/count` per REST line,
+  `chunk/size` per file byte range) whose sum drifts just below 100 half the time.
+- `step` names a sub-phase that has no measurable progress and puts the bar back to `-1`
+  (indeterminate) while keeping the task named. It covers the tail of `index`, which the read
+  progress does not describe at all: `refresh` (the ES index refresh, in `index-stream.ts`),
+  `checkConstraints` (the unicity gate) and `switchAlias`. The UI renders the translated step
+  in place of the percentage (`steps.*` in `dataset-task-progress.vue`).
 - On success a non-final task leaves `{ task, progress: 100 }`, immediately superseded when the
   next task starts. `finalize` — or any task flagged `finalTask`, such as the validate step of
   a draft cancelled by the worker itself — clears the field entirely.
-- **On failure the field is intentionally kept**, as `{ task, progress, error: true }`: while
+- **On failure the field is intentionally kept**, as `{ task, progress, step?, error: true }`: while
   the dataset sits in `error` status the UI shows which task failed (red bar) and how far it
   got. It is overwritten as soon as reprocessing starts (constraint dropped, new file
   uploaded, retry...).

--- a/docs/architecture/dataset-processing.md
+++ b/docs/architecture/dataset-processing.md
@@ -162,14 +162,17 @@ and the journal view).
   the reader runs far ahead of the indexer whenever the source fits in the pipeline buffers
   (measured on a 737KB / 6k lines csv, all 12 read chunks land before the first of 13 bulks is
   acknowledged), so the bar sat at 100% for the whole of the real indexing.
-- `indexing` shows a real percentage whenever the total is knowable without an extra read pass:
-  a REST dataset counts its mongo collection (`_needsIndexing` filter on partial updates), and
-  a re-index of unchanged data (config change on an already finalized dataset) reuses the
-  count written by the previous run — trusted because `dataUpdatedAt` only moves when a new
-  file or attachment is loaded. A **first** indexing of a file has no honest total
-  (`dataset.count` is written by this very task, `analyze` only samples the file, and
-  extrapolating a total from the source ratio inherits the buffering bias above): it keeps an
-  indeterminate bar carrying the acknowledged count.
+- `indexing` shows a real percentage whenever the total is exactly knowable without an extra
+  read pass: a REST dataset counts its mongo collection (`_needsIndexing` filter on partial
+  updates), and a re-index of unchanged data (config change on an already finalized dataset)
+  reuses the count written by the previous run — trusted because `dataUpdatedAt` only moves
+  when a new file or attachment is loaded. A **first** indexing of a file has no exact total
+  (`dataset.count` is written by this very task, `analyze` only samples the file) but still
+  shows an approximate percentage: the total is estimated at the reader position — lines
+  parsed so far divided by the fraction of source bytes consumed, both measured at the reader
+  so the buffering bias above only makes the estimate slightly low, and it converges to the
+  exact count once the source is fully read. The estimated percentage is capped at 99 (the
+  estimate is not a claim) and skipped only when the draft limit truncates the parse.
 - On success a non-final task leaves `{ task, progress: 100 }`, immediately superseded when the
   next task starts. `finalize` — or any task flagged `finalTask`, such as the validate step of
   a draft cancelled by the worker itself — clears the field entirely.

--- a/tests/features/datasets/index-progress.api.spec.ts
+++ b/tests/features/datasets/index-progress.api.spec.ts
@@ -11,8 +11,9 @@ const testUser1 = await axiosAuth('test_user1@test.com')
 // is exactly what the UI progress bar renders). The task reports the documents acknowledged
 // by ES, and a real percentage whenever the total is honestly knowable before the stream runs:
 // REST datasets count their mongo collection, a re-index of unchanged data reuses the count
-// written by the previous run. A first indexing of a file has no honest total (the reader
-// outruns ES by the whole pipeline buffering) and stays on an indeterminate bar.
+// written by the previous run. A first indexing of a file has no exact total but still shows
+// an approximate percentage, from a total estimated at the reader position (lines parsed so
+// far / fraction of source bytes consumed), capped at 99 because the estimate is not a claim.
 
 const log = { info: async () => {}, error: console.error, debug: () => {} }
 const ws = new WsClient({ url: wsUrl, log: log as any })
@@ -51,20 +52,30 @@ const uploadCsv = async (csv: string) => {
 test.describe('index task progress', () => {
   test.beforeEach(async () => { await clean() })
 
-  test('a first file indexing reports acknowledged documents on an indeterminate bar with named steps', async () => {
-    const csv = 'a,b\n' + Array.from({ length: 300 }, (_, i) => `v${i},${i}`).join('\n') + '\n'
+  test('a first file indexing reports an estimated percentage with named steps', async () => {
+    // large enough that the indexing spans several bulks and outlasts the 250ms publication
+    // throttle (so intermediate estimated percentages are observable), while staying under
+    // the 160KB defaultLimits.datasetStorage of the dev config
+    const csv = 'a,b\n' + Array.from({ length: 12000 }, (_, i) => `v${i},${i}`).join('\n') + '\n'
     const ds = await uploadCsv(csv)
     // subscribing right after the POST: the index task runs several tasks later, the
     // subscription (a websocket roundtrip) always beats it
     await ws.subscribe(`datasets/${ds.id}/task-progress`)
-    const messages = await collectUntilCleared(`datasets/${ds.id}/task-progress`)
+    const messages = await collectUntilCleared(`datasets/${ds.id}/task-progress`, 60000)
 
     const index = messages.filter(m => m.task === 'index')
     const indexing = index.filter(m => m.step === 'indexing')
     assert.ok(indexing.length >= 1, `expected indexing messages, got ${JSON.stringify(messages)}`)
     for (const m of indexing) {
-      assert.equal(m.progress, -1, `no honest percentage exists for a first file indexing, got ${JSON.stringify(m)}`)
       assert.equal(typeof m.count, 'number')
+    }
+    // the estimated total has no exact source, but it must still produce a moving determinate
+    // bar; it is capped at 99 (the estimate is not a claim) and never recedes
+    const percents = indexing.map(m => m.progress).filter(p => p !== -1)
+    assert.ok(percents.some(p => p > 0), `expected estimated percentages, got ${JSON.stringify(indexing)}`)
+    for (let i = 0; i < percents.length; i++) {
+      assert.ok(percents[i] >= 0 && percents[i] <= 99, `estimated percent out of range: ${JSON.stringify(percents)}`)
+      if (i > 0 && percents[i - 1] !== 0) assert.ok(percents[i] >= percents[i - 1], `receding bar: ${JSON.stringify(percents)}`)
     }
     const steps = index.map(m => m.step)
     for (const step of ['start', 'refresh', 'switchAlias']) {

--- a/tests/features/datasets/index-progress.api.spec.ts
+++ b/tests/features/datasets/index-progress.api.spec.ts
@@ -7,20 +7,15 @@ import { waitForFinalize } from '../../support/workers.ts'
 
 const testUser1 = await axiosAuth('test_user1@test.com')
 
-// The progress of the index task, as published on the task-progress websocket channel (which
-// is exactly what the UI progress bar renders). The task reports the documents acknowledged
-// by ES, and a real percentage whenever the total is honestly knowable before the stream runs:
-// REST datasets count their mongo collection, a re-index of unchanged data reuses the count
-// written by the previous run. A first indexing of a file has no exact total but still shows
-// an approximate percentage, from a total estimated at the reader position (lines parsed so
-// far / fraction of source bytes consumed), capped at 99 because the estimate is not a claim.
+// the progress of the index task, as published on the task-progress websocket channel —
+// exactly what the UI progress bar renders (see docs/architecture/dataset-processing.md)
 
 const log = { info: async () => {}, error: console.error, debug: () => {} }
 const ws = new WsClient({ url: wsUrl, log: log as any })
 test.afterAll(() => ws.close())
 
-// collect every message of the channel until the terminal clearTaskProgress (an empty object
-// published when the finalize task ends). Subscribe separately BEFORE triggering the work.
+// collect until the terminal clearTaskProgress (empty object published when finalize ends);
+// subscribe before triggering the work
 const collectUntilCleared = (channel: string, timeout = 30000): Promise<any[]> => {
   const messages: any[] = []
   return new Promise((resolve, reject) => {
@@ -53,13 +48,10 @@ test.describe('index task progress', () => {
   test.beforeEach(async () => { await clean() })
 
   test('a first file indexing reports an estimated percentage with named steps', async () => {
-    // large enough that the indexing spans several bulks and outlasts the 250ms publication
-    // throttle (so intermediate estimated percentages are observable), while staying under
-    // the 160KB defaultLimits.datasetStorage of the dev config
+    // spans several bulks and outlasts the 250ms throttle, under the 160KB dev storage limit
     const csv = 'a,b\n' + Array.from({ length: 12000 }, (_, i) => `v${i},${i}`).join('\n') + '\n'
     const ds = await uploadCsv(csv)
-    // subscribing right after the POST: the index task runs several tasks later, the
-    // subscription (a websocket roundtrip) always beats it
+    // the index task runs several tasks after the POST, the subscription always beats it
     await ws.subscribe(`datasets/${ds.id}/task-progress`)
     const messages = await collectUntilCleared(`datasets/${ds.id}/task-progress`, 60000)
 
@@ -69,8 +61,7 @@ test.describe('index task progress', () => {
     for (const m of indexing) {
       assert.equal(typeof m.count, 'number')
     }
-    // the estimated total has no exact source, but it must still produce a moving determinate
-    // bar; it is capped at 99 (the estimate is not a claim) and never recedes
+    // the estimated percentage must move, stay capped at 99 and never recede
     const percents = indexing.map(m => m.progress).filter(p => p !== -1)
     assert.ok(percents.some(p => p > 0), `expected estimated percentages, got ${JSON.stringify(indexing)}`)
     for (let i = 0; i < percents.length; i++) {
@@ -110,8 +101,7 @@ test.describe('index task progress', () => {
       title: 'idxprogrest',
       schema: [{ key: 'a', type: 'string' }]
     })).data
-    // the creation runs its own pipeline; wait for it so the collection below only sees the
-    // cycle triggered by the bulk write (REST tasks are quasi-synchronous: poll, don't listen)
+    // wait for the creation pipeline so we only collect the cycle triggered by the bulk write
     for (let i = 0; (await testUser1.get(`/api/v1/datasets/${ds.id}`)).data.status !== 'finalized'; i++) {
       if (i > 100) throw new Error('timeout waiting for REST dataset creation')
       await new Promise(resolve => setTimeout(resolve, 100))
@@ -119,8 +109,7 @@ test.describe('index task progress', () => {
 
     await ws.subscribe(`datasets/${ds.id}/task-progress`)
     const collected = collectUntilCleared(`datasets/${ds.id}/task-progress`)
-    // async=true forces the worker path: small bulks are otherwise indexed inline in the
-    // HTTP request (commitLines) without ever running the index task
+    // async=true forces the worker path, small bulks are otherwise indexed inline (commitLines)
     await testUser1.post(`/api/v1/datasets/${ds.id}/_bulk_lines`, Array.from({ length: 250 }, (_, i) => ({ a: 'line' + i })), { params: { async: 'true' } })
     const messages = await collected
 

--- a/tests/features/datasets/index-progress.api.spec.ts
+++ b/tests/features/datasets/index-progress.api.spec.ts
@@ -1,0 +1,125 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import FormData from 'form-data'
+import { WsClient } from '@data-fair/lib-node/ws-client.js'
+import { axiosAuth, clean, wsUrl } from '../../support/axios.ts'
+import { waitForFinalize } from '../../support/workers.ts'
+
+const testUser1 = await axiosAuth('test_user1@test.com')
+
+// The progress of the index task, as published on the task-progress websocket channel (which
+// is exactly what the UI progress bar renders). The task reports the documents acknowledged
+// by ES, and a real percentage whenever the total is honestly knowable before the stream runs:
+// REST datasets count their mongo collection, a re-index of unchanged data reuses the count
+// written by the previous run. A first indexing of a file has no honest total (the reader
+// outruns ES by the whole pipeline buffering) and stays on an indeterminate bar.
+
+const log = { info: async () => {}, error: console.error, debug: () => {} }
+const ws = new WsClient({ url: wsUrl, log: log as any })
+test.afterAll(() => ws.close())
+
+// collect every message of the channel until the terminal clearTaskProgress (an empty object
+// published when the finalize task ends). Subscribe separately BEFORE triggering the work.
+const collectUntilCleared = (channel: string, timeout = 30000): Promise<any[]> => {
+  const messages: any[] = []
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      ws.off('message', cb)
+      reject(new Error(`timeout collecting ${channel}, got ${JSON.stringify(messages)}`))
+    }, timeout)
+    const cb = (message: any) => {
+      if (message.channel !== channel || message.type !== 'message') return
+      messages.push(message.data)
+      if (!message.data?.task) {
+        clearTimeout(timer)
+        ws.off('message', cb)
+        resolve(messages)
+      }
+    }
+    ws.on('message', cb)
+  })
+}
+
+const uploadCsv = async (csv: string) => {
+  const form = new FormData()
+  form.append('file', Buffer.from(csv), 'data.csv')
+  return (await testUser1.post('/api/v1/datasets', form, {
+    headers: { 'Content-Length': form.getLengthSync(), ...form.getHeaders() }
+  })).data
+}
+
+test.describe('index task progress', () => {
+  test.beforeEach(async () => { await clean() })
+
+  test('a first file indexing reports acknowledged documents on an indeterminate bar with named steps', async () => {
+    const csv = 'a,b\n' + Array.from({ length: 300 }, (_, i) => `v${i},${i}`).join('\n') + '\n'
+    const ds = await uploadCsv(csv)
+    // subscribing right after the POST: the index task runs several tasks later, the
+    // subscription (a websocket roundtrip) always beats it
+    await ws.subscribe(`datasets/${ds.id}/task-progress`)
+    const messages = await collectUntilCleared(`datasets/${ds.id}/task-progress`)
+
+    const index = messages.filter(m => m.task === 'index')
+    const indexing = index.filter(m => m.step === 'indexing')
+    assert.ok(indexing.length >= 1, `expected indexing messages, got ${JSON.stringify(messages)}`)
+    for (const m of indexing) {
+      assert.equal(m.progress, -1, `no honest percentage exists for a first file indexing, got ${JSON.stringify(m)}`)
+      assert.equal(typeof m.count, 'number')
+    }
+    const steps = index.map(m => m.step)
+    for (const step of ['start', 'refresh', 'switchAlias']) {
+      assert.ok(steps.includes(step), `expected step ${step}, got ${JSON.stringify(steps)}`)
+    }
+  })
+
+  test('re-indexing unchanged data reports a real percentage from the previous count', async () => {
+    const csv = 'a,b\n' + Array.from({ length: 300 }, (_, i) => `v${i},${i}`).join('\n') + '\n'
+    const ds = await uploadCsv(csv)
+    await waitForFinalize(testUser1, ds.id)
+
+    // a constraints-only patch triggers a full re-index of the very same file
+    await ws.subscribe(`datasets/${ds.id}/task-progress`)
+    const collected = collectUntilCleared(`datasets/${ds.id}/task-progress`)
+    await testUser1.patch(`/api/v1/datasets/${ds.id}`, { constraints: [{ type: 'unique', properties: ['a'] }] })
+    const messages = await collected
+
+    const indexing = messages.filter(m => m.task === 'index' && m.step === 'indexing')
+    assert.ok(indexing.length >= 1, `expected indexing messages, got ${JSON.stringify(messages)}`)
+    const percents = indexing.map(m => m.progress).filter(p => p !== -1)
+    assert.ok(percents.length >= 1, `expected determinate percentages, got ${JSON.stringify(indexing)}`)
+    for (let i = 0; i < percents.length; i++) {
+      assert.ok(percents[i] >= 0 && percents[i] <= 100)
+      if (i > 0) assert.ok(percents[i] >= percents[i - 1], `receding bar: ${JSON.stringify(percents)}`)
+    }
+  })
+
+  test('indexing a REST dataset reports a real percentage from the collection count', async () => {
+    const ds = (await testUser1.post('/api/v1/datasets/idxprogrest', {
+      isRest: true,
+      title: 'idxprogrest',
+      schema: [{ key: 'a', type: 'string' }]
+    })).data
+    // the creation runs its own pipeline; wait for it so the collection below only sees the
+    // cycle triggered by the bulk write (REST tasks are quasi-synchronous: poll, don't listen)
+    for (let i = 0; (await testUser1.get(`/api/v1/datasets/${ds.id}`)).data.status !== 'finalized'; i++) {
+      if (i > 100) throw new Error('timeout waiting for REST dataset creation')
+      await new Promise(resolve => setTimeout(resolve, 100))
+    }
+
+    await ws.subscribe(`datasets/${ds.id}/task-progress`)
+    const collected = collectUntilCleared(`datasets/${ds.id}/task-progress`)
+    // async=true forces the worker path: small bulks are otherwise indexed inline in the
+    // HTTP request (commitLines) without ever running the index task
+    await testUser1.post(`/api/v1/datasets/${ds.id}/_bulk_lines`, Array.from({ length: 250 }, (_, i) => ({ a: 'line' + i })), { params: { async: 'true' } })
+    const messages = await collected
+
+    const indexing = messages.filter(m => m.task === 'index' && m.step === 'indexing')
+    assert.ok(indexing.length >= 1, `expected indexing messages, got ${JSON.stringify(messages)}`)
+    const percents = indexing.map(m => m.progress).filter(p => p !== -1)
+    assert.ok(percents.length >= 1, `expected determinate percentages, got ${JSON.stringify(indexing)}`)
+    for (let i = 0; i < percents.length; i++) {
+      assert.ok(percents[i] >= 0 && percents[i] <= 100)
+      if (i > 0) assert.ok(percents[i] >= percents[i - 1], `receding bar: ${JSON.stringify(percents)}`)
+    }
+  })
+})

--- a/tests/features/infra/task-progress.unit.spec.ts
+++ b/tests/features/infra/task-progress.unit.spec.ts
@@ -1,0 +1,103 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import path from 'node:path'
+
+// task-progress.ts imports `#mongo`, which loads (and validates) `#config`. The unit harness
+// doesn't set NODE_CONFIG_DIR, so point node-config at the real api/config dir and load the
+// modules by dynamic import afterwards — same pattern as lines-pipeline.unit.spec.ts.
+process.env.NODE_CONFIG_DIR ??= path.resolve(import.meta.dirname, '../../../api/config')
+
+// The progress bar of a dataset task is fed by inc() with FRACTIONAL increments: rest.ts sends
+// 100/count per line, data-streams.ts sends (chunk.length / size) * 100 per byte range. Two
+// independent defects used to leave a fully consumed stream displaying 99% forever:
+//  - the 250ms websocket throttle swallowed the very last tick (the one that reaches 100 lands
+//    microseconds after the previous one), and nothing rewrites the 100 afterwards because none
+//    of the progress instances created inside the workers ever calls end() — only the outer one
+//    in workers/index.ts does, once the whole task is already over
+//  - summing fractional incs drifts: the total lands on 99.999999999998 about as often as on
+//    100.000000000002, and a bare floor() turns the former into a permanent 99
+// These tests pin both, by recording what task-progress publishes on the websocket channel —
+// which is exactly what the UI progress bar renders.
+
+// task-progress writes to mongo and to the ws-messages queue; both are faked here. wsEmitter
+// keeps its collection in a module-level variable and init() is idempotent, hence the mutable
+// sink that each test resets rather than a fresh init per test.
+let sink: any[] = []
+const fakeDb = {
+  listCollections: () => ({ toArray: async () => [{ name: 'ws-messages' }] }),
+  collection: () => ({
+    insertOne: async (doc: any) => { if (doc.type === 'message') sink.push(doc.data) },
+    updateOne: async () => {}
+  })
+}
+
+const setup = async () => {
+  const wsEmitter = await import('@data-fair/lib-node/ws-emitter.js')
+  await wsEmitter.init(fakeDb as any)
+  const mongo = (await import('../../../api/src/mongo.ts')).default
+  ;(mongo as any).mongo = { db: fakeDb }
+  const taskProgress = (await import('../../../api/src/datasets/utils/task-progress.ts')).default
+  sink = []
+  return { taskProgress, published: () => sink as { task: string, progress: number, step?: string, error?: boolean }[] }
+}
+
+test.describe('task progress', () => {
+  test('reaches 100 even when the last tick lands inside the 250ms throttle window', async () => {
+    const { taskProgress, published } = await setup()
+    const progress = taskProgress('test-throttle', 'index', 100)
+    // 1000 incs back to back: everything after the first publication falls inside the 250ms
+    // throttle window, so 100 is the only other value allowed through
+    for (let i = 0; i < 1000; i++) await progress.inc(100 / 1000)
+    assert.equal(published().at(-1)?.progress, 100, `expected a final 100%, got ${JSON.stringify(published().at(-1))}`)
+  })
+
+  test('absorbs the float drift of fractional increments across stream shapes', async () => {
+    // REST lines: inc = 100/count. 1000 and 9973 are counts whose sum undershoots 100 in IEEE 754
+    for (const count of [3, 7, 1000, 9973, 100000]) {
+      const { taskProgress, published } = await setup()
+      const progress = taskProgress('test-drift-' + count, 'index', 100)
+      for (let i = 0; i < count; i++) await progress.inc(100 / count)
+      assert.equal(published().at(-1)?.progress, 100, `count=${count} should end at 100%, got ${JSON.stringify(published().at(-1))}`)
+    }
+
+    // file bytes: inc = (chunk / size) * 100, with an uneven trailing chunk
+    for (const size of [8978432, 65536000, 123456789]) {
+      const { taskProgress, published } = await setup()
+      const progress = taskProgress('test-drift-bytes-' + size, 'index', 100)
+      let read = 0
+      while (read < size) {
+        const chunk = Math.min(65536, size - read)
+        read += chunk
+        await progress.inc((chunk / size) * 100)
+      }
+      assert.equal(published().at(-1)?.progress, 100, `size=${size} should end at 100%, got ${JSON.stringify(published().at(-1))}`)
+    }
+  })
+
+  test('does not flood the websocket once 100 is reached', async () => {
+    const { taskProgress, published } = await setup()
+    const progress = taskProgress('test-flood', 'index', 100)
+    // 200 incs of 1 on a 100-step task: the bar tops out halfway and keeps being incremented
+    for (let i = 0; i < 200; i++) await progress.inc(1)
+    assert.equal(published().filter(p => p.progress === 100).length, 1)
+  })
+
+  test('step() hands the bar back to indeterminate with a named phase', async () => {
+    const { taskProgress, published } = await setup()
+    const progress = taskProgress('test-step', 'index', 100)
+    for (let i = 0; i < 1000; i++) await progress.inc(100 / 1000)
+    assert.equal(published().at(-1)?.progress, 100)
+
+    await progress.step('refresh')
+    assert.deepEqual(published().at(-1), { task: 'index', progress: -1, step: 'refresh' })
+  })
+
+  test('a failed task keeps the step so the UI shows which phase broke', async () => {
+    const { taskProgress, published } = await setup()
+    const progress = taskProgress('test-step-error', 'index', 100)
+    await progress.step('checkConstraints')
+    await progress.end(true)
+    assert.equal(published().at(-1)?.step, 'checkConstraints')
+    assert.equal(published().at(-1)?.error, true)
+  })
+})

--- a/tests/features/infra/task-progress.unit.spec.ts
+++ b/tests/features/infra/task-progress.unit.spec.ts
@@ -93,9 +93,9 @@ test.describe('task progress', () => {
   })
 
   test('step() carries a running count and throttles repeats of the same step', async () => {
-    // the index task has no honest percentage to show (the total line count is unknown while
-    // it runs) so it publishes the number of documents ES acknowledged instead; the counter
-    // fires once per bulk, which on a large dataset is far more often than the bar needs
+    // without a percent the bar is indeterminate and only carries the number of documents ES
+    // acknowledged; the counter fires once per bulk, which on a large dataset is far more
+    // often than the bar needs
     const { taskProgress, published } = await setup()
     const progress = taskProgress('test-count', 'index')
     for (let i = 1; i <= 500; i++) await progress.step('indexing', i * 10)

--- a/tests/features/infra/task-progress.unit.spec.ts
+++ b/tests/features/infra/task-progress.unit.spec.ts
@@ -116,4 +116,35 @@ test.describe('task progress', () => {
     assert.equal(published().at(-1)?.step, 'checkConstraints')
     assert.equal(published().at(-1)?.error, true)
   })
+
+  test('step() with a percent publishes a determinate bar carrying the count', async () => {
+    // the index task knows its total in two cases (REST collection count, re-index of
+    // unchanged data): it then publishes a real percentage alongside the acknowledged count
+    const { taskProgress, published } = await setup()
+    const progress = taskProgress('test-step-percent', 'index')
+    await progress.step('indexing', 500, 12.7)
+    assert.deepEqual(published().at(-1), { task: 'index', progress: 12, step: 'indexing', count: 500 })
+  })
+
+  test('a step percent never goes backwards and a step change resets the bar', async () => {
+    const { taskProgress, published } = await setup()
+    const progress = taskProgress('test-step-monotone', 'index')
+    await progress.step('indexing', 1000, 50)
+    assert.equal(published().at(-1)?.progress, 50)
+    // past the throttle window, a lower percent must not make the bar recede
+    await new Promise(resolve => setTimeout(resolve, 300))
+    await progress.step('indexing', 2000, 30)
+    assert.deepEqual(published().at(-1), { task: 'index', progress: 50, step: 'indexing', count: 2000 })
+    // a step change is never throttled and hands the bar back to indeterminate
+    await progress.step('refresh')
+    assert.deepEqual(published().at(-1), { task: 'index', progress: -1, step: 'refresh' })
+  })
+
+  test('a failed task keeps the percent and count of the step that broke', async () => {
+    const { taskProgress, published } = await setup()
+    const progress = taskProgress('test-step-percent-error', 'index')
+    await progress.step('indexing', 1000, 64)
+    await progress.end(true)
+    assert.deepEqual(published().at(-1), { task: 'index', progress: 64, error: true, step: 'indexing', count: 1000 })
+  })
 })

--- a/tests/features/infra/task-progress.unit.spec.ts
+++ b/tests/features/infra/task-progress.unit.spec.ts
@@ -92,6 +92,22 @@ test.describe('task progress', () => {
     assert.deepEqual(published().at(-1), { task: 'index', progress: -1, step: 'refresh' })
   })
 
+  test('step() carries a running count and throttles repeats of the same step', async () => {
+    // the index task has no honest percentage to show (the total line count is unknown while
+    // it runs) so it publishes the number of documents ES acknowledged instead; the counter
+    // fires once per bulk, which on a large dataset is far more often than the bar needs
+    const { taskProgress, published } = await setup()
+    const progress = taskProgress('test-count', 'index')
+    for (let i = 1; i <= 500; i++) await progress.step('indexing', i * 10)
+    const indexing = published().filter(p => p.step === 'indexing')
+    assert.equal(indexing.length, 1, `500 back-to-back calls must collapse to one, got ${indexing.length}`)
+    assert.deepEqual(indexing[0], { task: 'index', progress: -1, step: 'indexing', count: 10 })
+
+    // a different step is never throttled: phase changes must always be visible
+    await progress.step('refresh')
+    assert.deepEqual(published().at(-1), { task: 'index', progress: -1, step: 'refresh' })
+  })
+
   test('a failed task keeps the step so the UI shows which phase broke', async () => {
     const { taskProgress, published } = await setup()
     const progress = taskProgress('test-step-error', 'index', 100)

--- a/tests/features/infra/task-progress.unit.spec.ts
+++ b/tests/features/infra/task-progress.unit.spec.ts
@@ -2,26 +2,16 @@ import { test } from '@playwright/test'
 import assert from 'node:assert/strict'
 import path from 'node:path'
 
-// task-progress.ts imports `#mongo`, which loads (and validates) `#config`. The unit harness
-// doesn't set NODE_CONFIG_DIR, so point node-config at the real api/config dir and load the
-// modules by dynamic import afterwards — same pattern as lines-pipeline.unit.spec.ts.
+// point node-config at the real api/config dir before the dynamic imports below load #config
+// (same pattern as lines-pipeline.unit.spec.ts)
 process.env.NODE_CONFIG_DIR ??= path.resolve(import.meta.dirname, '../../../api/config')
 
-// The progress bar of a dataset task is fed by inc() with FRACTIONAL increments: rest.ts sends
-// 100/count per line, data-streams.ts sends (chunk.length / size) * 100 per byte range. Two
-// independent defects used to leave a fully consumed stream displaying 99% forever:
-//  - the 250ms websocket throttle swallowed the very last tick (the one that reaches 100 lands
-//    microseconds after the previous one), and nothing rewrites the 100 afterwards because none
-//    of the progress instances created inside the workers ever calls end() — only the outer one
-//    in workers/index.ts does, once the whole task is already over
-//  - summing fractional incs drifts: the total lands on 99.999999999998 about as often as on
-//    100.000000000002, and a bare floor() turns the former into a permanent 99
-// These tests pin both, by recording what task-progress publishes on the websocket channel —
-// which is exactly what the UI progress bar renders.
+// these tests pin the two defects that used to leave a consumed stream at 99% forever (the
+// throttled terminal tick and the float drift of fractional incs) by recording what is
+// published on the websocket channel — exactly what the UI progress bar renders
 
-// task-progress writes to mongo and to the ws-messages queue; both are faked here. wsEmitter
-// keeps its collection in a module-level variable and init() is idempotent, hence the mutable
-// sink that each test resets rather than a fresh init per test.
+// wsEmitter's init() is idempotent with a module-level collection, hence one mutable sink
+// reset by setup() rather than a fresh init per test
 let sink: any[] = []
 const fakeDb = {
   listCollections: () => ({ toArray: async () => [{ name: 'ws-messages' }] }),
@@ -45,8 +35,7 @@ test.describe('task progress', () => {
   test('reaches 100 even when the last tick lands inside the 250ms throttle window', async () => {
     const { taskProgress, published } = await setup()
     const progress = taskProgress('test-throttle', 'index', 100)
-    // 1000 incs back to back: everything after the first publication falls inside the 250ms
-    // throttle window, so 100 is the only other value allowed through
+    // back-to-back incs all land inside the throttle window: 100 is the only other value allowed through
     for (let i = 0; i < 1000; i++) await progress.inc(100 / 1000)
     assert.equal(published().at(-1)?.progress, 100, `expected a final 100%, got ${JSON.stringify(published().at(-1))}`)
   })
@@ -93,9 +82,7 @@ test.describe('task progress', () => {
   })
 
   test('step() carries a running count and throttles repeats of the same step', async () => {
-    // without a percent the bar is indeterminate and only carries the number of documents ES
-    // acknowledged; the counter fires once per bulk, which on a large dataset is far more
-    // often than the bar needs
+    // the counter fires once per bulk, far more often than the bar needs
     const { taskProgress, published } = await setup()
     const progress = taskProgress('test-count', 'index')
     for (let i = 1; i <= 500; i++) await progress.step('indexing', i * 10)
@@ -118,8 +105,6 @@ test.describe('task progress', () => {
   })
 
   test('step() with a percent publishes a determinate bar carrying the count', async () => {
-    // the index task knows its total in two cases (REST collection count, re-index of
-    // unchanged data): it then publishes a real percentage alongside the acknowledged count
     const { taskProgress, published } = await setup()
     const progress = taskProgress('test-step-percent', 'index')
     await progress.step('indexing', 500, 12.7)

--- a/ui/src/components/dataset/dataset-task-progress.vue
+++ b/ui/src/components/dataset/dataset-task-progress.vue
@@ -8,11 +8,20 @@
         :model-value="taskProgress.progress === -1 ? (taskProgress.error ? 100 : undefined) : taskProgress.progress"
         :indeterminate="taskProgress.progress === -1 && !taskProgress.error"
         :color="taskProgress.error ? 'error' : 'primary'"
-        :title="compact ? stepOrPercent : undefined"
         class="flex-grow-1"
         rounded
         height="6"
-      />
+      >
+        <!-- not a native title attribute: it changes on every publication, which resets the
+          browser tooltip timer so it never shows during an active task -->
+        <v-tooltip
+          v-if="compact && stepOrPercent"
+          activator="parent"
+          location="bottom"
+        >
+          {{ stepOrPercent }}
+        </v-tooltip>
+      </v-progress-linear>
       <span
         v-if="!compact && stepOrPercent"
         class="text-caption text-medium-emphasis ml-2 flex-shrink-0"
@@ -70,14 +79,14 @@ const props = defineProps<{
   compact?: boolean
 }>()
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 
 // label next to the bar: percentage when determinate, named step when set, both when applicable
 const stepOrPercent = computed(() => {
   if (!props.taskProgress) return null
   const parts: string[] = []
   if (props.taskProgress.progress !== -1) parts.push(`${props.taskProgress.progress}%`)
-  if (props.taskProgress.step) parts.push(t('steps.' + props.taskProgress.step, { n: (props.taskProgress.count ?? 0).toLocaleString() }))
+  if (props.taskProgress.step) parts.push(t('steps.' + props.taskProgress.step, { n: (props.taskProgress.count ?? 0).toLocaleString(locale.value) }))
   return parts.join(' · ') || null
 })
 </script>

--- a/ui/src/components/dataset/dataset-task-progress.vue
+++ b/ui/src/components/dataset/dataset-task-progress.vue
@@ -5,7 +5,7 @@
     </v-list-item-title>
     <div class="d-flex align-center mt-1">
       <v-progress-linear
-        :model-value="taskProgress.progress === -1 ? undefined : taskProgress.progress"
+        :model-value="taskProgress.progress === -1 ? (taskProgress.error ? 100 : undefined) : taskProgress.progress"
         :indeterminate="taskProgress.progress === -1 && !taskProgress.error"
         :color="taskProgress.error ? 'error' : 'primary'"
         :title="compact ? stepOrPercent : undefined"
@@ -37,6 +37,7 @@ fr:
     normalize: Conversion
     download: Téléchargement
   steps:
+    indexing: '{n} lignes indexées'
     refresh: rafraîchissement de l'index
     checkConstraints: vérification des contraintes
     switchAlias: bascule d'alias
@@ -53,6 +54,7 @@ en:
     normalize: Conversion
     download: Download
   steps:
+    indexing: '{n} rows indexed'
     refresh: index refresh
     checkConstraints: constraints check
     switchAlias: alias switch
@@ -70,7 +72,7 @@ const { t } = useI18n()
 
 // a named step replaces the percentage: the bar is indeterminate during these phases
 const stepOrPercent = computed(() => {
-  if (props.taskProgress?.step) return t('steps.' + props.taskProgress.step)
+  if (props.taskProgress?.step) return t('steps.' + props.taskProgress.step, { n: (props.taskProgress.count ?? 0).toLocaleString() })
   if (props.taskProgress && props.taskProgress.progress !== -1) return `${props.taskProgress.progress}%`
   return null
 })

--- a/ui/src/components/dataset/dataset-task-progress.vue
+++ b/ui/src/components/dataset/dataset-task-progress.vue
@@ -37,6 +37,7 @@ fr:
     normalize: Conversion
     download: Téléchargement
   steps:
+    start: démarrage de l'indexation
     indexing: '{n} lignes indexées'
     refresh: rafraîchissement de l'index
     checkConstraints: vérification des contraintes
@@ -54,6 +55,7 @@ en:
     normalize: Conversion
     download: Download
   steps:
+    start: indexing startup
     indexing: '{n} rows indexed'
     refresh: index refresh
     checkConstraints: constraints check
@@ -70,10 +72,13 @@ const props = defineProps<{
 
 const { t } = useI18n()
 
-// a named step replaces the percentage: the bar is indeterminate during these phases
+// the label next to the bar: the percentage when the bar is determinate, the named step when
+// one is set, both when indexing knows its total ("64% · 12 345 lignes indexées")
 const stepOrPercent = computed(() => {
-  if (props.taskProgress?.step) return t('steps.' + props.taskProgress.step, { n: (props.taskProgress.count ?? 0).toLocaleString() })
-  if (props.taskProgress && props.taskProgress.progress !== -1) return `${props.taskProgress.progress}%`
-  return null
+  if (!props.taskProgress) return null
+  const parts: string[] = []
+  if (props.taskProgress.progress !== -1) parts.push(`${props.taskProgress.progress}%`)
+  if (props.taskProgress.step) parts.push(t('steps.' + props.taskProgress.step, { n: (props.taskProgress.count ?? 0).toLocaleString() }))
+  return parts.join(' · ') || null
 })
 </script>

--- a/ui/src/components/dataset/dataset-task-progress.vue
+++ b/ui/src/components/dataset/dataset-task-progress.vue
@@ -72,8 +72,7 @@ const props = defineProps<{
 
 const { t } = useI18n()
 
-// the label next to the bar: the percentage when the bar is determinate, the named step when
-// one is set, both when indexing knows its total ("64% · 12 345 lignes indexées")
+// label next to the bar: percentage when determinate, named step when set, both when applicable
 const stepOrPercent = computed(() => {
   if (!props.taskProgress) return null
   const parts: string[] = []

--- a/ui/src/components/dataset/dataset-task-progress.vue
+++ b/ui/src/components/dataset/dataset-task-progress.vue
@@ -8,16 +8,16 @@
         :model-value="taskProgress.progress === -1 ? undefined : taskProgress.progress"
         :indeterminate="taskProgress.progress === -1 && !taskProgress.error"
         :color="taskProgress.error ? 'error' : 'primary'"
-        :title="compact && taskProgress.progress !== -1 ? `${taskProgress.progress}%` : undefined"
+        :title="compact ? stepOrPercent : undefined"
         class="flex-grow-1"
         rounded
         height="6"
       />
       <span
-        v-if="!compact && taskProgress.progress !== -1"
-        class="text-caption text-medium-emphasis ml-2"
+        v-if="!compact && stepOrPercent"
+        class="text-caption text-medium-emphasis ml-2 flex-shrink-0"
       >
-        {{ taskProgress.progress }}%
+        {{ stepOrPercent }}
       </span>
     </div>
   </v-list-item>
@@ -36,6 +36,10 @@ fr:
     finalize: Finalisation
     normalize: Conversion
     download: Téléchargement
+  steps:
+    refresh: rafraîchissement de l'index
+    checkConstraints: vérification des contraintes
+    switchAlias: bascule d'alias
 en:
   activity: Activity
   tasks:
@@ -48,15 +52,26 @@ en:
     finalize: Finalization
     normalize: Conversion
     download: Download
+  steps:
+    refresh: index refresh
+    checkConstraints: constraints check
+    switchAlias: alias switch
 </i18n>
 
 <script setup lang="ts">
 import { type TaskProgress } from '~/composables/dataset/dataset-store'
 
-defineProps<{
+const props = defineProps<{
   taskProgress?: TaskProgress
   compact?: boolean
 }>()
 
 const { t } = useI18n()
+
+// a named step replaces the percentage: the bar is indeterminate during these phases
+const stepOrPercent = computed(() => {
+  if (props.taskProgress?.step) return t('steps.' + props.taskProgress.step)
+  if (props.taskProgress && props.taskProgress.progress !== -1) return `${props.taskProgress.progress}%`
+  return null
+})
 </script>

--- a/ui/src/components/dataset/dataset-task-progress.vue
+++ b/ui/src/components/dataset/dataset-task-progress.vue
@@ -37,11 +37,11 @@ fr:
     normalize: Conversion
     download: Téléchargement
   steps:
-    start: démarrage de l'indexation
+    start: Démarrage de l'indexation
     indexing: '{n} lignes indexées'
-    refresh: rafraîchissement de l'index
-    checkConstraints: vérification des contraintes
-    switchAlias: bascule d'alias
+    refresh: Rafraîchissement de l'index
+    checkConstraints: Vérification des contraintes
+    switchAlias: Bascule de l'alias
 en:
   activity: Activity
   tasks:
@@ -55,11 +55,11 @@ en:
     normalize: Conversion
     download: Download
   steps:
-    start: indexing startup
+    start: Indexing startup
     indexing: '{n} rows indexed'
-    refresh: index refresh
-    checkConstraints: constraints check
-    switchAlias: alias switch
+    refresh: Index refresh
+    checkConstraints: Constraints check
+    switchAlias: Alias switch
 </i18n>
 
 <script setup lang="ts">

--- a/ui/src/composables/dataset/dataset-store.ts
+++ b/ui/src/composables/dataset/dataset-store.ts
@@ -4,7 +4,7 @@ import { isRestDataset } from '#shared/types-utils'
 import type { PatchDatasetReq } from '#api-doc/datasets/patch-req/index.js'
 
 export type ExtendedDataset = Dataset & { userPermissions: string[] }
-export type TaskProgress = { task: string, progress: number, step?: string, error?: string }
+export type TaskProgress = { task: string, progress: number, step?: string, count?: number, error?: string }
 
 export type DatasetStore = ReturnType<typeof createDatasetStore>
 export const datasetStoreKey = Symbol('dataset-store')

--- a/ui/src/composables/dataset/dataset-store.ts
+++ b/ui/src/composables/dataset/dataset-store.ts
@@ -4,7 +4,7 @@ import { isRestDataset } from '#shared/types-utils'
 import type { PatchDatasetReq } from '#api-doc/datasets/patch-req/index.js'
 
 export type ExtendedDataset = Dataset & { userPermissions: string[] }
-export type TaskProgress = { task: string, progress: number, error?: string }
+export type TaskProgress = { task: string, progress: number, step?: string, error?: string }
 
 export type DatasetStore = ReturnType<typeof createDatasetStore>
 export const datasetStoreKey = Symbol('dataset-store')


### PR DESCRIPTION
The progress bar of a dataset task lied about the tail of the work, and for `index` about the work itself.

**The terminal 100% was never published.** `inc()` returns early when a tick lands less than 250ms after the previous one, which is the nominal case for the last tick of a stream. Nothing rewrites it afterwards: none of the progress instances created inside the workers calls `end()`, only the outer one in `workers/index.ts` does, once the task is already over.

**The 100 was often not even computed.** The stream callers feed `inc()` with fractional increments and the sum drifts — it lands on 99.999999999998 about as often as on 100.000000000002, so `floor()` returned 99 on a fully consumed stream.

**The tail of `index` had no progress at all.** Once the stream was consumed the bar was left frozen while the ES refresh, the unicity check and the alias switch ran, none of which has measurable progress. `taskProgress` gains `step()`, which names the current phase on the bar, optionally with a running count and a percentage; without a percentage the bar goes back to indeterminate.

**`index` was measuring the wrong thing.** Its bar was driven by the share of the source the reader had consumed, which is not a measure of the work: the reader runs far ahead of the indexer whenever the source fits in the pipeline buffers. Measured on a 737KB / 6k lines csv, all 12 read chunks land — and the bar reached 100% — before the first of the 13 bulks is acknowledged by ES; against a remote cluster that gap is the whole task. `index` is now driven by the one thing it can count exactly — the documents ES has acknowledged — and shows a real percentage whenever the total is honestly knowable without an extra read pass: a REST dataset counts its mongo collection, and a re-index of unchanged data (config change on an already finalized dataset) reuses the count written by the previous run. A first indexing of a file has no exact total (`dataset.count` is written by this very task, `analyze` only samples the file) but still shows an approximate percentage, from a total estimated at the reader position (lines parsed so far / fraction of source bytes consumed), capped at 99 because the estimate is not a claim. The UI label combines both signals when available — "64% · 12 345 lignes indexées".

**Why:** the bar was reported frozen at 99%, then observed on staging jumping 0 → 64 → 100 with multi-second stalls at each step, which reads as a hung task rather than as work in progress.

**Heads-up:** `task-progress.ts` is shared by all eight dataset tasks — the `inc()` fixes affect every progress bar, though only `index` changes unit (the others measure work directly and keep their percentages). `index-stream._final` was rewritten from a `.then/.catch/.finally` chain into an async method to allow awaiting the progress calls mid-chain; semantics, including the 30s refresh retry, are preserved, and that is the hunk worth reading closest. The REST `countDocuments` moved from inside `readStreams` (which no longer takes a progress reporter) up to `index-lines.ts` — still a single count per indexing. The new `step` and `count` fields are additive on the `GET /datasets/{id}/task-progress` response and the websocket payload.
