### PR TITLE
fix(datasets): stop losing REST line writes on pre-6.18.0 indices

### DIFF
--- a/api/src/admin/elasticsearch-diagnose-service.ts
+++ b/api/src/admin/elasticsearch-diagnose-service.ts
@@ -14,7 +14,7 @@ import {
   type SectionError,
   type DatasetRef
 } from './elasticsearch-diagnose.ts'
-import { listDatasetsWithEsWarnings } from './service.ts'
+import { listDatasetsWithEsWarnings, listRestDatasetsWithoutLineBytes } from './service.ts'
 
 // Watermarks rarely change; refresh once a minute.
 const DEFAULT_LOW = 85
@@ -106,7 +106,7 @@ export const getElasticsearchDiagnose = async () => {
   const [
     health, pendingTasks, allocSettings,
     nodesStats, catShards, catIndices, tasksResponse,
-    datasetsWithEsWarnings, nbDatasetsInMongo
+    datasetsWithEsWarnings, restDatasetsWithoutLineBytes, nbDatasetsInMongo
   ] = await Promise.all([
     safeSection('cluster.health', () => es.client.cluster.health(), errors, null as any),
     safeSection('cluster.pendingTasks', async () => (await es.client.cluster.pendingTasks()).tasks ?? [], errors, [] as any[]),
@@ -128,6 +128,7 @@ export const getElasticsearchDiagnose = async () => {
     // — that's the shape both collectReferencedDatasetIds and mapLongTasks consume.
     safeSection('tasks.list', () => es.client.tasks.list({ detailed: true }), errors, { nodes: {} } as any),
     safeSection('datasetsWithEsWarnings', () => listDatasetsWithEsWarnings(1000), errors, { count: 0, results: [] }),
+    safeSection('restDatasetsWithoutLineBytes', () => listRestDatasetsWithoutLineBytes(1000), errors, { count: 0, results: [] }),
     safeSection('mongo.countDatasets', () => mongo.db.collection('datasets').countDocuments({
       isVirtual: { $ne: true },
       isMetaOnly: { $ne: true }
@@ -173,6 +174,7 @@ export const getElasticsearchDiagnose = async () => {
     unassignedShards: mapUnassignedShards(catShards as any[], explainByKey, indicesPrefix, datasetsById),
     indicesSummary: mapIndicesSummary(catIndices as any[], indicesPrefix, nbDatasetsInMongo as number, mongoIdsPresent),
     datasetsWithEsWarnings,
+    restDatasetsWithoutLineBytes,
     errors
   }
 }

--- a/api/src/admin/service.ts
+++ b/api/src/admin/service.ts
@@ -71,6 +71,24 @@ export async function listDatasetsWithEsWarnings (size = 1000, skip = 0) {
   return { count, results }
 }
 
+// REST datasets whose current index was built before `_bytes` was mapped (no `_esLineBytes`
+// marker): single-line writes into it are refused (see docs/architecture/storage-accounting.md)
+// until an operator reindexes it. File datasets rebuild a fresh index on every processing and
+// virtual datasets have none, so only REST datasets can be stuck on a legacy index.
+export async function listRestDatasetsWithoutLineBytes (size = 1000, skip = 0) {
+  const datasets = mongo.db.collection('datasets')
+  const query = { isRest: true, _esLineBytes: { $ne: true } }
+  const resultsPromise = datasets
+    .find(query)
+    .sort({ updatedAt: -1 })
+    .skip(skip)
+    .limit(size)
+    .project({ _id: 0, id: 1, title: 1, owner: 1, status: 1, count: 1, updatedAt: 1, dataUpdatedAt: 1 })
+    .toArray()
+  const [count, results] = await Promise.all([datasets.countDocuments(query), resultsPromise])
+  return { count, results }
+}
+
 export async function findDatasetsErrors (reqQuery: Record<string, any>) {
   const datasets = mongo.db.collection('datasets')
   // A compromised dataset deliberately keeps its real status ('finalized' — see

--- a/api/src/datasets/es/index-stream.ts
+++ b/api/src/datasets/es/index-stream.ts
@@ -22,6 +22,10 @@ interface IndexStreamOptions {
   // (markIndexedStream); file datasets pipe into a no-op sink, so skipping the
   // re-emit avoids a full per-line object copy.
   reemit?: boolean
+  // stamp the CSV-equivalent `_bytes` size on inserted lines. Only an index built by code that
+  // maps the field accepts it (strict mapping): a fresh index always does, an existing one does
+  // iff the dataset carries `_esLineBytes` (see docs/architecture/storage-accounting.md)
+  stampBytes: boolean
 }
 
 // remove some properties that must not be indexed
@@ -48,8 +52,13 @@ class IndexStream extends Transform {
   lineBytesSpec: { prefixes: Set<string>, nbCols: number }
   bulkChars: number
   i: number
+  // warnings from applyCalculations AND items rejected by the bulk response (errorsSummary)
   nbErroredItems: number
   erroredItems: any[]
+  // items rejected by the bulk response only (e.g. strict_dynamic_mapping_exception): these lines
+  // are NOT in the index, unlike the ones that merely carry a calculation warning
+  nbRejectedItems: number
+  firstRejectionReason: string | null
 
   constructor (options: IndexStreamOptions) {
     super({ objectMode: true })
@@ -64,6 +73,8 @@ class IndexStream extends Transform {
     this.i = 0
     this.nbErroredItems = 0
     this.erroredItems = []
+    this.nbRejectedItems = 0
+    this.firstRejectionReason = null
   }
 
   async transformPromise (item: any, encoding?: BufferEncoding) {
@@ -89,7 +100,7 @@ class IndexStream extends Transform {
       warning = await this.applyCalculations(item)
       // after applyCalculations so extension/calculated fields are present; calculated
       // fields and _file_raw are excluded by the spec (not CSV-export columns)
-      item._bytes = lineBytes(item, this.lineBytesSpec)
+      if (this.options.stampBytes) item._bytes = lineBytes(item, this.lineBytesSpec)
       this.body.push(JSON.stringify(params))
       const itemStr = JSON.stringify(item)
       this.body.push(itemStr)
@@ -147,13 +158,7 @@ class IndexStream extends Transform {
       if (this.options.attachments) bulkOpts.pipeline = 'attachment'
       const res: any = await es.client.bulk(bulkOpts)
       debug('Bulk sent OK')
-      if (this.options.reemit) {
-        for (let i = 0; i < res.items.length; i++) {
-          const item = res.items[i]
-          const _id = (item.index && item.index._id) || (item.update && item.update._id) || (item.delete && item.delete._id)
-          this.push({ _id, ...this.items[i] })
-        }
-      }
+      const rejected = new Set<number>()
       if (res.errors) {
         for (let i = 0; i < res.items.length; i++) {
           const item = {
@@ -167,9 +172,22 @@ class IndexStream extends Transform {
           if (item.error.type === 'cluster_block_exception') {
             throw new Error(item.error.type ? `${item.error.type} - ${item.error.reason}` : item.error)
           } else {
+            rejected.add(i)
             this.nbErroredItems += 1
+            this.nbRejectedItems += 1
+            this.firstRejectionReason = this.firstRejectionReason ?? item.error.caused_by?.reason ?? item.error.reason ?? item.error.type
             if (this.erroredItems.length < maxErroredItems) this.erroredItems.push(item)
           }
+        }
+      }
+      if (this.options.reemit) {
+        for (let i = 0; i < res.items.length; i++) {
+          // a rejected line is not in the index: do not re-emit it, so that markIndexedStream
+          // leaves its _needsIndexing flag and a later pass retries it instead of losing it
+          if (rejected.has(i)) continue
+          const item = res.items[i]
+          const _id = (item.index && item.index._id) || (item.update && item.update._id) || (item.delete && item.delete._id)
+          this.push({ _id, ...this.items[i] })
         }
       }
       this.body = []

--- a/api/src/datasets/utils/rest.ts
+++ b/api/src/datasets/utils/rest.ts
@@ -37,7 +37,7 @@ import { NEW_INDEX_SHAPE } from '../es/operations.ts'
 import { tabularTypes } from './types.ts'
 import { Piscina } from 'piscina'
 import { internalError } from '@data-fair/lib-node/observer.js'
-import type { DatasetLineAction, DatasetLine, RestDataset, DatasetLineRevision, RestActionsSummary, HistorizeContextHint, WhoHint } from '#types'
+import type { DatasetLineAction, DatasetLine, RestDataset, DatasetInternal, DatasetLineRevision, RestActionsSummary, HistorizeContextHint, WhoHint } from '#types'
 import { whoFromReq } from '../../integrity/who.ts'
 import type { NextFunction, Response, RequestHandler } from 'express'
 import { reqSession, reqSessionAuthenticated, reqUserAuthenticated, type Account, type SessionStateAuthenticated } from '@data-fair/lib-express'
@@ -50,6 +50,7 @@ import { isInFilesStorage } from '../../files-storage/utils.ts'
 import { computeModified } from './compute-modified.ts'
 import { defineReqContext, reqRestDataset, reqLinesOwnerOptional, reqResource, reqResourceType, reqBypassPermissions } from '../../misc/utils/req-context.ts'
 import { can } from '../../misc/utils/permissions.ts'
+import * as journals from '../../misc/utils/journals.ts'
 import { reqPublicBaseUrl } from '../../misc/utils/public-base-url.ts'
 
 type Operation = {
@@ -609,6 +610,17 @@ export const applyTransactions = async (dataset: RestDataset, sessionState: Sess
         const message = errorsText(validate.errors, '', operation.body)
         if (dataset.nonBlockingValidation) {
           operation._warning = message
+          // the index mapping is strict: a property outside the schema would get the whole line
+          // rejected by elasticsearch, drop it (the warning above names it) and keep the line
+          let additional = validate.errors?.filter(e => e.keyword === 'additionalProperties') ?? []
+          while (additional.length) {
+            for (const e of additional) {
+              delete operation.body[e.params.additionalProperty]
+              delete operation.fullBody[e.params.additionalProperty]
+            }
+            if (validate(operation.body)) break
+            additional = validate.errors?.filter(e => e.keyword === 'additionalProperties') ?? []
+          }
         } else {
           operation._error = message
           operation._status = 400
@@ -1013,11 +1025,23 @@ async function commitLines (dataset: RestDataset, lineIds: string[]) {
   }
   const attachments = !!dataset.schema.find(f => f['x-refersTo'] === 'http://schema.org/DigitalDocument')
   const indexName = aliasName(dataset)
+  // the dataset comes from mongo with its internal flags, RestDataset just does not type them
+  const stream = indexStream({ indexName, dataset, attachments, refresh: config.elasticsearch.singleLineOpRefresh, stampBytes: !!(dataset as DatasetInternal)._esLineBytes })
   await pump(
     ...await readStreams(dataset, { _id: { $in: lineIds } }),
-    indexStream({ indexName, dataset, attachments, refresh: config.elasticsearch.singleLineOpRefresh }),
+    stream,
     markIndexedStream(dataset)
   )
+  if (stream.nbRejectedItems) {
+    // the line is stored in mongo but elasticsearch rejected it (e.g. a field the index does not
+    // map): it kept its _needsIndexing flag so the next worker pass over the dataset retries it.
+    // Report it (journal + owner notification, like the worker does) and do not answer 200 to a
+    // client expecting read-after-write.
+    const message = `indexation refusée par elasticsearch pour ${stream.nbRejectedItems} ligne(s) : ${stream.firstRejectionReason}`
+    await journals.log('datasets', dataset, { type: 'error', data: message } as any)
+    internalError('rest-line-index-rejected', `dataset ${dataset.id}: ${message}`)
+    throw httpError(500, `la ligne est enregistrée mais son ${message}`)
+  }
 
   await mongo.datasets.updateOne({ id: dataset.id, _partialRestStatus: { $exists: false } }, {
     $set: {
@@ -1202,7 +1226,8 @@ export const deleteAllLines = async (req: RequestWithRestDataset, res: Response,
 
   // initDatasetIndex above replaced the index -> re-stamp, else a legacy stamp survives over a
   // new-shape index
-  await mongo.datasets.updateOne({ id: dataset.id }, { $set: { _partialRestStatus: 'updated', _indexShape: NEW_INDEX_SHAPE } })
+  // the fresh empty index is trivially fully stamped with _bytes (same reasoning as routes/write.ts)
+  await mongo.datasets.updateOne({ id: dataset.id }, { $set: { _partialRestStatus: 'updated', _indexShape: NEW_INDEX_SHAPE, _esLineBytes: true } })
 
   res.status(204).send()
   storageUtils.updateStorage(dataset).catch((err) => console.error('failed to update storage after deleteAllLines', err))

--- a/api/src/misc/routers/test-env.ts
+++ b/api/src/misc/routers/test-env.ts
@@ -346,6 +346,38 @@ router.post('/es-divert-alias/:datasetId', async (req, res, next) => {
   }
 })
 
+// Rebuild a dataset's index WITHOUT one of its mapped fields and point the alias at it: models
+// an index created by an older release, before that field was added to buildIndexMappings
+// (strict mapping -> a bulk item carrying the field is rejected). The orphan copy is cleaned by
+// nothing: test-env only.
+router.post('/es-strip-mapping-field/:datasetId', async (req, res, next) => {
+  try {
+    const dataset = await mongo.datasets.findOne({ id: req.params.datasetId })
+    if (!dataset) return res.status(404).send()
+    const field: string = req.body.field
+    const { aliasName } = await import('../../datasets/es/commons.ts')
+    const alias = aliasName(dataset)
+    const current = Object.keys(await es.client.indices.getAlias({ name: alias }))[0]
+    const definition = (await es.client.indices.get({ index: current }))[current]
+    const settings = { ...definition.settings }
+    settings.index = { ...settings.index }
+    for (const key of ['uuid', 'provided_name', 'creation_date', 'version']) delete settings.index[key]
+    const mappings = definition.mappings ?? {}
+    delete mappings.properties?.[field]
+    const stripped = `${current}-stripped-${Date.now()}`
+    await es.client.indices.create({ index: stripped, body: { settings, mappings } })
+    await es.client.reindex({
+      body: { source: { index: current }, dest: { index: stripped }, script: { source: 'ctx._source.remove(params.field)', params: { field } } },
+      refresh: true,
+      wait_for_completion: true
+    })
+    await es.client.indices.updateAliases({ body: { actions: [{ remove: { alias, index: current } }, { add: { alias, index: stripped } }] } })
+    res.json({ ok: true })
+  } catch (err) {
+    next(err)
+  }
+})
+
 // Trigger the expired-revision purge on demand (test-only). `ignoreAge` skips the age pre-filter
 // and `skewMarginMs` shrinks the clock-skew margin, so a test can exercise the real retain-until
 // decision on a seconds-long lock instead of waiting out a full retention window.

--- a/api/src/workers/batch-processor/index-lines.ts
+++ b/api/src/workers/batch-processor/index-lines.ts
@@ -91,7 +91,9 @@ export default async function (dataset: DatasetInternal) {
 
   // only the REST path consumes the re-emitted lines (markIndexedStream); for file
   // datasets the sink is a no-op, so skip the per-line copy on the readable side
-  const indexStream = getIndexStream({ indexName, dataset, attachments: !!attachmentsProperty, reemit: isRestDataset(dataset) })
+  // a full reindex targets a fresh index that maps _bytes; a partial REST sync targets the
+  // existing one, which maps it iff the dataset is marked _esLineBytes
+  const indexStream = getIndexStream({ indexName, dataset, attachments: !!attachmentsProperty, reemit: isRestDataset(dataset), stampBytes: !partialUpdate || !!dataset._esLineBytes })
 
   if (!dataset.extensions || dataset.extensions.filter(e => e.active).length === 0) {
     if (dataset.file && await filesStorage.fileExists(datasetUtils.fullFilePath(dataset))) {

--- a/docs/architecture/storage-accounting.md
+++ b/docs/architecture/storage-accounting.md
@@ -50,9 +50,23 @@ lineBytes({ name: 'abc', nb: 12, _ext_geo: { lat: 1.5, lon: 48 }, _i: 4, _update
 the plain-insert branch — not the `updateMode` `doc`-patch branch, not the delete branch) computes
 `item._bytes = lineBytes(item, this.lineBytesSpec)` **after** `applyCalculations(item)`, so
 extension/calculated fields already present at insert time are reflected. This path is exercised
-both by the batch reindex worker and by `commitLines` (`api/src/datasets/utils/rest.ts` ≈ line
-996, the real-time single-line REST write-then-read-after-write path) — any line that is
-(re-)written to Elasticsearch gets a fresh `_bytes`.
+both by the batch reindex worker and by `commitLines` (`api/src/datasets/utils/rest.ts`, the
+real-time single-line REST write-then-read-after-write path).
+
+**Only into an index that maps it** (`stampBytes` option of `IndexStream`, mandatory so every
+caller decides). Index mappings are `dynamic: strict`: a document carrying `_bytes` is rejected
+whole by an index built before the field existed. A full reindex always targets a fresh index and
+stamps; a partial REST sync (worker `_needsIndexing` pass, `commitLines`) targets the existing
+index and stamps **iff the dataset is marked `_esLineBytes`** — exactly the datasets whose current
+index was built by stamping code (see below), and the only ones whose sum is read anyway. This
+gating is what 6.18.0 lacked: it stamped unconditionally, every single-line write into a
+pre-6.18.0 REST index was rejected, and the bulk stream then swallowed the rejection (HTTP 200,
+line marked as indexed in mongo, stale or missing in `/lines`; the lines lost that way are only
+recovered by a full reindex of the dataset, which is the manual remedy chosen over an upgrade
+script — the Elasticsearch admin page lists the REST datasets still on such an index, section
+`restDatasetsWithoutLineBytes` of `/api/v1/admin/elasticsearch/diagnose`, with a reindex button). `IndexStream` no longer re-emits a rejected line — its `_needsIndexing` flag survives and
+`commitLines` answers 500 + journal error instead of 200 (see
+`tests/features/datasets/rest/rest-datasets-legacy-index.api.spec.ts`).
 
 `_bytes` is mapped in `buildIndexMappings` (`operations.ts` ≈ line 542) as
 `{ type: 'integer', index: false }` — aggregatable via doc_values, never searched.
@@ -106,7 +120,7 @@ Summing `_bytes` is only trustworthy once **every** doc in the index carries it 
 guaranteed right after a full index rebuild done by code that stamps it. So the CSV-equivalent
 metric is adopted per-dataset, not globally:
 
-- `api/src/workers/batch-processor/index-lines.ts` sets `result._esLineBytes = true` (≈ line 221)
+- `api/src/workers/batch-processor/index-lines.ts` sets `result._esLineBytes = true`
   **only** in the full-reindex branch — i.e. when `partialUpdate` (`dataset._partialRestStatus ===
   'updated' | 'extended'`, ≈ line 48) is false, right after the whole index has been rebuilt
   through `IndexStream` and the alias switched. The REST partial-update branch (existing index,
@@ -135,9 +149,9 @@ metric is adopted per-dataset, not globally:
   delay, not a correctness bug.
 - **Rolling-deploy caveat, marker-set-at-creation windows**: some paths set `_esLineBytes` directly
   instead of waiting for a stamping full reindex, because the index is trivially fully stamped at
-  the moment the marker is set (e.g. `api/src/datasets/routes/write.ts` ≈ line 99 sets it on REST
-  dataset creation, right after the API pod builds the index empty — vacuously true with zero
-  docs). During a rollout this marker can outlive its invariant: a REST dataset created by a new
+  the moment the marker is set (e.g. `api/src/datasets/routes/write.ts` sets it on REST dataset
+  creation, and `deleteAllLines` in `api/src/datasets/utils/rest.ts` on its fresh index, right after
+  the API pod builds the index empty — vacuously true with zero docs). During a rollout this marker can outlive its invariant: a REST dataset created by a new
   API pod gets `_esLineBytes = true` on its empty index, but the *first* batch of lines is then
   indexed by an old worker replica (`api/src/workers/batch-processor/index-lines.ts`) that doesn't
   stamp `_bytes`; symmetrically, a draft fully rebuilt by an old worker and then validated
@@ -149,6 +163,10 @@ metric is adopted per-dataset, not globally:
   forever to guard an ephemeral deploy window. The exposure is bounded to datasets whose index
   was (re)built during the deploy itself, and any full reindex of an affected dataset converges
   and repairs it, since a full reindex re-stamps every doc through the same `IndexStream` path.
+  Since the stamp is gated on the marker, the same window has a second, louder face: an index
+  rebuilt by an old worker under a marker that says it's stamped does not *map* `_bytes`, so
+  single-line writes into it are rejected (500 + journal error, line kept flagged) until that
+  full reindex.
 - Virtual datasets never take this path (`storage()` guards `!isVirtualDataset(dataset)`): they
   have no index of their own lines, so their `indexed` size stays the existing
   proportional-to-descendants `master-data` computation.

--- a/tests/features/admin/elasticsearch-diagnose.api.spec.ts
+++ b/tests/features/admin/elasticsearch-diagnose.api.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@playwright/test'
 import assert from 'node:assert/strict'
 import { axiosAuth, clean, checkPendingTasks } from '../../support/axios.ts'
-import { waitForFinalize } from '../../support/workers.ts'
+import { waitForFinalize, sendDataset, patchRawDataset, clearDatasetCache } from '../../support/workers.ts'
 
 const testUser1 = await axiosAuth('test_user1@test.com')
 const adminUser = await axiosAuth('test_superadmin@test.com', undefined, true)
@@ -58,5 +58,28 @@ test.describe('admin/elasticsearch/diagnose', () => {
     assert.equal(typeof body.datasetsWithEsWarnings.count, 'number')
 
     assert.ok(Array.isArray(body.errors))
+  })
+
+  test('lists the REST datasets whose index predates the _bytes mapping, until they are reindexed', async () => {
+    await testUser1.put('/api/v1/datasets/esdiag-legacy', {
+      isRest: true,
+      title: 'esdiag-legacy',
+      schema: [{ key: 'attr1', type: 'string' }]
+    })
+    await testUser1.post('/api/v1/datasets/esdiag-legacy/_bulk_lines', [{ attr1: 'a' }])
+    await waitForFinalize(testUser1, 'esdiag-legacy')
+    // a file dataset never carries the marker before its first full reindex, it is not concerned
+    await sendDataset('datasets/dataset1.csv', testUser1)
+
+    const listed = async () => (await adminUser.get('/api/v1/admin/elasticsearch/diagnose')).data.restDatasetsWithoutLineBytes.results.map((d: any) => d.id)
+    assert.deepEqual(await listed(), [])
+
+    await patchRawDataset('esdiag-legacy', { $unset: { _esLineBytes: 1 } })
+    await clearDatasetCache()
+    assert.deepEqual(await listed(), ['esdiag-legacy'])
+
+    await adminUser.post('/api/v1/datasets/esdiag-legacy/_reindex')
+    await waitForFinalize(testUser1, 'esdiag-legacy')
+    assert.deepEqual(await listed(), [])
   })
 })

--- a/tests/features/datasets/rest/rest-datasets-crud.api.spec.ts
+++ b/tests/features/datasets/rest/rest-datasets-crud.api.spec.ts
@@ -433,6 +433,11 @@ test1,,"",valko`, { headers: { 'content-type': 'text/csv' } })
 
     const resPost = await ax.post('/api/v1/datasets/rest4/lines', { attr1: 'test', attr3: 'test1' })
     assert.equal(resPost.data._warning, 'ne doit pas contenir de propriétés additionnelles (attr3)')
+    // the extra property is dropped (the strict index would reject the whole line), the line is indexed
+    assert.equal(resPost.data.attr3, undefined)
+    const resLines = await ax.get('/api/v1/datasets/rest4/lines')
+    assert.equal(resLines.data.total, 1)
+    assert.equal(resLines.data.results[0].attr1, 'test')
 
     const res = await ax.post('/api/v1/datasets/rest4/_bulk_lines', [
       { _id: 'line1', attr1: 'test' },

--- a/tests/features/datasets/rest/rest-datasets-legacy-index.api.spec.ts
+++ b/tests/features/datasets/rest/rest-datasets-legacy-index.api.spec.ts
@@ -1,0 +1,112 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { axios, axiosAuth, clean, checkPendingTasks, config, directoryUrl, mockAppUrl } from '../../../support/axios.ts'
+import { waitForFinalize, clearRateLimiting, clearDatasetCache, getRawDataset, patchRawDataset, datasetEsMappingProperties } from '../../../support/workers.ts'
+
+const anonymous = axios()
+const testUser1 = await axiosAuth('test_user1@test.com')
+const testSuperadmin = await axiosAuth('test_superadmin@test.com', undefined, true)
+
+// 6.18.0 started stamping `_bytes` on every indexed line, but an index built by an older release
+// has a strict mapping without it: every single-line write into such an index was rejected by
+// elasticsearch with a per-item error that the bulk stream only memorized -> HTTP 200, line marked
+// as indexed in mongo, line stale or missing in /lines. The stamp is now gated on `_esLineBytes`
+// (set only when the current index was built by stamping code) and a rejection is loud.
+test.describe('REST datasets - writes into an index built by an older release', () => {
+  test.beforeEach(async () => {
+    await clean()
+  })
+
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === 'passed') await checkPendingTasks()
+  })
+
+  const createDataset = async (id: string) => {
+    await testUser1.put(`/api/v1/datasets/${id}`, {
+      isRest: true,
+      title: id,
+      primaryKey: ['attr1'],
+      schema: [{ key: 'attr1', type: 'string' }, { key: 'attr2', type: 'string' }]
+    })
+    const res = await testUser1.post(`/api/v1/datasets/${id}/lines`, { attr1: 'key1', attr2: 'initial' })
+    await waitForFinalize(testUser1, id)
+    return res.data._id as string
+  }
+
+  // model a dataset whose index was built before 6.18.0: no _bytes in the (strict) mapping, no marker
+  const makeLegacy = async (id: string, keepMarker = false) => {
+    await anonymous.post(`/api/v1/test-env/es-strip-mapping-field/${id}`, { field: '_bytes' })
+    assert.equal((await datasetEsMappingProperties(id))._bytes, undefined)
+    if (!keepMarker) {
+      await patchRawDataset(id, { $unset: { _esLineBytes: 1 } })
+      await clearDatasetCache()
+    }
+  }
+
+  test('single-line writes are indexed without _bytes (the production regression)', async () => {
+    const ax = testUser1
+    const lineId = await createDataset('restlegacy')
+    await makeLegacy('restlegacy')
+
+    let res = await ax.patch(`/api/v1/datasets/restlegacy/lines/${lineId}`, { attr2: 'patched' })
+    assert.equal(res.status, 200)
+    res = await ax.get('/api/v1/datasets/restlegacy/lines')
+    assert.equal(res.data.results[0].attr2, 'patched')
+    await waitForFinalize(ax, 'restlegacy')
+
+    // anonymous patch through an application key, as in the production report
+    res = await ax.post('/api/v1/applications', { url: mockAppUrl('monapp1') })
+    const appId = res.data.id
+    await ax.put('/api/v1/applications/' + appId + '/config', {
+      datasets: [{
+        href: `${config.publicUrl}/api/v1/datasets/restlegacy`,
+        applicationKeyPermissions: { operations: ['createLine', 'patchLine', 'readLines'] }
+      }]
+    })
+    res = await ax.post(`/api/v1/applications/${appId}/keys`, [{ title: 'Access key' }])
+    const key = res.data[0].id
+    const anonymousToken = (await anonymous.get(directoryUrl + '/api/auth/anonymous-action')).data
+    await clearRateLimiting()
+    await new Promise(resolve => setTimeout(resolve, 2000))
+    const headers = { referrer: config.publicUrl + `/app/${appId}/?key=${key}`, 'x-anonymousToken': anonymousToken }
+    res = await anonymous.post('/api/v1/datasets/restlegacy/lines', { _action: 'patch', _id: lineId, attr2: 'anon-patched' }, { headers })
+    assert.equal(res.status, 200)
+    res = await anonymous.get('/api/v1/datasets/restlegacy/lines', { headers })
+    assert.equal(res.data.results[0].attr2, 'anon-patched')
+    await waitForFinalize(ax, 'restlegacy')
+
+    // a bulk write goes through the worker's partial sync of the same index
+    res = await ax.post('/api/v1/datasets/restlegacy/_bulk_lines', [{ attr1: 'key1', attr2: 'bulk-patched' }, { attr1: 'key2', attr2: 'created' }])
+    assert.equal(res.data.nbOk, 2)
+    await waitForFinalize(ax, 'restlegacy')
+    res = await ax.get('/api/v1/datasets/restlegacy/lines', { params: { sort: 'attr1' } })
+    assert.deepEqual(res.data.results.map((r: any) => r.attr2), ['bulk-patched', 'created'])
+  })
+
+  test('a line the index rejects is not silently dropped', async () => {
+    const ax = testUser1
+    const lineId = await createDataset('restrejected')
+    // the marker outlived its index (rolling-deploy caveat in storage-accounting.md)
+    await makeLegacy('restrejected', true)
+
+    // the write is stored in mongo but cannot be indexed: the client must not get a 200
+    await assert.rejects(ax.patch(`/api/v1/datasets/restrejected/lines/${lineId}`, { attr2: 'patched' }), (err: any) => err.status === 500 && err.data.includes('_bytes'))
+    let res = await anonymous.get('/api/v1/test-env/rest-collection-find-one/restrejected', { params: { filter: JSON.stringify({ _id: lineId }) } })
+    assert.equal(res.data.attr2, 'patched')
+    assert.equal(res.data._needsIndexing, true, 'the line must stay flagged for indexing')
+    // reported in the journal, the dataset itself is untouched
+    res = await ax.get('/api/v1/datasets/restrejected/journal')
+    assert.ok(res.data.find((e: any) => e.type === 'error' && e.data.includes('_bytes')), 'journal error expected')
+    assert.equal((await getRawDataset('restrejected')).status, 'finalized')
+    res = await ax.get('/api/v1/datasets/restrejected/lines')
+    assert.equal(res.data.results[0].attr2, 'initial')
+
+    // a full reindex rebuilds an index that maps the field and picks the flagged line up
+    await testSuperadmin.post('/api/v1/datasets/restrejected/_reindex')
+    await waitForFinalize(ax, 'restrejected')
+    res = await ax.get('/api/v1/datasets/restrejected/lines')
+    assert.equal(res.data.results[0].attr2, 'patched')
+    res = await anonymous.get('/api/v1/test-env/rest-collection-find-one/restrejected', { params: { filter: JSON.stringify({ _id: lineId }) } })
+    assert.equal(res.data._needsIndexing, undefined)
+  })
+})

--- a/ui/src/pages/admin/elasticsearch.vue
+++ b/ui/src/pages/admin/elasticsearch.vue
@@ -534,6 +534,57 @@
       </v-sheet>
     </template>
 
+    <!-- REST datasets whose index predates the _bytes mapping: single-line writes are refused
+         until a full reindex rebuilds it (docs/architecture/storage-accounting.md) -->
+    <template v-if="data?.restDatasetsWithoutLineBytes">
+      <h3 class="text-title-large mt-6">
+        {{ t('legacyIndex.title') }}
+      </h3>
+      <p
+        v-if="data.restDatasetsWithoutLineBytes.count === 0"
+        class="text-medium-emphasis"
+      >
+        {{ t('legacyIndex.none') }}
+      </p>
+      <template v-else>
+        <p class="text-medium-emphasis">
+          {{ t('legacyIndex.help', { count: data.restDatasetsWithoutLineBytes.count }) }}
+        </p>
+        <v-sheet
+          class="my-4"
+          style="max-height:800px; overflow-y: scroll;"
+        >
+          <v-list lines="two">
+            <v-list-item
+              v-for="d in data.restDatasetsWithoutLineBytes.results"
+              :key="d.id"
+            >
+              <v-list-item-title>
+                <a
+                  :href="`/data-fair/dataset/${d.id}`"
+                  target="_top"
+                  class="simple-link"
+                >{{ d.title }} ({{ d.owner.name }})</a>
+              </v-list-item-title>
+              <v-list-item-subtitle>
+                {{ t('legacyIndex.subtitle', { status: d.status, count: d.count ?? 0, date: d.dataUpdatedAt ? dayjs(d.dataUpdatedAt).format('lll') : '-' }) }}
+              </v-list-item-subtitle>
+              <template #append>
+                <v-btn
+                  :icon="mdiPlay"
+                  color="primary"
+                  :title="t('legacyIndex.reindex')"
+                  variant="text"
+                  :loading="reindex.loading.value"
+                  @click="reindex.execute(d.id)"
+                />
+              </template>
+            </v-list-item>
+          </v-list>
+        </v-sheet>
+      </template>
+    </template>
+
     <v-progress-circular
       v-if="diagnoseFetch.loading.value && !data"
       indeterminate
@@ -594,6 +645,12 @@ fr:
     title: Jeux de données avec avertissements Elasticsearch
     none: Aucun jeu de données avec avertissements Elasticsearch
     reindex: Réindexer
+  legacyIndex:
+    title: Jeux de données éditables à réindexer
+    none: Aucun jeu de données éditable sur un index antérieur à la version 6.18.0
+    help: "{count} jeu(x) de données éditable(s) sur un index construit avant la version 6.18.0 : les écritures ligne à ligne y ont été perdues entre le déploiement de la 6.18.0 et son correctif, une réindexation complète reconstruit l'index à partir des données stockées."
+    subtitle: "état {status}, {count} lignes, dernière écriture {date}"
+    reindex: Réindexer
 en:
   title: Elasticsearch
   refresh: Refresh
@@ -645,6 +702,12 @@ en:
     title: Datasets with Elasticsearch warnings
     none: No datasets with Elasticsearch warnings
     reindex: Reindex
+  legacyIndex:
+    title: Editable datasets to reindex
+    none: No editable dataset on an index older than version 6.18.0
+    help: "{count} editable dataset(s) on an index built before version 6.18.0: line-by-line writes were lost there between the 6.18.0 deployment and its fix, a full reindex rebuilds the index from the stored data."
+    subtitle: "status {status}, {count} lines, last write {date}"
+    reindex: Reindex
 </i18n>
 
 <script setup lang="ts">
@@ -668,9 +731,11 @@ type DiagnoseResponse = {
   unassignedShards: any[]
   indicesSummary: any | null
   datasetsWithEsWarnings: { count: number, results: any[] }
+  restDatasetsWithoutLineBytes: { count: number, results: any[] }
   errors: Array<{ section: string, message: string }>
 }
 
+const { dayjs } = useLocaleDayjs()
 const diagnoseFetch = useFetch<DiagnoseResponse>($apiPath + '/admin/elasticsearch/diagnose')
 const data = computed(() => diagnoseFetch.data.value)
 


### PR DESCRIPTION
Since 6.18.0 every indexed line carries `_bytes`, but only an index built by that release maps it (mappings are strict). On a REST dataset whose index predates it, every single-line write and partial bulk sync was rejected by Elasticsearch, and the bulk stream swallowed the rejection: HTTP 200, Mongo updated, index stale. Application-key writes were only the reporter's path, not the cause.

- gate the `_bytes` stamp on `_esLineBytes` (new mandatory `stampBytes` option of `IndexStream`): a fresh index always stamps, an existing one only when the dataset is marked; `deleteAllLines` marks its fresh index
- a line rejected by the bulk response is no longer re-emitted, so its `_needsIndexing` flag survives; `commitLines` answers 500 + journal error instead of 200
- `nonBlockingValidation` drops out-of-schema properties instead of storing a line the strict index then rejects whole
- the Elasticsearch admin page lists the REST datasets still on a legacy index (`restDatasetsWithoutLineBytes` in the diagnose payload) with the reindex button; lines lost before this fix are recovered by that manual full reindex, no upgrade script

**Why:** anonymous patches on the koumoul.com dataset `vehg4sujb1msr6v0lk1h1f-8` returned 200 but never showed up in `/lines`: the newest `_updatedAt` in its index was 2026-08-31 while `dataUpdatedAt` was 2026-09-04, the day after the 6.18.0 release.

**Heads-up:**
- rejected lines now keep `_needsIndexing` and are retried on every partial pass; a line Elasticsearch will never accept produces a journal error each time and, if it is the only line of a pass, trips the worker's "more than half in error" rule and puts the dataset in error
- `nonBlockingValidation` no longer stores out-of-schema properties in Mongo (they were never queryable, but a later schema change followed by a reindex would have surfaced them)
- pods still on 6.18.0 during the rollout keep losing writes silently; reindex the listed datasets once the rollout is complete
