### PR TITLE
fix(ui): keep special columns inside their cell in the table view

### DIFF
--- a/ui/src/components/dataset/table/dataset-table-value-multiple.vue
+++ b/ui/src/components/dataset/table/dataset-table-value-multiple.vue
@@ -1,11 +1,12 @@
 <template>
   <v-chip-group
-    :class="dense ? 'py-0' : ''"
+    class="py-0"
     style="max-width:500px;"
   >
     <v-chip
       v-for="(value, i) in extendedValues"
       :key="i"
+      class="my-0"
       :text="value.formatted"
       :base-color="hovered === value ? 'primary' : 'default'"
       :size="dense ? 'small' : undefined"

--- a/ui/src/components/dataset/table/dataset-table-value.vue
+++ b/ui/src/components/dataset/table/dataset-table-value.vue
@@ -18,11 +18,15 @@
     >{{ extendedValue.formatted }}</a>
   </template>
 
-  <div v-else>
-    <!-- color pin is an extra decoration displayed alongside the value -->
-    <div
-      v-if="property['x-refersTo'] === 'https://schema.org/color' && extendedValue.raw"
+  <div
+    v-else
+    :class="{ 'item-value-with-pin': colorPin }"
+  >
+    <!-- color pin is an extra decoration prepended to the value -->
+    <span
+      v-if="colorPin"
       class="item-value-color-pin"
+      :class="{ 'item-value-color-pin-dense': dense }"
       :style="`background-color:${extendedValue.raw}`"
     />
 
@@ -129,6 +133,8 @@ const emit = defineEmits<{
   showDetailDialog: []
 }>()
 
+const colorPin = computed(() => property['x-refersTo'] === 'https://schema.org/color' && !!extendedValue.raw)
+
 const { t } = useI18n()
 const localeDayjs = useLocaleDayjs()
 const viewerZone = Intl.DateTimeFormat().resolvedOptions().timeZone
@@ -148,15 +154,24 @@ const dateTimeTitle = computed(() => {
 </script>
 
 <style>
+.item-value-with-pin {
+  display: flex;
+  align-items: center;
+}
 .item-value-color-pin {
-  width: 24px;
-  height: 24px;
+  flex: none;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
-  display: inline-block;
-  position: absolute;
-  top: 8px;
-  left: 2px;
-  border: 2px solid #ccc;
+  margin-right: 6px;
+  /* ring contrasted with the theme surface, so pale swatches stay visible in light and dark */
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.38);
+  box-sizing: border-box;
+}
+.item-value-color-pin-dense {
+  width: 14px;
+  height: 14px;
+  margin-right: 4px;
 }
 .item-value-date-time {
   text-decoration: underline dotted;

--- a/ui/src/components/dataset/table/dataset-table-value.vue
+++ b/ui/src/components/dataset/table/dataset-table-value.vue
@@ -33,7 +33,7 @@
     <!-- updatedByName / ownerName: show the user/owner avatar followed by their name (not the avatar URL) -->
     <template v-if="(property.key === '_updatedByName' || property.key === '_ownerName') && extendedValue.formatted.startsWith($sdUrl)">
       <v-avatar
-        :size="28"
+        :size="dense ? 24 : 28"
         :image="extendedValue.formatted"
         class="me-2"
       />
@@ -50,7 +50,7 @@
           v-bind="props"
         >
           <v-avatar
-            :size="28"
+            :size="dense ? 24 : 28"
             :image="extendedValue.formatted"
           />
         </span>


### PR DESCRIPTION
Columns with a special rendering in the dataset table view drew themselves partly outside their own cell.
- **Color concept** — the swatch was absolutely positioned over the start of the value, hiding the leading `#` of a hex color and overflowing a dense row. It is now a plain element in the flow, prepended to the value, 20px and 14px in dense mode, its wrapper switching to flex/center only when a swatch is displayed so every other cell keeps its exact current rendering. Its hardcoded `2px solid #ccc` border, the last hardcoded grey of its kind in the UI, becomes `1px solid rgba(var(--v-theme-on-surface), 0.38)`: unchanged to the eye in the light theme, correct in the dark one and with site custom colors.
- **Multi-valued columns** — the chip group's vertical padding and its chips' margins pushed the row past the height the virtual scroller is configured with (`item-height`): 49px instead of 40, and 35 instead of 28 in dense mode. The group is now always `py-0` and its chips `my-0` (`py-0` was applied in dense mode only, and did not suffice).
- **Account columns** — avatars were a hardcoded 28px, the exact height of a dense row; they shrink to 24px in dense mode.

**Why:** the color swatch rendering was unusable, with no spacing between the swatch and its value, and the raw value has to stay readable, `#` included. Checking the neighbouring special columns for the same class of problem turned up the other two.

**Heads-up:** `fix-line-owner-columns-calculated` rewrites the same avatar block in `dataset-table-value.vue`; whichever merges second needs to carry the `dense ? 24 : 28` sizing over. Two things are left alone on purpose: an account with no avatar still renders an empty cell, which that branch already fixes, and a column tagged `http://schema.org/image` prints its raw URL as plain text where `DigitalDocument` and `WebPage` render a link.
