### PR TITLE
fix(permissions): check the new owner of a resource against all the user's memberships

### DIFF
--- a/api/src/applications/router.ts
+++ b/api/src/applications/router.ts
@@ -121,7 +121,8 @@ router.put('/:applicationId/owner', readApplication, permissionMiddleware('delet
   const sessionState = reqSessionAuthenticated(req)
 
   // Must be able to delete the current application, and to create a new one for the new owner to proceed
-  if (!permissions.canDoForOwner(req.body, 'applications', 'post', sessionState)) return res.status(403).type('text/plain').send('Vous ne pouvez pas créer d\'application dans le nouveau propriétaire')
+  // (checked against all the user's memberships, the new owner is rarely the active account)
+  if (!permissions.canDoForOwner(req.body, 'applications', 'post', sessionState, true)) return res.status(403).type('text/plain').send('Vous ne pouvez pas créer d\'application dans le nouveau propriétaire')
 
   const ctx = { sessionState, logCtx: reqEventLogContext(req) }
   const patchedApp = await service.changeApplicationOwner(ctx, reqApplication(req), req.body)

--- a/api/src/datasets/routes/metadata.ts
+++ b/api/src/datasets/routes/metadata.ts
@@ -9,7 +9,6 @@ import { httpError } from '@data-fair/lib-utils/http-errors.js'
 import eventsLog from '@data-fair/lib-express/events-log.js'
 import eventsQueue from '@data-fair/lib-node/events-queue.js'
 import { session, reqSession, reqSessionAuthenticated } from '@data-fair/lib-express'
-import config from '#config'
 import mongo from '#mongo'
 import filesStorage from '#files-storage'
 import { readDataset, reqDataset, reqDatasetFull, lockDataset } from '../middlewares.ts'
@@ -214,14 +213,8 @@ export const registerMetadataRoutes = (router: Router) => {
     const sessionState = reqSessionAuthenticated(req)
 
     // Must be able to delete the current dataset, and to create a new one for the new owner to proceed
-    if (!sessionState.user.adminMode) {
-      if (req.body.type === 'user' && req.body.id !== sessionState.user.id) return res.status(403).type('text/plain').send(req.__('errors.missingPermission'))
-      if (req.body.type === 'organization') {
-        const userOrg = sessionState.user.organizations.find(o => o.id === req.body.id)
-        if (!userOrg) return res.status(403).type('text/plain').send(req.__('errors.missingPermission'))
-        if (![config.contribRole, config.adminRole].includes(userOrg.role)) return res.status(403).type('text/plain').send(req.__('errors.missingPermission'))
-      }
-    }
+    // (checked against all the user's memberships, the new owner is rarely the active account)
+    if (!permissions.canDoForOwner(req.body, 'datasets', 'post', sessionState, true)) return res.status(403).type('text/plain').send(req.__('errors.missingPermission'))
 
     if (req.body.type !== dataset.owner.type || req.body.id !== dataset.owner.id) {
       const remaining = await limits.remaining(req.body)

--- a/api/src/misc/utils/permissions.ts
+++ b/api/src/misc/utils/permissions.ts
@@ -111,15 +111,15 @@ export const canDoForOwnerMiddleware = function (operationClass: string, ignoreD
 }
 
 /** Returns the session's role within the resource owner (or null if the session is anonymous, an application key, or unrelated to the owner). */
-export const getOwnerRole = (owner: AccountKeys, sessionState: SessionState | undefined, ignoreDepartment = false) => {
+export const getOwnerRole = (owner: AccountKeys, sessionState: SessionState | undefined, ignoreDepartment = false, allAccounts = false) => {
   if (!sessionState?.user || !sessionState?.account || (sessionState as SessionState & { isApplicationKey?: boolean }).isApplicationKey) return null
-  return getAccountRole(sessionState, owner, { acceptDepAsRoot: ignoreDepartment })
+  return getAccountRole(sessionState, owner, { acceptDepAsRoot: ignoreDepartment, allAccounts })
 }
 
 /** Returns the operation classes the session can perform by virtue of being a member of the resource owner (admin/contrib/null). */
-const getOwnerClasses = (owner: AccountKeys, sessionState: SessionState, resourceType: ResourceType) => {
+const getOwnerClasses = (owner: AccountKeys, sessionState: SessionState, resourceType: ResourceType, allAccounts = false) => {
   const operationsClasses = permissionsClasses.operationsClasses[resourceType]
-  const ownerRole = getOwnerRole(owner, sessionState)
+  const ownerRole = getOwnerRole(owner, sessionState, false, allAccounts)
   if (!ownerRole) return null
   // classes of operations the user can do based on him being member of the resource's owner
   if (ownerRole === config.adminRole || (sessionState.user?.adminMode)) {
@@ -310,10 +310,11 @@ export const filterCan = function (sessionState: SessionState, resourceType: Res
 /**
  * Returns true if the session is a member of the given owner with the rights to perform an operation class.
  * Used at resource creation, where permissions are still expressed at the operation class level.
+ * allAccounts checks the user's memberships instead of only the active account (owner transfers).
  */
-export const canDoForOwner = function (owner: AccountKeys, resourceType: ResourceType, operationClass: string, sessionState: SessionState) {
+export const canDoForOwner = function (owner: AccountKeys, resourceType: ResourceType, operationClass: string, sessionState: SessionState, allAccounts = false) {
   if (sessionState.user?.adminMode) return true
-  const ownerClasses = getOwnerClasses(owner, sessionState, resourceType)
+  const ownerClasses = getOwnerClasses(owner, sessionState, resourceType, allAccounts)
   return ownerClasses && ownerClasses.includes(operationClass)
 }
 

--- a/tests/features/auth/permissions.api.spec.ts
+++ b/tests/features/auth/permissions.api.spec.ts
@@ -246,6 +246,25 @@ test.describe('permissions', () => {
     assert.deepEqual(newPermissions[newPermissions.length - 1], { operations: ['readDescription', 'list'] })
   })
 
+  test('Department admin can transfer a dataset to another department but not to the organization root', async () => {
+    const testUser4Dep1 = await axiosAuth('test_user4@test.com', 'test_org1')
+    testUser4Dep1.setOrg('test_org1', 'dep1')
+    const testUser4Dep2 = await axiosAuth('test_user4@test.com', 'test_org1')
+    testUser4Dep2.setOrg('test_org1', 'dep2')
+
+    let dataset = (await testUser4Dep1.post('/api/v1/datasets', { isRest: true, title: 'A dataset' })).data
+    assert.equal(dataset.owner.department, 'dep1')
+
+    // test_user4 is admin of dep1 and dep2 but not of the organization root
+    await assert.rejects(
+      testUser4Dep1.put(`/api/v1/datasets/${dataset.id}/owner`, { type: 'organization', id: 'test_org1', name: 'Test Org 1' }),
+      (err: any) => err.status === 403
+    )
+    await testUser4Dep1.put(`/api/v1/datasets/${dataset.id}/owner`, { type: 'organization', id: 'test_org1', name: 'Test Org 1', department: 'dep2' })
+    dataset = (await testUser4Dep2.get(`/api/v1/datasets/${dataset.id}`)).data
+    assert.deepEqual(dataset.owner, { type: 'organization', id: 'test_org1', name: 'Test Org 1', department: 'dep2' })
+  })
+
   test('Change application ownership to an organization that is not the active account', async () => {
     // from the personal account to an organization where the user is admin
     let application = (await testUser1.post('/api/v1/applications', { title: 'An application', url: mockAppUrl('monapp1') })).data

--- a/tests/features/auth/permissions.api.spec.ts
+++ b/tests/features/auth/permissions.api.spec.ts
@@ -246,6 +246,52 @@ test.describe('permissions', () => {
     assert.deepEqual(newPermissions[newPermissions.length - 1], { operations: ['readDescription', 'list'] })
   })
 
+  test('Change application ownership to an organization that is not the active account', async () => {
+    // from the personal account to an organization where the user is admin
+    let application = (await testUser1.post('/api/v1/applications', { title: 'An application', url: mockAppUrl('monapp1') })).data
+    await testUser1.put(`/api/v1/applications/${application.id}/owner`, { type: 'organization', id: 'test_org1', name: 'Test Org 1' })
+    application = (await testUser1Org.get(`/api/v1/applications/${application.id}`)).data
+    assert.deepEqual(application.owner, { type: 'organization', id: 'test_org1', name: 'Test Org 1' })
+
+    // from an organization to another one where the user is only a simple user
+    application = (await testUser1Org.post('/api/v1/applications', { title: 'An application', url: mockAppUrl('monapp1') })).data
+    await assert.rejects(
+      testUser1Org.put(`/api/v1/applications/${application.id}/owner`, { type: 'organization', id: 'test_org3', name: 'Test Org 3' }),
+      (err: any) => err.status === 403
+    )
+    // to an organization the user is not a member of
+    await assert.rejects(
+      testUser1Org.put(`/api/v1/applications/${application.id}/owner`, { type: 'organization', id: 'test_org4', name: 'Test Org 4' }),
+      (err: any) => err.status === 403
+    )
+    // to another user
+    await assert.rejects(
+      testUser1Org.put(`/api/v1/applications/${application.id}/owner`, { type: 'user', id: 'test_user3', name: 'Test User3' }),
+      (err: any) => err.status === 403
+    )
+    application = (await testUser1Org.get(`/api/v1/applications/${application.id}`)).data
+    assert.deepEqual(application.owner, { type: 'organization', id: 'test_org1', name: 'Test Org 1' })
+  })
+
+  test('Department admin can transfer an application to another department but not to the organization root', async () => {
+    const testUser4Dep1 = await axiosAuth('test_user4@test.com', 'test_org1')
+    testUser4Dep1.setOrg('test_org1', 'dep1')
+    const testUser4Dep2 = await axiosAuth('test_user4@test.com', 'test_org1')
+    testUser4Dep2.setOrg('test_org1', 'dep2')
+
+    let application = (await testUser4Dep1.post('/api/v1/applications', { title: 'An application', url: mockAppUrl('monapp1') })).data
+    assert.equal(application.owner.department, 'dep1')
+
+    // test_user4 is admin of dep1 and dep2 but not of the organization root
+    await assert.rejects(
+      testUser4Dep1.put(`/api/v1/applications/${application.id}/owner`, { type: 'organization', id: 'test_org1', name: 'Test Org 1' }),
+      (err: any) => err.status === 403
+    )
+    await testUser4Dep1.put(`/api/v1/applications/${application.id}/owner`, { type: 'organization', id: 'test_org1', name: 'Test Org 1', department: 'dep2' })
+    application = (await testUser4Dep2.get(`/api/v1/applications/${application.id}`)).data
+    assert.deepEqual(application.owner, { type: 'organization', id: 'test_org1', name: 'Test Org 1', department: 'dep2' })
+  })
+
   test('user can do everything in his own account', async () => {
     const dataset = (await testUser1.post('/api/v1/datasets', { isRest: true, title: 'A dataset' })).data
     assert.equal(dataset.owner.name, 'Test User1')


### PR DESCRIPTION
`PUT /applications/:id/owner` answered `403 - Vous ne pouvez pas créer d'application dans le nouveau propriétaire` as soon as the new owner was not the session's active account, even for an admin of the target organization. The route checks the new owner with `canDoForOwner`, which goes through `getAccountRole` without `allAccounts` and therefore only compares the target with `sessionState.account` — the organization the user is currently switched on. Since the owner-change dialog is shared with datasets and lists every account the user belongs to, the UI offered transfers the API could never accept. The datasets route did not have the problem because it walked `sessionState.user.organizations` by hand — but that hand-written check matched organizations by id only, so a department-scoped admin could transfer a dataset to the organization root or to another department they are not a member of.

- `canDoForOwner` (and `getOwnerRole` / `getOwnerClasses` under it) take an opt-in `allAccounts` flag forwarded to `getAccountRole`, so the role comes from the user's memberships instead of the active account. It defaults to `false`: the creation routes, `canDoForOwnerMiddleware` and the settings middlewares keep their previous behaviour.
- Both owner-change routes (applications and datasets) are the only callers passing `true`; the datasets route drops its manual check. Everything else on those routes is unchanged: the `delete` / `changeOwner` admin gate on the source resource, the limits checks on datasets, the rejection of application-key sessions in `getOwnerRole`, and API-key sessions, whose `user.organizations` only ever holds the key's own organization.
- Three API tests in `tests/features/auth/permissions.api.spec.ts`: a transfer from the personal account to an organization the user administers succeeds, while transfers to an organization where the user is a plain `user`, to an organization they are not a member of, or to another user still return 403; a department admin can move an application or a dataset to another department they administer but not to the organization root.

**Why:** reported by a user administering several organizations who could not move an application from one to the other, while the same operation works on datasets.

**Heads-up:** the datasets side is a tightening — a department admin could previously transfer a dataset to the organization root (or to a department they don't belong to); this now returns 403 like it always did for applications. Root-level admins and contribs are unaffected.

Verified locally: the new tests fail on `master` (403 for applications, missing rejection for datasets) and pass with the change; `permissions.api.spec.ts`, `api-keys.api.spec.ts`, `tests/features/applications` and `integrity/admin.api.spec.ts` are green (108 passed; one xlsx restore test in the integrity suite is timing-flaky and passes on its own). Lint clean, `check-types` ratchet at baseline (489).
