### PR TITLE
feat(vocabulary): add the transport stop and route concepts

### DIFF
--- a/api/contract/vocabulary.js
+++ b/api/contract/vocabulary.js
@@ -1033,5 +1033,45 @@ export default [
       fr: 'Plateforme',
       en: 'Platform'
     }
+  },
+  {
+    id: 'transport-stop',
+    title: {
+      fr: 'Arrêt de transport',
+      en: 'Transport stop'
+    },
+    description: {
+      fr: "Identifiant d'un arrêt de transport en commun",
+      en: 'Identifier of a public transport stop'
+    },
+    identifiers: [
+      'http://vocab.gtfs.org/terms#Stop',
+      'https://w3id.org/transmodel/journeys#ScheduledStopPoint'
+    ],
+    type: 'string',
+    tag: {
+      fr: 'Transport',
+      en: 'Transport'
+    }
+  },
+  {
+    id: 'transport-route',
+    title: {
+      fr: 'Ligne de transport',
+      en: 'Transport route'
+    },
+    description: {
+      fr: "Identifiant ou code d'une ligne de transport en commun",
+      en: 'Identifier or code of a public transport line'
+    },
+    identifiers: [
+      'http://vocab.gtfs.org/terms#Route',
+      'https://w3id.org/transmodel/journeys#Line'
+    ],
+    type: 'string',
+    tag: {
+      fr: 'Transport',
+      en: 'Transport'
+    }
   }
 ]


### PR DESCRIPTION
Add two concepts to the standard vocabulary, under a new `Transport` tag: `transport-stop` and `transport-route`.

**Why:** the GTFS processing plugin produces three datasets — arrêts, horaires, tracés — that are only joinable if the stop and the route carry the same concept across them. Until now the plugin asked each organisation to declare private concepts and to paste their URIs into its configuration; these two make it work out of the box.

Identifiers come from Linked GTFS and from the published Transmodel ontology:
- `transport-stop` — `http://vocab.gtfs.org/terms#Stop`, `https://w3id.org/transmodel/journeys#ScheduledStopPoint`
- `transport-route` — `http://vocab.gtfs.org/terms#Route`, `https://w3id.org/transmodel/journeys#Line`

Two details worth recording: the GTFS **classes** are used rather than the lowercase `#stop` / `#route`, which are linking properties (StopTime → Stop, Trip → Route) rather than the things themselves; and the Transmodel namespaces are per-module, `w3id.org/transmodel/terms` does not exist despite being reserved early in the CEN working group.

**Heads-up:** an organisation that had minted a private concept on one of these URIs would now see the standard one take over — `api/src/datasets/utils/data-schema.ts:237` looks the standard vocabulary up before the owner's.
