### PR TITLE
fix(notifications): preserve special chars in event titles and bodies

### DIFF
--- a/api/i18n/messages/en.json
+++ b/api/i18n/messages/en.json
@@ -3,8 +3,8 @@
 		"missingBaseApp": "The base application is unknown or as a restricted access.",
 		"missingApp": "Application configuration not found",
 		"brokenHTML": "HTML structure is broken, expect html, head and body elements",
-		"noAppAtUrl": "The page at URL {{url}} doesn't seem to host an application compatible with this service.",
-		"missingDataset": "The dataset {{id}} is unknown or does not belong to you",
+		"noAppAtUrl": "The page at URL {{{url}}} doesn't seem to host an application compatible with this service.",
+		"missingDataset": "The dataset {{{id}}} is unknown or does not belong to you",
 		"extensionShortIdConflict": "The dataset contains 2 extensions that have a conflict on the prefix of the extended columns.",
 		"badContentType": "This API expects a compatible content-type header, most often application/json",
 		"exceedLimitStorage": "You exceeded your strorage limit.",
@@ -17,25 +17,25 @@
 		"looksLikeSpam": "Message rejected, activity looks like a spam robot.",
 		"requireAnonymousToken": "An anonymous token is required.",
 		"noCrossDomain": "Request from an other domain not supported.",
-		"urlFriendly": "\"{{value}}\" should be more URL friendly, maybe you could use \"{{slug}}\" ?",
+		"urlFriendly": "\"{{{value}}}\" should be more URL friendly, maybe you could use \"{{{slug}}}\" ?",
 		"dupSlug": "This slug is already used"
 	},
 	"appRequire": {
 		"noDataset": "does not use a dataset as source.",
 		"aDataset": "a dataset",
 		"geoData": "geolocalized data (latitude/longitude concepts)",
-		"aConcept": "the concept {{concept}}",
-		"oneOfConcepts": "one of the concepts {{concepts}}",
-		"aType": "the type {{type}}",
-		"oneOfTypes": "one of the types {{types}}",
+		"aConcept": "the concept {{{concept}}}",
+		"oneOfConcepts": "one of the concepts {{{concepts}}}",
+		"aType": "the type {{{type}}}",
+		"oneOfTypes": "one of the types {{{types}}}",
 		"orJoin": " or ",
 		"requires": "requires ",
 		"requiresJoin": " and "
 	},
-	"hasBreakingChanges": "the dataset \"{{title}}\" has breaking changes:",
+	"hasBreakingChanges": "the dataset \"{{{title}}}\" has breaking changes:",
 	"breakingChanges": {
-		"missing": "the column \"{{key}}\" doesn't exist anymore",
-		"type": "the column \"{{key}}\" changed type"
+		"missing": "the column \"{{{key}}}\" doesn't exist anymore",
+		"type": "the column \"{{{key}}}\" changed type"
 	},
 	"sheets": {
 		"data": "Data",
@@ -87,122 +87,122 @@
 	"notifications": {
 		"datasets": {
 			"error": {
-				"title": "Error of dataset {{label}}",
-				"body": "There was an error during processing of the dataset {{label}}: {{detail}}."
+				"title": "Error of dataset {{{label}}}",
+				"body": "There was an error during processing of the dataset {{{label}}}: {{{detail}}}."
 			},
 			"draft-error": {
-				"title": "Error of draft dataset {{label}}",
-				"body": "There was an error during processing of the draft of the dataset {{label}}: {{detail}}."
+				"title": "Error of draft dataset {{{label}}}",
+				"body": "There was an error during processing of the draft of the dataset {{{label}}}: {{{detail}}}."
 			},
 			"validation-error": {
-				"title": "Validation errors on dataset {{label}}",
-				"body": "Dataset {{label}} has {{nbErrors}} row(s) with errors. Download the diagnostic file: {{diagnosticUrl}}"
+				"title": "Validation errors on dataset {{{label}}}",
+				"body": "Dataset {{{label}}} has {{{nbErrors}}} row(s) with errors. Download the diagnostic file: {{{diagnosticUrl}}}"
 			},
 			"draft-validation-error": {
-				"title": "Validation errors on draft {{label}}",
-				"body": "Draft of dataset {{label}} has {{nbErrors}} row(s) with errors. Download the diagnostic file: {{diagnosticUrl}}"
+				"title": "Validation errors on draft {{{label}}}",
+				"body": "Draft of dataset {{{label}}} has {{{nbErrors}}} row(s) with errors. Download the diagnostic file: {{{diagnosticUrl}}}"
 			},
 			"dataset-created": {
-				"title": "New dataset {{label}}",
-				"body": "The new dataset {{label}} was just created."
+				"title": "New dataset {{{label}}}",
+				"body": "The new dataset {{{label}}} was just created."
 			},
 			"draft-dataset-created": {
-				"title": "New draft dataset {{label}}",
-				"body": "The new dataset {{label}} was just created in draft mode."
+				"title": "New draft dataset {{{label}}}",
+				"body": "The new dataset {{{label}}} was just created in draft mode."
 			},
 			"publication-requested": {
 				"title": "Request for publication of a dataset",
-				"body": "A contributor is asking to publish the dataset {{label}} on {{publicationSite}}."
+				"body": "A contributor is asking to publish the dataset {{{label}}} on {{{publicationSite}}}."
 			},
 			"published": {
-				"title": "Publication of {{label}}",
-				"body": "The dataset {{label}} has been published on {{publicationSite}}."
+				"title": "Publication of {{{label}}}",
+				"body": "The dataset {{{label}}} has been published on {{{publicationSite}}}."
 			},
 			"published-topic": {
-				"title": "Publication of {{label}} in {{topic}}",
-				"body": "The dataset {{label}} has been published on {{publicationSite}} in the topic {{topic}}."
+				"title": "Publication of {{{label}}} in {{{topic}}}",
+				"body": "The dataset {{{label}}} has been published on {{{publicationSite}}} in the topic {{{topic}}}."
 			},
 			"draft-data-updated": {
-				"title": "Draft file updated {{label}}",
-				"body": "A new file was loaded on the dataset {{label}} in draft mode."
+				"title": "Draft file updated {{{label}}}",
+				"body": "A new file was loaded on the dataset {{{label}}} in draft mode."
 			},
 			"data-updated": {
-				"title": "File updated {{label}}",
-				"body": "A new file was loaded on the dataset {{label}}."
+				"title": "File updated {{{label}}}",
+				"body": "A new file was loaded on the dataset {{{label}}}."
 			},
 			"structure-updated": {
-				"title": "Structure change of {{label}}",
-				"body": "The structure of the dataset {{label}} was modified."
+				"title": "Structure change of {{{label}}}",
+				"body": "The structure of the dataset {{{label}}} was modified."
 			},
 			"draft-structure-updated": {
-				"title": "Structure change of draft {{label}}",
-				"body": "The structure of the draft of the dataset {{label}} was modified."
+				"title": "Structure change of draft {{{label}}}",
+				"body": "The structure of the draft of the dataset {{{label}}} was modified."
 			},
 			"draft-draft-validated": {
-				"title": "Draft validated {{label}}",
-				"body": "The draft of the dataset {{label}} has been validated ({{cause}})."
+				"title": "Draft validated {{{label}}}",
+				"body": "The draft of the dataset {{{label}}} has been validated ({{{cause}}})."
 			},
 			"breaking-change": {
-				"title": "Breaking change {{label}}",
-				"body": "The dataset {{label}} was modified in a way that might entail breakages : {{breakingChangesDesc}}."
+				"title": "Breaking change {{{label}}}",
+				"body": "The dataset {{{label}}} was modified in a way that might entail breakages : {{{breakingChangesDesc}}}."
 			},
 			"draft-draft-cancelled": {
-				"title": "Draft cancelled {{label}}",
-				"body": "The draft of the dataset {{label}} was cancelled, it is back to its previous validated state."
+				"title": "Draft cancelled {{{label}}}",
+				"body": "The draft of the dataset {{{label}}} was cancelled, it is back to its previous validated state."
 			},
 			"integrity-breach": {
 				"title": "Integrity breach",
-				"body": "Dataset {{label}} was modified outside the legitimate write path (divergence detected by the integrity check on its data file or metadata)."
+				"body": "Dataset {{{label}}} was modified outside the legitimate write path (divergence detected by the integrity check on its data file or metadata)."
 			},
 			"integrity-renewal-failed": {
 				"title": "Integrity lock renewal failed",
-				"body": "The protection lock of dataset {{label}} could not be renewed. If this persists, the integrity guarantee will lapse when the current lock expires."
+				"body": "The protection lock of dataset {{{label}}} could not be renewed. If this persists, the integrity guarantee will lapse when the current lock expires."
 			},
 			"integrity-check-stale": {
 				"title": "Integrity check overdue",
-				"body": "Dataset {{label}} has produced no definitive integrity verdict for too long (pending writes, a stuck pipeline or a store outage). Its protection state is currently unverified."
+				"body": "Dataset {{{label}}} has produced no definitive integrity verdict for too long (pending writes, a stuck pipeline or a store outage). Its protection state is currently unverified."
 			},
 			"integrity-scope-incoherent": {
 				"title": "Integrity protection incoherence",
-				"body": "The integrity store still protects dataset {{label}} but the database says its protection is off (or the dataset is gone) with no signed-off disable. This looks like an out-of-band disarm — review it."
+				"body": "The integrity store still protects dataset {{{label}}} but the database says its protection is off (or the dataset is gone) with no signed-off disable. This looks like an out-of-band disarm — review it."
 			},
 			"integrity-trail-altered": {
 				"title": "Integrity trail altered",
-				"body": "The revision trail of dataset {{label}} shows signs of alteration (shadowed or hidden revisions). The original locked revisions are intact; review the anomalies in the integrity panel."
+				"body": "The revision trail of dataset {{{label}}} shows signs of alteration (shadowed or hidden revisions). The original locked revisions are intact; review the anomalies in the integrity panel."
 			}
 		},
 		"applications": {
 			"error": {
-				"title": "Error of application {{label}}",
-				"body": "There was an error during processing of the application {{label}}: {{detail}}."
+				"title": "Error of application {{{label}}}",
+				"body": "There was an error during processing of the application {{{label}}}: {{{detail}}}."
 			},
 			"application-created": {
-				"title": "New application {{label}}",
-				"body": "The new application {{label}} was just created."
+				"title": "New application {{{label}}}",
+				"body": "The new application {{{label}}} was just created."
 			},
 			"publication-requested": {
 				"title": "Request for publication of an application",
-				"body": "A contributor is asking to publish the application {{label}} on {{publicationSite}}."
+				"body": "A contributor is asking to publish the application {{{label}}} on {{{publicationSite}}}."
 			},
 			"published": {
-				"title": "Publication of {{label}}",
-				"body": "The application {{label}} has been published on {{publicationSite}}."
+				"title": "Publication of {{{label}}}",
+				"body": "The application {{{label}}} has been published on {{{publicationSite}}}."
 			},
 			"published-topic": {
-				"title": "Publication of {{label}} in {{topic}}",
-				"body": "The application {{label}} has been published on {{publicationSite}} in the topic {{topic}}."
+				"title": "Publication of {{{label}}} in {{{topic}}}",
+				"body": "The application {{{label}}} has been published on {{{publicationSite}}} in the topic {{{topic}}}."
 			}
 		}
 	},
 	"mails": {
 		"api-key": {
 			"expiring": {
-				"subject": "Your API key {{title}} is about to expire",
-				"text": "API key {{title}} expires on {{expireAt}}."
+				"subject": "Your API key {{{title}}} is about to expire",
+				"text": "API key {{{title}}} expires on {{{expireAt}}}."
 			},
 			"expired": {
-				"subject": "Your API key {{title}} expires on {{expireAt}}",
-				"text": "API key {{title}} expires on {{expireAt}}."
+				"subject": "Your API key {{{title}}} expires on {{{expireAt}}}",
+				"text": "API key {{{title}}} expires on {{{expireAt}}}."
 			}
 		}
 	}

--- a/api/i18n/messages/en.json
+++ b/api/i18n/messages/en.json
@@ -21,7 +21,7 @@
 		"dupSlug": "This slug is already used"
 	},
 	"appRequire": {
-		"noDataset": "does not use a dataset as source.",
+		"noDataset": "Does not use a dataset as source.",
 		"aDataset": "a dataset",
 		"geoData": "geolocalized data (latitude/longitude concepts)",
 		"aConcept": "the concept {{{concept}}}",
@@ -29,10 +29,10 @@
 		"aType": "the type {{{type}}}",
 		"oneOfTypes": "one of the types {{{types}}}",
 		"orJoin": " or ",
-		"requires": "requires ",
+		"requires": "Requires ",
 		"requiresJoin": " and "
 	},
-	"hasBreakingChanges": "the dataset \"{{{title}}}\" has breaking changes:",
+	"hasBreakingChanges": "The dataset \"{{{title}}}\" has breaking changes:",
 	"breakingChanges": {
 		"missing": "the column \"{{{key}}}\" doesn't exist anymore",
 		"type": "the column \"{{{key}}}\" changed type"

--- a/api/i18n/messages/fr.json
+++ b/api/i18n/messages/fr.json
@@ -3,8 +3,8 @@
 		"missingBaseApp": "Modèle d'application inconnu ou à accès restreint.",
 		"missingApp": "Application configuration not found",
 		"brokenHTML": "La structure HTML est corrompue, les éléments html, head et body sont requis",
-		"noAppAtUrl": "La page à l'adresse {{url}} ne semble pas héberger une application compatible avec ce service.",
-		"missingDataset": "Le jeu de données {{id}} est inconnu ou ne vous appartient pas.",
+		"noAppAtUrl": "La page à l'adresse {{{url}}} ne semble pas héberger une application compatible avec ce service.",
+		"missingDataset": "Le jeu de données {{{id}}} est inconnu ou ne vous appartient pas.",
 		"extensionShortIdConflict": "Le jeu de données contient 2 extensions qui sont en conflit sur le préfixe des colonnes étendus.",
 		"badContentType": "Cette API attend un header content-type compatible, le plus souvent application/json.",
 		"exceedLimitStorage": "Vous avez atteint la limite de votre espace de stockage.",
@@ -17,25 +17,25 @@
 		"looksLikeSpam": "Message refusé, l'activité ressemble à celle d'un robot spammeur.",
 		"requireAnonymousToken": "Un jeton d'action anonyme est requis.",
 		"noCrossDomain": "Appel depuis un domaine extérieur non supporté.",
-		"urlFriendly": "\"{{value}}\" n'est pas assez lisible pour être utilisé dans une URL, peut-être pourriez vous utiliser \"{{slug}}\" ?",
+		"urlFriendly": "\"{{{value}}}\" n'est pas assez lisible pour être utilisé dans une URL, peut-être pourriez vous utiliser \"{{{slug}}}\" ?",
 		"dupSlug": "Ce slug est déjà utilisé"
 	},
 	"appRequire": {
 		"noDataset": "N'utilise pas de jeu de données comme source.",
 		"aDataset": "une source de données",
 		"geoData": "des données géolocalisées (concepts latitude/longitude)",
-		"aConcept": "le concept {{concept}}",
-		"oneOfConcepts": "un des concepts {{concepts}}",
-		"aType": "le type {{type}}",
-		"oneOfTypes": "un des types {{types}}",
+		"aConcept": "le concept {{{concept}}}",
+		"oneOfConcepts": "un des concepts {{{concepts}}}",
+		"aType": "le type {{{type}}}",
+		"oneOfTypes": "un des types {{{types}}}",
 		"orJoin": " ou ",
 		"requires": "Nécessite ",
 		"requiresJoin": " et "
 	},
-	"hasBreakingChanges": "le jeu de données \"{{title}}\" a des ruptures de compatibilité :",
+	"hasBreakingChanges": "le jeu de données \"{{{title}}}\" a des ruptures de compatibilité :",
 	"breakingChanges": {
-		"missing": "la colonne \"{{key}}\" n'existe plus",
-		"type": "la colonne \"{{key}}\" a changé de type"
+		"missing": "la colonne \"{{{key}}}\" n'existe plus",
+		"type": "la colonne \"{{{key}}}\" a changé de type"
 	},
 	"sheets": {
 		"data": "Données",
@@ -89,122 +89,122 @@
 	"notifications": {
 		"datasets": {
 			"error": {
-				"title": "Erreur du jeu de données {{label}}",
-				"body": "Il y a eu une erreur pendant le traitement du jeu de données {{label}} : {{detail}}."
+				"title": "Erreur du jeu de données {{{label}}}",
+				"body": "Il y a eu une erreur pendant le traitement du jeu de données {{{label}}} : {{{detail}}}."
 			},
 			"draft-error": {
-				"title": "Erreur du brouillon du jeu de données {{label}}",
-				"body": "Il y a eu une erreur pendant le traitement du brouillon du jeu de données {{label}} : {{detail}}."
+				"title": "Erreur du brouillon du jeu de données {{{label}}}",
+				"body": "Il y a eu une erreur pendant le traitement du brouillon du jeu de données {{{label}}} : {{{detail}}}."
 			},
 			"validation-error": {
-				"title": "Erreurs de validation sur le jeu de données {{label}}",
-				"body": "Le jeu de données {{label}} a {{nbErrors}} ligne(s) en erreur. Téléchargez le fichier de diagnostic : {{diagnosticUrl}}"
+				"title": "Erreurs de validation sur le jeu de données {{{label}}}",
+				"body": "Le jeu de données {{{label}}} a {{{nbErrors}}} ligne(s) en erreur. Téléchargez le fichier de diagnostic : {{{diagnosticUrl}}}"
 			},
 			"draft-validation-error": {
-				"title": "Erreurs de validation sur le brouillon {{label}}",
-				"body": "Le brouillon du jeu de données {{label}} a {{nbErrors}} ligne(s) en erreur. Téléchargez le fichier de diagnostic : {{diagnosticUrl}}"
+				"title": "Erreurs de validation sur le brouillon {{{label}}}",
+				"body": "Le brouillon du jeu de données {{{label}}} a {{{nbErrors}}} ligne(s) en erreur. Téléchargez le fichier de diagnostic : {{{diagnosticUrl}}}"
 			},
 			"dataset-created": {
-				"title": "Nouveau jeu de données {{label}}",
-				"body": "Le jeu de données {{label}} vient d'être créé."
+				"title": "Nouveau jeu de données {{{label}}}",
+				"body": "Le jeu de données {{{label}}} vient d'être créé."
 			},
 			"draft-dataset-created": {
-				"title": "Nouveau jeu de données brouillon {{label}}",
-				"body": "Le jeu de données {{label}} vient d'être créé en mode brouillon."
+				"title": "Nouveau jeu de données brouillon {{{label}}}",
+				"body": "Le jeu de données {{{label}}} vient d'être créé en mode brouillon."
 			},
 			"publication-requested": {
 				"title": "Demande de publication de jeu de données",
-				"body": "Un contributeur demande de publier le jeu de données {{label}} sur {{publicationSite}}."
+				"body": "Un contributeur demande de publier le jeu de données {{{label}}} sur {{{publicationSite}}}."
 			},
 			"published": {
-				"title": "Publication de {{label}}",
-				"body": "Le jeu de données {{label}} a été publié sur {{publicationSite}}."
+				"title": "Publication de {{{label}}}",
+				"body": "Le jeu de données {{{label}}} a été publié sur {{{publicationSite}}}."
 			},
 			"published-topic": {
-				"title": "Publication de {{label}} dans {{topic}}",
-				"body": "Le jeu de données {{label}} a été publié sur {{publicationSite}} dans la thématique {{topic}}."
+				"title": "Publication de {{{label}}} dans {{{topic}}}",
+				"body": "Le jeu de données {{{label}}} a été publié sur {{{publicationSite}}} dans la thématique {{{topic}}}."
 			},
 			"draft-data-updated": {
-				"title": "Fichier brouillon mis à jour {{label}}",
-				"body": "Un nouveau fichier a été chargé sur le jeu de données {{label}} en mode brouillon."
+				"title": "Fichier brouillon mis à jour {{{label}}}",
+				"body": "Un nouveau fichier a été chargé sur le jeu de données {{{label}}} en mode brouillon."
 			},
 			"data-updated": {
-				"title": "Fichier mis à jour {{label}}",
-				"body": "Un nouveau fichier a été chargé sur le jeu de données {{label}}."
+				"title": "Fichier mis à jour {{{label}}}",
+				"body": "Un nouveau fichier a été chargé sur le jeu de données {{{label}}}."
 			},
 			"structure-updated": {
-				"title": "Changement de structure {{label}}",
-				"body": "La structure du jeu de données {{label}} a été modifiée."
+				"title": "Changement de structure {{{label}}}",
+				"body": "La structure du jeu de données {{{label}}} a été modifiée."
 			},
 			"draft-structure-updated": {
-				"title": "Changement de structure brouillon {{label}}",
-				"body": "La structure du brouillon du jeu de données {{label}} a été modifiée."
+				"title": "Changement de structure brouillon {{{label}}}",
+				"body": "La structure du brouillon du jeu de données {{{label}}} a été modifiée."
 			},
 			"draft-draft-validated": {
-				"title": "Brouillon validé {{label}}",
-				"body": "Le brouillon du jeu de données {{label}} a été validé ({{cause}})."
+				"title": "Brouillon validé {{{label}}}",
+				"body": "Le brouillon du jeu de données {{{label}}} a été validé ({{{cause}}})."
 			},
 			"breaking-change": {
-				"title": "Rupture de compatibilité de {{label}}",
-				"body": "Le jeu de données {{label}} a été modifié d'une manière qui inclue des risques de rupture de compatibilité : {{breakingChangesDesc}}."
+				"title": "Rupture de compatibilité de {{{label}}}",
+				"body": "Le jeu de données {{{label}}} a été modifié d'une manière qui inclue des risques de rupture de compatibilité : {{{breakingChangesDesc}}}."
 			},
 			"draft-draft-cancelled": {
-				"title": "Brouillon annulé {{label}}",
-				"body": "Le brouillon du jeu de données {{label}} a été annulé, il est de retour à son état validé précédent."
+				"title": "Brouillon annulé {{{label}}}",
+				"body": "Le brouillon du jeu de données {{{label}}} a été annulé, il est de retour à son état validé précédent."
 			},
 			"integrity-breach": {
 				"title": "Atteinte à l'intégrité",
-				"body": "Le jeu de données {{label}} a été modifié hors du circuit d'écriture légitime (divergence détectée par la vérification d'intégrité sur son fichier de données ou ses métadonnées)."
+				"body": "Le jeu de données {{{label}}} a été modifié hors du circuit d'écriture légitime (divergence détectée par la vérification d'intégrité sur son fichier de données ou ses métadonnées)."
 			},
 			"integrity-renewal-failed": {
 				"title": "Échec du renouvellement du verrou d'intégrité",
-				"body": "Le verrou de protection du jeu de données {{label}} n'a pas pu être renouvelé. Si le problème persiste, la garantie d'intégrité expirera à l'échéance du verrou actuel."
+				"body": "Le verrou de protection du jeu de données {{{label}}} n'a pas pu être renouvelé. Si le problème persiste, la garantie d'intégrité expirera à l'échéance du verrou actuel."
 			},
 			"integrity-check-stale": {
 				"title": "Vérification d'intégrité en retard",
-				"body": "Le jeu de données {{label}} n'a pas produit de verdict d'intégrité définitif depuis trop longtemps (écritures en attente, pipeline bloqué ou entrepôt indisponible). Son état de protection est actuellement non vérifié."
+				"body": "Le jeu de données {{{label}}} n'a pas produit de verdict d'intégrité définitif depuis trop longtemps (écritures en attente, pipeline bloqué ou entrepôt indisponible). Son état de protection est actuellement non vérifié."
 			},
 			"integrity-scope-incoherent": {
 				"title": "Incohérence de protection d'intégrité",
-				"body": "L'entrepôt d'intégrité protège encore le jeu de données {{label}} mais la base indique que sa protection est désactivée (ou que le jeu de données a disparu) sans désactivation signée. Cela ressemble à un désarmement hors circuit — à vérifier."
+				"body": "L'entrepôt d'intégrité protège encore le jeu de données {{{label}}} mais la base indique que sa protection est désactivée (ou que le jeu de données a disparu) sans désactivation signée. Cela ressemble à un désarmement hors circuit — à vérifier."
 			},
 			"integrity-trail-altered": {
 				"title": "Historique de révisions altéré",
-				"body": "L'historique de révisions du jeu de données {{label}} présente des signes d'altération (révisions masquées ou réécrites). Les révisions verrouillées d'origine sont intactes ; consultez les anomalies dans le panneau d'intégrité."
+				"body": "L'historique de révisions du jeu de données {{{label}}} présente des signes d'altération (révisions masquées ou réécrites). Les révisions verrouillées d'origine sont intactes ; consultez les anomalies dans le panneau d'intégrité."
 			}
 		},
 		"applications": {
 			"error": {
-				"title": "Erreur de l'application {{label}}",
-				"body": "Il y a eu une erreur pendant le traitement de l'application {{label}} : {{detail}}."
+				"title": "Erreur de l'application {{{label}}}",
+				"body": "Il y a eu une erreur pendant le traitement de l'application {{{label}}} : {{{detail}}}."
 			},
 			"application-created": {
-				"title": "Nouvelle application {{label}}",
-				"body": "L'application' {{label}} vient d'être créée."
+				"title": "Nouvelle application {{{label}}}",
+				"body": "L'application' {{{label}}} vient d'être créée."
 			},
 			"publication-requested": {
 				"title": "Demande de publication d'application'",
-				"body": "Un contributeur demande de publier l'application {{label}} sur {{publicationSite}}."
+				"body": "Un contributeur demande de publier l'application {{{label}}} sur {{{publicationSite}}}."
 			},
 			"published": {
-				"title": "Publication de {{label}}",
-				"body": "L'application {{label}} a été publiée sur {{publicationSite}}."
+				"title": "Publication de {{{label}}}",
+				"body": "L'application {{{label}}} a été publiée sur {{{publicationSite}}}."
 			},
 			"published-topic": {
-				"title": "Publication de {{label}} dans {{topic}}",
-				"body": "L'application {{label}} a été publiée sur {{publicationSite}} dans la thématique {{topic}}."
+				"title": "Publication de {{{label}}} dans {{{topic}}}",
+				"body": "L'application {{{label}}} a été publiée sur {{{publicationSite}}} dans la thématique {{{topic}}}."
 			}
 		}
 	},
 	"mails": {
 		"api-key": {
 			"expiring": {
-				"subject": "Votre clé d'API {{title}} expire bientôt",
-				"text": "La clé d'API {{title}} arrive à expiration le {{expireAt}}."
+				"subject": "Votre clé d'API {{{title}}} expire bientôt",
+				"text": "La clé d'API {{{title}}} arrive à expiration le {{{expireAt}}}."
 			},
 			"expired": {
-				"subject": "Votre clé d'API {{title}} arrive à expiration",
-				"text": "La clé d'API {{title}} arrive à expiration le {{expireAt}}."
+				"subject": "Votre clé d'API {{{title}}} arrive à expiration",
+				"text": "La clé d'API {{{title}}} arrive à expiration le {{{expireAt}}}."
 			}
 		}
 	}

--- a/api/i18n/messages/fr.json
+++ b/api/i18n/messages/fr.json
@@ -32,7 +32,7 @@
 		"requires": "Nécessite ",
 		"requiresJoin": " et "
 	},
-	"hasBreakingChanges": "le jeu de données \"{{{title}}}\" a des ruptures de compatibilité :",
+	"hasBreakingChanges": "Le jeu de données \"{{{title}}}\" a des ruptures de compatibilité :",
 	"breakingChanges": {
 		"missing": "la colonne \"{{{key}}}\" n'existe plus",
 		"type": "la colonne \"{{{key}}}\" a changé de type"
@@ -180,10 +180,10 @@
 			},
 			"application-created": {
 				"title": "Nouvelle application {{{label}}}",
-				"body": "L'application' {{{label}}} vient d'être créée."
+				"body": "L'application {{{label}}} vient d'être créée."
 			},
 			"publication-requested": {
-				"title": "Demande de publication d'application'",
+				"title": "Demande de publication d'application",
 				"body": "Un contributeur demande de publier l'application {{{label}}} sur {{{publicationSite}}}."
 			},
 			"published": {

--- a/tests/features/datasets/upload/datasets-drafts-lifecycle.api.spec.ts
+++ b/tests/features/datasets/upload/datasets-drafts-lifecycle.api.spec.ts
@@ -118,13 +118,16 @@ test.describe('datasets in draft mode - lifecycle', () => {
   test('create a draft when updating the data file', async () => {
     const notifCollector = await collectNotifications()
 
-    // Send dataset
+    // Send dataset (use a title with apostrophe and accents to detect HTML-encoding regressions in i18n)
+    const titleWithSpecialChars = "test d'apostrophe + àccéent"
     const datasetFd = fs.readFileSync('./tests/resources/datasets/dataset1.csv')
     const form = new FormData()
     form.append('file', datasetFd, 'dataset1.csv')
+    form.append('title', titleWithSpecialChars)
     const ax = testUser1
     let res = await ax.post('/api/v1/datasets', form, { headers: { 'Content-Length': form.getLengthSync(), ...form.getHeaders() } })
     let dataset = await waitForFinalize(ax, res.data.id)
+    assert.equal(dataset.title, titleWithSpecialChars)
 
     // upload a new file with incompatible schema
     const datasetFd2 = fs.readFileSync('./tests/resources/datasets/dataset2.csv')
@@ -201,6 +204,11 @@ test.describe('datasets in draft mode - lifecycle', () => {
     // the localized "cause" param must be interpolated into the notification body
     assert.ok(notifications[2].body.fr.includes('validation manuelle'), `fr body should mention the cause, got "${notifications[2].body.fr}"`)
     assert.ok(notifications[2].body.en.includes('manual validation'), `en body should mention the cause, got "${notifications[2].body.en}"`)
+    // notification title and body must not be HTML-encoded (apostrophes, accents must be preserved as-is)
+    assert.equal(notifications[0].title.fr, `Nouveau jeu de données ${titleWithSpecialChars}`)
+    assert.equal(notifications[0].title.en, `New dataset ${titleWithSpecialChars}`)
+    assert.ok(notifications[0].body.fr.includes(titleWithSpecialChars), 'notification body should contain the raw title')
+    assert.ok(!JSON.stringify(notifications[0]).includes('&#39;'), 'notification must not contain HTML-encoded apostrophes')
   })
 
   // a compatible schema patch is applied to the index through a partial mapping update instead of


### PR DESCRIPTION
i18n messages interpolated their values with Mustache double braces (`{{label}}`), which HTML-escapes them: a dataset title holding an apostrophe reached the events service as `l&#39;`, and mail subjects — plain text — rendered the entity literally. Every interpolation switches to triple braces (`{{{label}}}`) so values travel raw, and a drafts-lifecycle test now asserts a title with an apostrophe and accents survives untouched in the notification. Also fixes typos and missing capitals in notification and application messages.

**Why:** escaping in the i18n templates is the wrong layer — it pollutes plain-text output and cannot know how the value will be rendered. It belongs where the value is interpolated into HTML, which is the notification mail built by the events service: done in data-fair/events#10.

**Heads-up:** deploy data-fair/events#10 before this one. Until it ships, nothing escapes the notification mail body and anyone able to name a resource can inject HTML into the mail sent to every subscriber of the topic. Deployed in that order the two are safe at every point: while both escape, mail bodies show `l&#39;utilisateur` literally — cosmetic, and it clears as soon as this PR lands.
