### PR TITLE
fix(datasets): compute _bytes with the CSV export serializer so indexed size matches the download

### DIFF
--- a/api/src/datasets/es/index-stream.ts
+++ b/api/src/datasets/es/index-stream.ts
@@ -8,7 +8,7 @@ import debugLib from 'debug'
 import es from '#es'
 import { internalError } from '@data-fair/lib-node/observer.js'
 import type { Dataset } from '#types'
-import { lineBytes, lineBytesSpec } from './operations.ts'
+import { lineBytes, lineBytesSpec, type LineBytesSpec } from './operations.ts'
 
 const debug = debugLib('index-stream')
 
@@ -49,7 +49,7 @@ class IndexStream extends Transform {
   // error reporting and (REST only) re-emitting on the readable side
   items: any[]
   applyCalculations: (item: any) => Promise<string | null>
-  lineBytesSpec: { prefixes: Set<string>, nbCols: number }
+  lineBytesSpec: LineBytesSpec
   bulkChars: number
   i: number
   // warnings from applyCalculations AND items rejected by the bulk response (errorsSummary)
@@ -66,7 +66,7 @@ class IndexStream extends Transform {
     this.options.refresh = this.options.refresh || false
     this.options.reemit = this.options.reemit ?? true
     this.applyCalculations = extensionsUtils.prepareCalculations(options.dataset)
-    this.lineBytesSpec = lineBytesSpec(options.dataset.schema ?? [])
+    this.lineBytesSpec = lineBytesSpec(options.dataset)
     this.body = []
     this.items = []
     this.bulkChars = 0

--- a/api/src/datasets/es/operations.ts
+++ b/api/src/datasets/es/operations.ts
@@ -1,5 +1,7 @@
 import { httpError } from '@data-fair/lib-utils/http-errors.js'
 import memoize from 'memoizee'
+import { getCsvSerializer } from '../utils/csv-jit.ts'
+import { getFlattenNoCache } from '../utils/flatten.ts'
 import capabilities from '../../../contract/capabilities.js'
 
 export interface ExtractedError {
@@ -810,34 +812,26 @@ export const buildIndexMappings = (
 }
 
 // CSV-equivalent size accounting for the indexed_bytes metric.
-// Counted columns are exactly the ones the CSV export emits (outputs.ts): schema
-// properties without x-calculated. Extension columns are nested objects in the
-// indexed item, so counting walks the top-level key segment of each property.
-export const lineBytesSpec = (schema: any[]): { prefixes: Set<string>, nbCols: number } => {
-  const counted = (schema ?? []).filter(p => !p['x-calculated'])
-  return {
-    prefixes: new Set(counted.map(p => p.key.split('.')[0])),
-    nbCols: counted.length
-  }
+// `_bytes` is defined as the byte length of the row the default CSV export (`/lines?format=csv`,
+// no select, ',' delimiter — compileForRequest in outputs.ts) emits for the line, header and BOM
+// excluded. It is computed with the export's own serializer + flatten so the two cannot drift:
+// strings quoted (embedded quotes doubled), booleans as 1/0, separator arrays joined, extension
+// sub-objects flattened, calculated columns excluded. Compiled without the memo caches: the stamp
+// runs on the schema being indexed, which may differ from the one cached under the same
+// (id, finalizedAt) key by a previous read or reindex.
+export interface LineBytesSpec { row: (line: Record<string, any>) => string, flatten: (line: Record<string, any>) => Record<string, any> }
+
+export const lineBytesSpec = (dataset: { id: string, finalizedAt?: string, schema?: any[] }): LineBytesSpec => {
+  const schema = dataset.schema ?? []
+  const selectKeys = schema.filter(p => !p['x-calculated']).map(p => p.key)
+  const { row } = getCsvSerializer({ dataset: { ...dataset, schema }, selectKeys, header: false, bom: false, cache: false })
+  return { row, flatten: getFlattenNoCache({ ...dataset, schema }) }
 }
 
-const valueBytes = (value: any): number => {
-  if (value === null || value === undefined) return 0
-  if (typeof value === 'string') return Buffer.byteLength(value)
-  if (typeof value === 'object') {
-    let sum = 0
-    for (const v of Object.values(value)) sum += valueBytes(v)
-    return sum
-  }
-  return Buffer.byteLength(String(value))
-}
-
-// per line: value bytes + 1 byte per counted column (separator / newline),
-// mirroring the size of a CSV export of the same data
-export const lineBytes = (item: Record<string, any>, spec: { prefixes: Set<string>, nbCols: number }): number => {
-  let sum = spec.nbCols
-  for (const prefix of spec.prefixes) sum += valueBytes(item[prefix])
-  return sum
+// the flatten helper mutates its input (moves nested extension values to flat keys, joins separator
+// arrays), so it runs on a shallow copy and the indexed line is left untouched
+export const lineBytes = (item: Record<string, any>, spec: LineBytesSpec): number => {
+  return Buffer.byteLength(spec.row(spec.flatten({ ...item })))
 }
 
 /**

--- a/api/src/datasets/es/operations.ts
+++ b/api/src/datasets/es/operations.ts
@@ -1,7 +1,7 @@
 import { httpError } from '@data-fair/lib-utils/http-errors.js'
 import memoize from 'memoizee'
 import { getCsvSerializer } from '../utils/csv-jit.ts'
-import { getFlattenNoCache } from '../utils/flatten.ts'
+import { getFlattenNoCache, isFlattenIdentity } from '../utils/flatten.ts'
 import capabilities from '../../../contract/capabilities.js'
 
 export interface ExtractedError {
@@ -819,19 +819,22 @@ export const buildIndexMappings = (
 // sub-objects flattened, calculated columns excluded. Compiled without the memo caches: the stamp
 // runs on the schema being indexed, which may differ from the one cached under the same
 // (id, finalizedAt) key by a previous read or reindex.
-export interface LineBytesSpec { row: (line: Record<string, any>) => string, flatten: (line: Record<string, any>) => Record<string, any> }
+// flatten is null when the schema has no nested extension key and no separator column: the export's flatten
+// would be the identity, so the line is serialized as-is without the defensive copy it would otherwise need
+export interface LineBytesSpec { row: (line: Record<string, any>) => string, flatten: ((line: Record<string, any>) => Record<string, any>) | null }
 
 export const lineBytesSpec = (dataset: { id: string, finalizedAt?: string, schema?: any[] }): LineBytesSpec => {
   const schema = dataset.schema ?? []
   const selectKeys = schema.filter(p => !p['x-calculated']).map(p => p.key)
   const { row } = getCsvSerializer({ dataset: { ...dataset, schema }, selectKeys, header: false, bom: false, cache: false })
-  return { row, flatten: getFlattenNoCache({ ...dataset, schema }) }
+  const fullDataset = { ...dataset, schema }
+  return { row, flatten: isFlattenIdentity(fullDataset) ? null : getFlattenNoCache(fullDataset) }
 }
 
 // the flatten helper mutates its input (moves nested extension values to flat keys, joins separator
 // arrays), so it runs on a shallow copy and the indexed line is left untouched
 export const lineBytes = (item: Record<string, any>, spec: LineBytesSpec): number => {
-  return Buffer.byteLength(spec.row(spec.flatten({ ...item })))
+  return Buffer.byteLength(spec.row(spec.flatten ? spec.flatten({ ...item }) : item))
 }
 
 /**

--- a/api/src/datasets/utils/csv-jit.ts
+++ b/api/src/datasets/utils/csv-jit.ts
@@ -169,12 +169,15 @@ export interface GetCsvSerializerArgs {
   header?: boolean
   /** record separator (defaults to '\n') */
   newline?: string
+  /** memoize the compiled serializer on (dataset id, finalizedAt, options) — defaults to true; pass
+   *  false when the schema may differ from the one cached under the same key (e.g. at index time) */
+  cache?: boolean
 }
 
 export const getCsvSerializer = (args: GetCsvSerializerArgs): CompiledCsv => {
   const {
     dataset, selectKeys, useTitle = false,
-    delimiter = ',', bom = true, header = true, newline = '\n'
+    delimiter = ',', bom = true, header = true, newline = '\n', cache = true
   } = args
 
   const propByKey = new Map<string, any>()
@@ -193,6 +196,8 @@ export const getCsvSerializer = (args: GetCsvSerializerArgs): CompiledCsv => {
     }
     return { key, header: h || key, type }
   })
+
+  if (!cache) return compileCsv(columns, { bom, header, delimiter, newline })
 
   const cacheKey = [
     dataset.id,

--- a/api/src/datasets/utils/flatten.ts
+++ b/api/src/datasets/utils/flatten.ts
@@ -8,7 +8,9 @@
 import type { DatasetLine } from '#types'
 import memoize from 'memoizee'
 
-const compileFlatten = (datasetId: string, finalizedAt: string, preserveArrays: boolean, fillNull: string, dataset: any): (line: any) => DatasetLine => {
+// the statements applied to a line: nested keys (extension sub-objects) moved to flat keys, separator
+// arrays joined, fillNull keys defaulted. Empty when the schema needs none of it, i.e. flatten is the identity
+const flattenStatements = (preserveArrays: boolean, fillNull: string, dataset: any): string => {
   let jitCode = ''
   const nestedKeys: string[] = []
   const fillNullArr = fillNull.split(',').filter(Boolean)
@@ -41,10 +43,12 @@ const compileFlatten = (datasetId: string, finalizedAt: string, preserveArrays: 
   for (const fillNullKey of fillNullArr) {
     jitCode += `if (o["${fillNullKey}"] === undefined) { o["${fillNullKey}"] = null }\n`
   }
-  jitCode += 'return o;'
+  return jitCode
+}
 
+const compileFlatten = (datasetId: string, finalizedAt: string, preserveArrays: boolean, fillNull: string, dataset: any): (line: any) => DatasetLine => {
   // @ts-ignore
-  return new Function('o', jitCode)
+  return new Function('o', flattenStatements(preserveArrays, fillNull, dataset) + 'return o;')
 }
 
 const memoizedCompileFlatten = memoize(compileFlatten, {
@@ -61,4 +65,10 @@ export const getFlatten = (dataset: any, preserveArrays: boolean = false, fillNu
 
 export const getFlattenNoCache = (dataset: any, preserveArrays: boolean = false, fillNull: string[] = []) => {
   return compileFlatten(dataset.id, dataset.finalizedAt, preserveArrays, fillNull.join(','), dataset)
+}
+
+// true when flatten(line) would return the line unchanged (no nested key, no separator column to join, no
+// fillNull), letting callers that must not mutate their input skip the flatten and the copy it requires
+export const isFlattenIdentity = (dataset: any, preserveArrays: boolean = false, fillNull: string[] = []) => {
+  return flattenStatements(preserveArrays, fillNull.join(','), dataset) === ''
 }

--- a/docs/architecture/storage-accounting.md
+++ b/docs/architecture/storage-accounting.md
@@ -22,28 +22,41 @@ Both live on `Dataset.storage` (`{ size, indexed: { size, parts }, attachments, 
 
 ## The CSV-equivalent formula
 
-Counted columns are **exactly the columns a CSV export would emit** — the same rule as
-`compileForRequest` in `api/src/datasets/utils/outputs.ts:34`: every schema property without
-`x-calculated` (so `_i`, `_updatedAt`, `_geopoint`, `_rand`, `_file_raw`, and friends are
-excluded; extension output columns are included, since they aren't calculated).
+`_bytes` is **defined as the byte length of the row the default CSV export emits for the line** —
+`/lines?format=csv` with no `select`, `,` delimiter, `\n` newline — header row and BOM excluded.
+So for a whole dataset, `indexed_bytes` = size of the full CSV download minus its 3-byte BOM and
+its header line (`tests/features/datasets/storage-line-bytes.api.spec.ts` asserts exactly that
+against a real export).
 
-`api/src/datasets/es/operations.ts`:
+Rather than re-implementing the serializer's rules, the stamp **runs the export's own code**
+(`api/src/datasets/es/operations.ts`):
 
-- `lineBytesSpec(schema)` — a pure, per-dataset precomputation: `nbCols` (count of counted
-  columns) and `prefixes` (their top-level key segment — extension columns are nested objects
-  like `_ext_geo.lat`/`_ext_geo.lon`, so counting walks by the `_ext_geo` prefix, reading the
-  whole sub-object once).
-- `lineBytes(item, spec)` — per line: `spec.nbCols` (1 byte per counted column, standing in for
-  the CSV separator/newline) **+** the UTF-8 byte length of each counted value
-  (`Buffer.byteLength`, objects summed recursively). Missing/null values contribute 0 bytes but
-  still keep their separator byte.
+- `lineBytesSpec(dataset)` — once per `IndexStream`: compiles the export's row serializer
+  (`getCsvSerializer` from `csv-jit.ts`, same column selection as `compileForRequest` in
+  `outputs.ts`: every schema property without `x-calculated`, so `_i`, `_updatedAt`, `_geopoint`,
+  `_rand`, `_attachment_url`, `_ext_x.error` and friends are excluded; extension output columns are
+  included) with `header: false, bom: false`, plus the export's flatten helper (`getFlattenNoCache`,
+  which moves nested extension values such as `_ext_geo.lat` to flat keys and joins `separator`
+  arrays). Both are compiled **without their memo caches**: those are keyed on
+  `(id, finalizedAt)`, and at index time the schema being indexed can differ from the one a
+  previous read or reindex cached under the same key.
+- `lineBytes(item, spec)` — per line: `Buffer.byteLength(spec.row(spec.flatten({ ...item })))`.
+  The shallow copy matters: flatten mutates its input, and the item goes on to Elasticsearch as-is.
+
+The consequences of "same serializer" are exactly the CSV conventions: strings are always quoted
+(`+2` bytes) with embedded `"` doubled, booleans are `1`/`0`, numbers are `String(v)`, null or
+missing values are empty cells, multi-valued columns are joined with their separator then quoted,
+object values are `JSON.stringify`ed then quoted if needed, `\0` characters are stripped, and each
+line ends with one newline.
 
 ```
-lineBytes({ name: 'abc', nb: 12, _ext_geo: { lat: 1.5, lon: 48 }, _i: 4, _updatedAt: '…' })
-  = 'abc'(3) + '12'(2) + '1.5'(3) + '48'(2) + 4 separators = 14
+schema: name (string), nb (integer), flag (boolean), tags (string, separator ';'),
+        _ext_geo.lat / _ext_geo.lon (number), _i / _updatedAt / _ext_geo.error (x-calculated)
+lineBytes({ name: 'a"b', nb: 12, flag: true, tags: ['x', 'y'], _ext_geo: { lat: 1.5, lon: 48, error: 'boom' }, _i: 4 })
+  = byteLength('"a""b",12,1,"x;y",1.5,48\n') = 25
 ```
 
-(worked examples, including multi-byte UTF-8 and the calculated-column exclusion, in
+(worked examples, including multi-byte UTF-8 and the no-mutation guarantee, in
 `tests/features/datasets/es/line-bytes.unit.spec.ts`).
 
 **Where it's stamped.** `api/src/datasets/es/index-stream.ts` (`IndexStream.transformPromise`,

--- a/docs/architecture/storage-accounting.md
+++ b/docs/architecture/storage-accounting.md
@@ -42,6 +42,9 @@ Rather than re-implementing the serializer's rules, the stamp **runs the export'
   previous read or reindex cached under the same key.
 - `lineBytes(item, spec)` — per line: `Buffer.byteLength(spec.row(spec.flatten({ ...item })))`.
   The shallow copy matters: flatten mutates its input, and the item goes on to Elasticsearch as-is.
+  When the schema has no nested key and no separator column, flatten would be the identity
+  (`isFlattenIdentity` in `flatten.ts`, derived from the same statement generator as the compiled
+  flatten), so `spec.flatten` is `null` and the line is serialized directly, copy skipped.
 
 The consequences of "same serializer" are exactly the CSV conventions: strings are always quoted
 (`+2` bytes) with embedded `"` doubled, booleans are `1`/`0`, numbers are `String(v)`, null or

--- a/tests/features/datasets/es/line-bytes.unit.spec.ts
+++ b/tests/features/datasets/es/line-bytes.unit.spec.ts
@@ -1,46 +1,63 @@
 import { test } from '@playwright/test'
 import assert from 'node:assert/strict'
 import { lineBytes, lineBytesSpec } from '../../../../api/src/datasets/es/operations.ts'
+import { getCsvSerializer } from '../../../../api/src/datasets/utils/csv-jit.ts'
+import { getFlattenNoCache } from '../../../../api/src/datasets/utils/flatten.ts'
+
+// `_bytes` is defined as the byte length of the row the default CSV export (`/lines?format=csv`,
+// no select, ',' delimiter) would emit for the line — header and BOM excluded.
 
 const schema = [
-  { key: 'name' },
-  { key: 'nb' },
-  { key: '_i', 'x-calculated': true },
-  { key: '_updatedAt', 'x-calculated': true },
-  { key: '_ext_geo.lat', 'x-extension': 'geo/coords' },
-  { key: '_ext_geo.lon', 'x-extension': 'geo/coords' }
+  { key: 'name', type: 'string' },
+  { key: 'nb', type: 'integer' },
+  { key: 'flag', type: 'boolean' },
+  { key: 'tags', type: 'string', separator: ';' },
+  { key: '_i', type: 'integer', 'x-calculated': true },
+  { key: '_updatedAt', type: 'string', 'x-calculated': true },
+  { key: '_ext_geo.lat', type: 'number', 'x-extension': 'geo/coords' },
+  { key: '_ext_geo.lon', type: 'number', 'x-extension': 'geo/coords' },
+  { key: '_ext_geo.error', type: 'string', 'x-extension': 'geo/coords', 'x-calculated': true }
 ]
+const dataset = { id: 'ds1', finalizedAt: '2026-01-01T00:00:00Z', schema }
 
 test.describe('lineBytes', () => {
-  test('counts non-calculated schema columns', () => {
-    const spec = lineBytesSpec(schema)
-    // counted props: name, nb, _ext_geo.lat, _ext_geo.lon -> nbCols = 4
-    assert.equal(spec.nbCols, 4)
-    // top-level prefixes: name, nb, _ext_geo
-    assert.deepEqual([...spec.prefixes].sort(), ['_ext_geo', 'name', 'nb'])
+  test('equals the byte length of the default CSV export row', () => {
+    const spec = lineBytesSpec(dataset)
+    // string quoted, boolean as 1/0, separator array joined then quoted, nested extension flattened,
+    // calculated columns (_i, _updatedAt, _ext_geo.error) excluded
+    const item = { name: 'a"b', nb: 12, flag: true, tags: ['x', 'y'], _ext_geo: { lat: 1.5, lon: 48, error: 'boom' }, _i: 4, _updatedAt: '2026-01-01' }
+    // "a""b",12,1,"x;y",1.5,48\n
+    assert.equal(lineBytes(item, spec), 25)
+
+    // same figure as what the /lines csv serializer produces for the flattened line
+    const selectKeys = schema.filter(p => !p['x-calculated']).map(p => p.key)
+    const { row } = getCsvSerializer({ dataset, selectKeys, header: false, bom: false })
+    const flatten = getFlattenNoCache(dataset)
+    assert.equal(lineBytes(item, spec), Buffer.byteLength(row(flatten({ ...item }))))
   })
 
-  test('sums stringified value bytes plus one byte per column', () => {
-    const spec = lineBytesSpec(schema)
-    const item = { name: 'abc', nb: 12, _ext_geo: { lat: 1.5, lon: 48 }, _i: 4, _updatedAt: '2026-01-01' }
-    // 'abc'(3) + '12'(2) + '1.5'(3) + '48'(2) + 4 separators = 14
-    assert.equal(lineBytes(item, spec), 14)
+  test('does not mutate the indexed line', () => {
+    const spec = lineBytesSpec(dataset)
+    const item = { name: 'abc', tags: ['x', 'y'], _ext_geo: { lat: 1.5, lon: 48 } }
+    lineBytes(item, spec)
+    assert.deepEqual(item, { name: 'abc', tags: ['x', 'y'], _ext_geo: { lat: 1.5, lon: 48 } })
   })
 
   test('multi-byte UTF-8 strings are measured in bytes', () => {
-    const spec = lineBytesSpec([{ key: 'name' }])
-    // 'é' is 2 bytes in UTF-8 -> 2 + 1 separator = 3
-    assert.equal(lineBytes({ name: 'é' }, spec), 3)
+    const spec = lineBytesSpec({ id: 'ds2', schema: [{ key: 'name', type: 'string' }] })
+    // "é"\n -> 2 quotes + 2 bytes + newline
+    assert.equal(lineBytes({ name: 'é' }, spec), 5)
   })
 
-  test('missing and null values count zero bytes but keep their separator', () => {
-    const spec = lineBytesSpec([{ key: 'a' }, { key: 'b' }, { key: 'c' }])
+  test('missing and null values emit empty cells but keep their delimiters and newline', () => {
+    const spec = lineBytesSpec({ id: 'ds3', schema: [{ key: 'a', type: 'string' }, { key: 'b', type: 'integer' }, { key: 'c', type: 'boolean' }] })
+    // ,,\n
     assert.equal(lineBytes({ a: null, b: undefined }, spec), 3)
   })
 
-  test('booleans stringified, internal non-schema keys ignored', () => {
-    const spec = lineBytesSpec([{ key: 'flag' }])
-    // 'true'(4) + 1 = 5 ; _file_raw and _geopoint must not count
-    assert.equal(lineBytes({ flag: true, _file_raw: 'aaaaaaaaaa', _geopoint: '1,2' }, spec), 5)
+  test('internal non-schema keys are ignored', () => {
+    const spec = lineBytesSpec({ id: 'ds4', schema: [{ key: 'flag', type: 'boolean' }] })
+    // 1\n
+    assert.equal(lineBytes({ flag: true, _file_raw: 'aaaaaaaaaa', _geopoint: '1,2' }, spec), 2)
   })
 })

--- a/tests/features/datasets/es/line-bytes.unit.spec.ts
+++ b/tests/features/datasets/es/line-bytes.unit.spec.ts
@@ -36,6 +36,12 @@ test.describe('lineBytes', () => {
     assert.equal(lineBytes(item, spec), Buffer.byteLength(row(flatten({ ...item }))))
   })
 
+  test('skips the flatten (and the copy it needs) when no column is nested or multi-valued', () => {
+    assert.equal(lineBytesSpec({ id: 'ds5', schema: [{ key: 'name', type: 'string' }, { key: 'nb', type: 'integer' }] }).flatten, null)
+    assert.notEqual(lineBytesSpec({ id: 'ds6', schema: [{ key: 'tags', type: 'string', separator: ';' }] }).flatten, null)
+    assert.notEqual(lineBytesSpec({ id: 'ds7', schema: [{ key: '_ext_geo.lat', type: 'number' }] }).flatten, null)
+  })
+
   test('does not mutate the indexed line', () => {
     const spec = lineBytesSpec(dataset)
     const item = { name: 'abc', tags: ['x', 'y'], _ext_geo: { lat: 1.5, lon: 48 } }

--- a/tests/features/datasets/storage-line-bytes.api.spec.ts
+++ b/tests/features/datasets/storage-line-bytes.api.spec.ts
@@ -6,10 +6,18 @@ import { waitForFinalize } from '../../support/workers.ts'
 
 const ax = await axiosAuth('test_user1@test.com')
 
-// two lines: 'aaa'(3)+'1'(1) and 'bébé'(6)+'22'(2), 2 columns -> +2 each
-// expected indexed size = (3+1+2) + (6+2+2) = 16
+// indexed size = byte length of the default CSV export minus BOM and header:
+// '"aaa",1\n' (8) + '"bébé",22\n' (12) = 20
 const csvContent = 'str1,int1\naaa,1\nbébé,22\n'
-const expectedBytes = 16
+const expectedBytes = 20
+
+// the metric is defined as the size of the CSV export: header off, only the 3-byte BOM remains
+const csvExportBytes = async (id: string) => {
+  const res = await ax.get(`/api/v1/datasets/${id}/lines`, { params: { format: 'csv', header: 'false' }, responseType: 'arraybuffer' })
+  const body = Buffer.from(res.data)
+  assert.equal(body.subarray(0, 3).toString('hex'), 'efbbbf')
+  return body.length - 3
+}
 
 test.describe('storage line-bytes accounting', () => {
   test.beforeEach(async () => { await clean() })
@@ -26,6 +34,7 @@ test.describe('storage line-bytes accounting', () => {
 
     assert.deepEqual(fileDataset.storage.indexed.parts, ['lines'])
     assert.equal(fileDataset.storage.indexed.size, expectedBytes)
+    assert.equal(await csvExportBytes(fileDataset.id), expectedBytes)
 
     // _bytes is internal: it must not leak into line responses
     res = await ax.get(`/api/v1/datasets/${fileDataset.id}/lines`)
@@ -48,6 +57,7 @@ test.describe('storage line-bytes accounting', () => {
 
     assert.deepEqual(restDataset.storage.indexed.parts, ['lines'])
     assert.equal(restDataset.storage.indexed.size, expectedBytes)
+    assert.equal(await csvExportBytes(restId), expectedBytes)
   })
 
   test('REST updates and deletes track the indexed size', async () => {
@@ -62,15 +72,16 @@ test.describe('storage line-bytes accounting', () => {
     res = await ax.post(`/api/v1/datasets/${id}/lines`, { str1: 'aaa' })
     const lineId = res.data._id
     await waitForFinalize(ax, id)
-    // 'aaa'(3) + 1 separator
+    // '"aaa"\n'
     let dataset = (await ax.get(`/api/v1/datasets/${id}`)).data
-    assert.equal(dataset.storage.indexed.size, 4)
+    assert.equal(dataset.storage.indexed.size, 6)
 
     // grow the value by 3 bytes
     await ax.put(`/api/v1/datasets/${id}/lines/${lineId}`, { str1: 'aaaaaa' })
     await waitForFinalize(ax, id)
     dataset = (await ax.get(`/api/v1/datasets/${id}`)).data
-    assert.equal(dataset.storage.indexed.size, 7)
+    assert.equal(dataset.storage.indexed.size, 9)
+    assert.equal(await csvExportBytes(id), 9)
 
     await ax.delete(`/api/v1/datasets/${id}/lines/${lineId}`)
     await waitForFinalize(ax, id)


### PR DESCRIPTION
`_bytes` (summed into `indexed_bytes`) is now the byte length of the row the default CSV export emits for the line, header and BOM excluded, computed with the export's own serializer and flatten helper instead of a hand-rolled approximation. For a whole dataset, `indexed_bytes` equals the CSV download size minus its BOM and header line.

**Why:** after 6.18 the stored indexed size drifted from the size of the CSV download: the old formula ignored string quoting and quote doubling, counted booleans as `true`/`false` instead of `1`/`0`, summed separator arrays without their separators and included the calculated `_ext_x.error` sub-key. Using the serializer itself removes the drift for good.

- `lineBytesSpec(dataset)` compiles the export row serializer (no header, no BOM) and the flatten helper once per index stream, without their `(id, finalizedAt)` memo caches so the stamp follows the schema being indexed.
- `lineBytes` runs them on a shallow copy so the indexed line is untouched.
- `getCsvSerializer` gains a `cache: false` option.
- The API test asserts the stored size against a real `format=csv&header=false` download read as raw bytes, for file and REST datasets and after a REST update.

**Heads-up:** indexed sizes grow by about 2 bytes per non-null text cell, so accounts close to their `indexed_bytes` quota may cross it on their next reindex. REST datasets already on the new metric mix old and new per-line values until their next full reindex. The `IndexStream` now compiles two small functions at construction, including on single-line REST writes.
