### PR TITLE
feat(ui): select several departments or partners at once in the permissions dialog

### DIFF
--- a/ui/src/components/permissions/permission-dialog.vue
+++ b/ui/src/components/permissions/permission-dialog.vue
@@ -34,9 +34,10 @@
           <template v-if="orgSelectType === 'ownerOrg'">
             <v-select
               v-if="owner.departments && owner.departments.length"
-              v-model="permission.department"
+              v-model="departments"
               :items="departmentItems"
               :label="t('department')"
+              multiple
             />
 
             <v-select
@@ -50,11 +51,12 @@
 
           <template v-if="orgSelectType === 'partner'">
             <v-select
-              v-model="partner"
+              v-model="partners"
               :items="owner.partners"
               item-title="name"
               item-value="id"
               return-object
+              multiple
               :label="t('partner')"
             />
           </template>
@@ -115,7 +117,7 @@
           :disabled="!valid"
           color="primary"
           variant="flat"
-          @click="emit('update:modelValue', permission as Permission); showDialog = false"
+          @click="submit"
         >
           {{ t('validate') }}
         </v-btn>
@@ -137,7 +139,7 @@ fr:
   detailedActions: Actions détaillées
   expertMode: Mode expert
   actions: Actions
-  department: Département
+  department: Départements
   allDeps: Tous les départements
   noDep: Aucun département (organisation principale seulement)
   allUsers: Tous les utilisateurs de la plateforme non anonymes
@@ -145,7 +147,7 @@ fr:
   userByEmail: Utilisateur désigné par son adresse email
   email: Email
   amongPartners: Parmi les organisations partenaires
-  partner: Partenaire
+  partner: Partenaires
   ownerOrg: Organisation propriétaire
   classNames:
     list: Lister
@@ -167,7 +169,7 @@ en:
   detailedActions: Detailed actions
   expertMode: Expert mode
   actions: Actions
-  department: Department
+  department: Departments
   allDeps: All departments
   noDep: No department (main organization only)
   allUsers: All non-anonymous users of the platform
@@ -175,7 +177,7 @@ en:
   userByEmail: User designed by their email
   email: Email
   amongPartners: Among partner organizations
-  partner: Partner
+  partner: Partners
   ownerOrg: Owner organization
   classNames:
     list: List
@@ -211,7 +213,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  'update:modelValue': [value: Permission]
+  'update:modelValue': [value: Permission[]]
 }>()
 
 const { t, te } = useI18n()
@@ -219,6 +221,9 @@ const { t, te } = useI18n()
 const showDialog = ref(false)
 const permission = ref<EditablePermission | null>(null)
 const expertMode = ref(false)
+// multi-selects producing one permission per selected department / partner
+const departments = ref<(string | null)[]>([null])
+const partners = ref<{ id: string, name: string }[]>([])
 
 // --- Computed: restricted permission classes (public scope = only read/list/use) ---
 const restrictedPermissionClasses = computed(() => {
@@ -266,10 +271,16 @@ const permissionTypes = computed(() => {
 // --- Computed: department items ---
 const departmentItems = computed(() => {
   if (!props.owner.departments?.length) return []
+  // 'all departments' and 'no department' are exclusive with each other and with the department list:
+  // checking one greys out the rest instead of silently unchecking it
+  const all = departments.value.includes(null)
+  const none = departments.value.includes('-')
+  const specific = departments.value.some(d => d !== null && d !== '-')
   return [
-    { value: null, title: t('allDeps') },
-    ...props.owner.departments.map((d: any) => ({ value: d.id, title: `${d.name} (${d.id})` })),
-    { value: '-', title: t('noDep') }
+    { value: null, title: t('allDeps'), props: { disabled: none || specific } },
+    { value: '-', title: t('noDep'), props: { disabled: all || specific } },
+    { type: 'divider' },
+    ...props.owner.departments.map((d: any) => ({ value: d.id, title: `${d.name} (${d.id})`, props: { disabled: all || none } }))
   ]
 })
 
@@ -336,30 +347,12 @@ const orgSelectType = computed({
     delete permission.value.email
     permission.value.department = null
     permission.value.roles = []
+    departments.value = [null]
+    partners.value = []
     if (v === 'ownerOrg') {
       permission.value.id = props.owner.id
       permission.value.name = props.owner.name
     } else if (v === 'partner') {
-      permission.value.id = null
-      permission.value.name = null
-    }
-  }
-})
-
-// --- Computed get/set: partner ---
-const partner = computed({
-  get () {
-    if (orgSelectType.value !== 'partner') return null
-    if (!permission.value?.id) return null
-    return props.owner.partners?.find((p) => p.id === permission.value?.id) ?? null
-  },
-  set (org: { id: string, name: string } | null) {
-    if (!permission.value) return
-    delete permission.value.email
-    if (org) {
-      permission.value.id = org.id
-      permission.value.name = org.name
-    } else {
       permission.value.id = null
       permission.value.name = null
     }
@@ -394,7 +387,11 @@ const valid = computed(() => {
   if (!permission.value) return false
   const p = permission.value
   if ((!p.operations || !p.operations.length) && (!p.classes || !p.classes.length)) return false
-  if (p.type === 'organization' && !p.id) return false
+  if (p.type === 'organization') {
+    if (orgSelectType.value === 'partner') {
+      if (!partners.value.length) return false
+    } else if (!p.id) return false
+  }
   if (p.type === 'user' && !(p.id || p.email)) return false
   return true
 })
@@ -422,6 +419,27 @@ function init () {
       permission.value.name = props.owner.name
     }
   }
+  departments.value = [permission.value!.department ?? null]
+  partners.value = permission.value!.type === 'organization' && permission.value!.id && permission.value!.id !== props.owner.id
+    ? [{ id: permission.value!.id, name: permission.value!.name ?? '' }]
+    : []
+}
+
+// one permission per selected department / partner
+function submit () {
+  const p = permission.value!
+  const clone = () => JSON.parse(JSON.stringify(p)) as EditablePermission
+  let permissions: EditablePermission[]
+  if (p.type === 'organization' && orgSelectType.value === 'partner') {
+    permissions = partners.value.map(org => ({ ...clone(), id: org.id, name: org.name }))
+  } else if (p.type === 'organization' && orgSelectType.value === 'ownerOrg') {
+    permissions = (departments.value.length ? departments.value : [null])
+      .map(department => ({ ...clone(), department }))
+  } else {
+    permissions = [p]
+  }
+  emit('update:modelValue', permissions as Permission[])
+  showDialog.value = false
 }
 
 function setPermissionType () {

--- a/ui/src/components/permissions/permissions-editor.vue
+++ b/ui/src/components/permissions/permissions-editor.vue
@@ -544,15 +544,15 @@ async function fetchOwnerDetails () {
 
 // --- Permission CRUD for detailed mode ---
 
-function addPermission (p: Permission) {
+function addPermission (permissions: Permission[]) {
   if (!props.modelValue) return
-  save([...props.modelValue, p])
+  save([...props.modelValue, ...permissions])
 }
 
-function editPermission (index: number, p: Permission) {
+function editPermission (index: number, permissions: Permission[]) {
   if (!props.modelValue) return
   const next = [...props.modelValue]
-  next[index] = p
+  next.splice(index, 1, ...permissions)
   save(next)
 }
 


### PR DESCRIPTION
Granting the same permission to three departments meant reopening the dialog three times, and likewise for partner organizations. Both selects are now multi-selects, and validating creates one permission per checked entry — the roles select already worked that way, these two did not.

- **Departments**: `Tous les départements` and `Aucun département (organisation principale seulement)` move to the top of the list, above the departments themselves, and stay mutually exclusive with each other and with the department list — checking one greys the rest out through each item's `props.disabled` rather than silently unchecking it. Checking two departments produces two permissions carrying the same roles and actions.
- **Partners**: plain multi-select, one permission per partner. Validate stays disabled until at least one is checked, where the single-select variant relied on `permission.id` being set.
- Both selects become local state (`departments`, `partners`) instead of being bound straight to `permission.department` / `permission.id`, reset when the dialog opens and when the org scope switches between owner and partners. `submit()` deep-clones the working permission per entry so the produced permissions never share their `roles` / `classes` / `operations` arrays.
- `permissions-editor` follows: `addPermission` concatenates, and `editPermission` does a `splice(index, 1, ...permissions)` — so editing an existing permission and checking two departments replaces that one row with two.

**Why:** reported as tedious in the back-office — the dialog forces one round trip per department or per partner, for permissions that are otherwise identical.

**Heads-up:** the dialog's `update:modelValue` payload changes from `Permission` to `Permission[]`; `permissions-editor` is its only consumer. Nothing else in the emitted permissions changes shape, so existing permissions keep rendering and editing as before.

Verified by hand against a Koumoul org with three departments and two partners: two departments → two permissions (`department: "data"` / `"support"`), `Aucun` → one permission with `department: "-"`, `Tous` → one permission with no department, two partners → two permissions. The `detailed mode` e2e tests in `tests/features/ui/permissions.e2e.spec.ts` fail identically on this branch and on `master` in my dev environment (`#share` never becomes visible, before the dialog is even opened), so they are left to CI; I did check by hand that the existing `add partner org permission` test still holds, since it clicks Valider with the select menu open and the menu now stays open after a pick — the vuetify menu has no scrim, so the click reaches the button.
