### PR TITLE
fix(settings): purge pending publication requests when deleting a site

### DIFF
--- a/api/src/settings/service.ts
+++ b/api/src/settings/service.ts
@@ -318,10 +318,12 @@ export const deletePublicationSite = async (ctx: SettingsWriteContext, siteType:
   validateSettings(settings)
   await mongo.settings.replaceOne(ownerFilter, settings, { upsert: true })
   const ref = `${siteType}:${siteId}`
-  const publicationSitesFilter = { publicationSites: ref }
+  // a pending publication request points at the site too, it becomes dangling if left behind
+  const publicationSitesFilter = { $or: [{ publicationSites: ref }, { requestedPublicationSites: ref }] }
+  const pullRef = { $pull: { publicationSites: ref, requestedPublicationSites: ref } }
   // stamp BEFORE the $pull: the pull removes the very element this filter matches, so stamping
   // after would match nothing (over-stamping here is harmless, the relay dedupes)
   await stampHistorizeMany(publicationSitesFilter)
-  await mongo.datasets.updateMany(publicationSitesFilter, { $pull: { publicationSites: ref } })
-  await mongo.applications.updateMany({ publicationSites: ref }, { $pull: { publicationSites: ref } })
+  await mongo.datasets.updateMany(publicationSitesFilter, pullRef)
+  await mongo.applications.updateMany(publicationSitesFilter, pullRef)
 }

--- a/tests/features/applications/publication-sites.api.spec.ts
+++ b/tests/features/applications/publication-sites.api.spec.ts
@@ -56,6 +56,30 @@ test.describe('publication sites', () => {
     await ax.patch(`/api/v1/datasets/${dataset.id}`, { publicationSites: ['data-fair-portals:portal1'] })
   })
 
+  test('deleting a publication site pulls its refs, published and requested alike', async () => {
+    const ax = testUser1Org
+
+    const portal = { type: 'data-fair-portals', id: 'portal1', url: 'http://portal.com' }
+    await ax.post('/api/v1/settings/organization/test_org1/publication-sites', portal)
+
+    const dataset = (await ax.post('/api/v1/datasets', { isRest: true, title: 'published dataset', schema: [] })).data
+    await ax.patch(`/api/v1/datasets/${dataset.id}`, { publicationSites: ['data-fair-portals:portal1'] })
+    const requestedDataset = (await ax.post('/api/v1/datasets', { isRest: true, title: 'requested dataset', schema: [] })).data
+    await ax.patch(`/api/v1/datasets/${requestedDataset.id}`, { requestedPublicationSites: ['data-fair-portals:portal1'] })
+
+    const app = (await ax.post('/api/v1/applications', { url: mockAppUrl('monapp1') })).data
+    await ax.patch(`/api/v1/applications/${app.id}`, { publicationSites: ['data-fair-portals:portal1'] })
+    const requestedApp = (await ax.post('/api/v1/applications', { url: mockAppUrl('monapp1') })).data
+    await ax.patch(`/api/v1/applications/${requestedApp.id}`, { requestedPublicationSites: ['data-fair-portals:portal1'] })
+
+    await ax.delete('/api/v1/settings/organization/test_org1/publication-sites/data-fair-portals/portal1')
+
+    assert.deepEqual((await ax.get(`/api/v1/datasets/${dataset.id}`)).data.publicationSites, [])
+    assert.deepEqual((await ax.get(`/api/v1/datasets/${requestedDataset.id}`)).data.requestedPublicationSites, [])
+    assert.deepEqual((await ax.get(`/api/v1/applications/${app.id}`)).data.publicationSites, [])
+    assert.deepEqual((await ax.get(`/api/v1/applications/${requestedApp.id}`)).data.requestedPublicationSites, [])
+  })
+
   test('should publish dataset on a org site and access it from re-exposition of data-fair', async () => {
     const ax = testUser1Org
 


### PR DESCRIPTION
Deleting a publication site pulled its ref from `publicationSites` but left `requestedPublicationSites` untouched, so a dataset or application with a pending publication request kept a dangling ref to a site that no longer exists.
- match both fields in the filter, so resources holding only a request are reached too
- `$pull` the ref from both fields, on datasets and applications alike

**Why:** found while making the portals manager clean up after itself on portal deletion — a deleted portal left pending publication requests pointing at it. The portals manager already handles its own `pages` this way (`portals` and `requestedPortals` in the same `$or`).

**Heads-up:** this is forward-looking only, refs already dangling in base are left as-is.
