### PR TITLE
fix(schema): preserve x-group on multi-value fields in safe-schema / flat separator

### DIFF
--- a/shared/schema.js
+++ b/shared/schema.js
@@ -73,6 +73,7 @@ export const cleanJsonSchemaProperty = (p, defaultPublicUrl, publicBaseUrl, flat
         readOnly: cleanProp.readOnly,
         anyOf: cleanProp.anyOf,
         oneOf: cleanProp.oneOf,
+        'x-group': cleanProp['x-group'],
         layout: { ...layout }
       }
     } else {
@@ -80,6 +81,7 @@ export const cleanJsonSchemaProperty = (p, defaultPublicUrl, publicBaseUrl, flat
       delete itemsProps.title
       delete itemsProps.description
       delete itemsProps.readOnly
+      delete itemsProps['x-group']
 
       /** @type {any} */
       const array = {
@@ -92,6 +94,7 @@ export const cleanJsonSchemaProperty = (p, defaultPublicUrl, publicBaseUrl, flat
       // keep the extension marker on the array itself, not only on its items, so the edit
       // form recognizes multi-valued extension fields (otherwise they are never rendered)
       if (cleanProp['x-extension']) array['x-extension'] = cleanProp['x-extension']
+      if (cleanProp['x-group']) array['x-group'] = cleanProp['x-group']
       if (layout.getItems) {
         array.layout = { getItems: layout.getItems }
       }

--- a/tests/features/datasets/rest/rest-datasets-own-lines.api.spec.ts
+++ b/tests/features/datasets/rest/rest-datasets-own-lines.api.spec.ts
@@ -22,14 +22,17 @@ test.describe('REST datasets with owner specific lines', () => {
       isRest: true,
       title: 'a rest dataset',
       rest: { lineOwnership: true, history: true },
-      schema: [{ key: 'col1', type: 'string' }]
+      schema: [
+        { key: 'col1', type: 'string' },
+        { key: 'col_multi', type: 'string', separator: ',', 'x-group': 'Group A' }
+      ]
     })
     assert.equal(res.status, 201)
     assert.equal(res.data.slug, 'a-rest-dataset')
     let dataset = res.data
     assert.ok(dataset.schema.find((p: any) => p.key === '_owner'))
     assert.ok(dataset.schema.find((p: any) => p.key === '_ownerName'))
-    assert.equal(dataset.schema.length, 7)
+    assert.equal(dataset.schema.length, 8)
 
     res = await testUser1Org.get(`/api/v1/datasets/${dataset.id}/lines`)
     assert.equal(res.data.total, 0)
@@ -37,7 +40,7 @@ test.describe('REST datasets with owner specific lines', () => {
     // owner's admin can use routes to manage his own lines
     await testUser1Org.post(`/api/v1/datasets/${dataset.id}/own/user:test_user1/lines`, { _id: 'dmeadusline', col1: 'value 1' })
     dataset = await waitForFinalize(testUser1Org, dataset.id)
-    assert.equal(dataset.schema.length, 7)
+    assert.equal(dataset.schema.length, 8)
     res = await testUser1Org.get(`/api/v1/datasets/${dataset.id}/own/user:test_user1/lines`)
     assert.equal(res.data.total, 1)
     res = await testUser1Org.get(`/api/v1/datasets/${dataset.id}/lines`)
@@ -119,9 +122,14 @@ test.describe('REST datasets with owner specific lines', () => {
     // safe schema for external users is purged of indices about the data
     res = await testUser3.get(`/api/v1/datasets/${dataset.id}/safe-schema`)
     assert.equal(res.data.find((p: any) => p.key === 'col1')['x-cardinality'], undefined)
+    assert.equal(res.data.find((p: any) => p.key === 'col_multi')['x-group'], 'Group A')
     res = await testUser1Org.get(`/api/v1/datasets/${dataset.id}/schema`)
     assert.equal(res.data.find((p: any) => p.key === 'col1')['x-cardinality'], 2)
+    assert.equal(res.data.find((p: any) => p.key === 'col_multi')['x-group'], 'Group A')
     await assert.rejects(testUser3.get(`/api/v1/datasets/${dataset.id}/schema`), (err: any) => err.status === 403)
+
+    res = await testUser3.get(`/api/v1/datasets/${dataset.id}/safe-schema?mimeType=application/schema%2Bjson`)
+    assert.equal(res.data.properties.col_multi['x-group'], 'Group A')
   })
 
   test('Handle a dataset with line ownership and a primary key that includes _owner', async () => {

--- a/tests/features/datasets/schema/clean-json-schema-property.unit.spec.ts
+++ b/tests/features/datasets/schema/clean-json-schema-property.unit.spec.ts
@@ -1,0 +1,62 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { cleanJsonSchemaProperty } from '../../../../shared/schema.js'
+
+test.describe('cleanJsonSchemaProperty unit tests', () => {
+  test('preserves x-group on multi-value field in flatArrays mode (flat separator)', () => {
+    const prop = {
+      key: 'type_de_public',
+      type: 'string',
+      title: 'Type de public',
+      description: 'Public concerné',
+      separator: ',',
+      'x-group': 'Descriptif de la salle'
+    }
+    const cleanProp = cleanJsonSchemaProperty(prop, 'http://localhost:5888', 'http://localhost:5888', true)
+    assert.equal(cleanProp['x-group'], 'Descriptif de la salle')
+    assert.equal(cleanProp.type, 'string')
+    assert.deepEqual(cleanProp.layout, { separator: ',' })
+  })
+
+  test('preserves x-group on multi-value field with x-display in flatArrays mode', () => {
+    const prop = {
+      key: 'equipements_disponibles',
+      type: 'string',
+      title: 'Équipements disponibles',
+      separator: ',',
+      'x-display': 'textarea',
+      'x-group': 'Descriptif de la salle'
+    }
+    const cleanProp = cleanJsonSchemaProperty(prop, 'http://localhost:5888', 'http://localhost:5888', true)
+    assert.equal(cleanProp['x-group'], 'Descriptif de la salle')
+    assert.equal(cleanProp['x-display'], 'textarea')
+  })
+
+  test('omits x-group if not defined on multi-value field in flatArrays mode', () => {
+    const prop = {
+      key: 'tags',
+      type: 'string',
+      title: 'Tags',
+      separator: ','
+    }
+    const cleanProp = cleanJsonSchemaProperty(prop, 'http://localhost:5888', 'http://localhost:5888', true)
+    assert.equal(cleanProp['x-group'], undefined)
+    assert.equal(JSON.parse(JSON.stringify(cleanProp))['x-group'], undefined)
+  })
+
+  test('preserves x-group on array and removes from items in non-flat arrays mode (flatArrays: false)', () => {
+    const prop = {
+      key: 'type_de_public',
+      type: 'string',
+      title: 'Type de public',
+      description: 'Public concerné',
+      separator: ',',
+      'x-group': 'Descriptif de la salle'
+    }
+    const cleanProp = cleanJsonSchemaProperty(prop, 'http://localhost:5888', 'http://localhost:5888', false)
+    assert.equal(cleanProp.type, 'array')
+    assert.equal(cleanProp['x-group'], 'Descriptif de la salle')
+    assert.equal(cleanProp.items.type, 'string')
+    assert.equal(cleanProp.items['x-group'], undefined)
+  })
+})


### PR DESCRIPTION
### Context & Problem
The `GET /api/v1/datasets/{id}/safe-schema` endpoint (and `GET /schema?mimeType=application/schema+json`) omitted `x-group` for multi-valued fields (`separator` defined, without `x-display` or `format`), whereas the full schema (`/schema`) carries it. As a result, consumer applications could no longer group these multi-value fields in their respective form/view sections.

### Root Cause
In `shared/schema.js` (`cleanJsonSchemaProperty`), the flat separator branch (`layout.separator` present, `flatArrays = true`, without `x-display`/`format`) reconstructed a minimal property literal that omitted `'x-group': cleanProp['x-group']`.
Similarly, when `flatArrays = false` (used with `arrays=true`), `x-group` was left inside `itemsProps` instead of being attached to the outer `array` property container.

### Changes
- **`shared/schema.js`**:
  - In flat separator mode (`flatArrays = true`), preserve `'x-group': cleanProp['x-group']` on the returned property.
  - In array mode (`flatArrays = false`), set `array['x-group'] = cleanProp['x-group']` and delete `itemsProps['x-group']`.
- **`tests/features/datasets/schema/clean-json-schema-property.unit.spec.ts`**:
  - Added dedicated unit tests covering `x-group` retention in both flat and array modes, with and without `x-display`.
- **`tests/features/datasets/rest/rest-datasets-own-lines.api.spec.ts`**:
  - Added multi-value `col_multi` with `x-group` to the dataset schema and asserted `x-group` presence on `GET /safe-schema` and `GET /safe-schema?mimeType=application/schema+json`.

### Verification
- `npm run test-unit` is green (829 passed).
- `npm run lint` is clean (0 errors/warnings).
- `npm run check-types-ratchet` is at baseline (489 errors, no regression).