### PR TITLE
fix(ui): escape map popup content and upgrade maplibre-gl to 6.8.0

### DIFF
--- a/docs/architecture/map-tiles.md
+++ b/docs/architecture/map-tiles.md
@@ -47,6 +47,33 @@ when legacy map applications have been updated to target `/tileserver`
 directly and their deployed configs re-saved, or when traffic logs show the
 redirect is no longer hit.
 
+## The MapLibre worker (build coupling)
+
+From MapLibre 6 the library no longer inlines its web worker. It resolves the
+worker from its own `import.meta.url`, expecting `maplibre-gl-worker.mjs` as a
+sibling — under a bundler that resolves next to *our* chunk, where the file is
+not, so the URL must be set explicitly. Two pieces make that work, and both are
+load-bearing:
+
+- `ui/src/components/dataset/map/maplibre-worker.ts` calls `setWorkerUrl()` with
+  a `?worker&url` import. The `worker` part (not a plain `?url`) is what makes
+  Vite bundle the worker together with the `maplibre-gl-shared` chunk it
+  imports. Import this module for its side effect wherever a `Map` is
+  constructed — currently `use-map.ts` and `dataset-map-bounds.vue`.
+- `worker: { format: 'es' }` in `ui/vite.config.ts`. Vite's default worker
+  format is iife, which serves MapLibre's ESM worker as a classic script;
+  MapLibre starts it with `new Worker(url, { type: 'module' })`, and the
+  mismatch fails with `Cannot use import statement outside a module`.
+
+The failure mode in both cases is the same and easy to misread: the map canvas
+appears, the base style renders, and **no vector tiles ever load** — tile
+parsing happens in the worker. Check the browser console, not the network tab.
+
+The CSP allows this via `worker-src 'self' blob:` (from
+`@data-fair/lib-express`). The worker URL is same-origin, so the `blob:` part is
+no longer needed by data-fair itself; MapLibre 5 needed it for the inline worker
+blob it used to create, which is also why `config.CSP_NONCE` used to be set.
+
 ## Category coloring & legend (`?category=`)
 
 The map previews (`/dataset/{id}/map` and `/embed/dataset/{id}/map`) accept a

--- a/package-lock.json
+++ b/package-lock.json
@@ -3641,9 +3641,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@mapbox/unitbezier": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
-      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
+      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
@@ -3658,16 +3658,6 @@
         "pbf": "^4.0.2"
       }
     },
-    "node_modules/@mapbox/whoots-js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
-      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@maplibre/geojson-vt": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.1.tgz",
@@ -3679,13 +3669,13 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "24.10.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.10.0.tgz",
-      "integrity": "sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==",
+      "version": "26.4.2",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-26.4.2.tgz",
+      "integrity": "sha512-6J0vZqMZvRAJKtdWJdDGHEh1YJ2ZHG08/GOur8gCArYhO8ZkM//OXqtI2AAEz4jc2G+Wq4MfcePg8qNK5TZ4Kg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.3",
         "@mapbox/unitbezier": "^1.0.0",
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
@@ -3697,13 +3687,6 @@
         "gl-style-migrate": "dist/gl-style-migrate.mjs",
         "gl-style-validate": "dist/gl-style-validate.mjs"
       }
-    },
-    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/@mapbox/unitbezier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-1.0.0.tgz",
-      "integrity": "sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
     },
     "node_modules/@maplibre/mlt": {
       "version": "1.2.1",
@@ -14560,28 +14543,26 @@
       "license": "MIT"
     },
     "node_modules/maplibre-gl": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
-      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-6.8.0.tgz",
+      "integrity": "sha512-+ZkjKTodsVLY0ewQThvXRxXQsclcsSgOm5LlnrBM3G8AloMJKt6Haw8mY4xrOl8T0WMqH6DTYjktZ9zGQXZd4w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/tiny-sdf": "^2.1.0",
-        "@mapbox/unitbezier": "^0.0.1",
-        "@mapbox/vector-tile": "^2.0.4",
-        "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/geojson-vt": "^6.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
-        "@maplibre/mlt": "^1.1.8",
-        "@maplibre/vt-pbf": "^4.3.0",
+        "@mapbox/tiny-sdf": "^2.2.0",
+        "@mapbox/unitbezier": "^1.0.0",
+        "@mapbox/vector-tile": "^3.0.0",
+        "@maplibre/geojson-vt": "^6.1.1",
+        "@maplibre/maplibre-gl-style-spec": "^26.4.1",
+        "@maplibre/mlt": "^1.2.1",
+        "@maplibre/vt-pbf": "^4.3.2",
         "@types/geojson": "^7946.0.16",
-        "earcut": "^3.0.2",
+        "earcut": "^3.2.3",
         "gl-matrix": "^3.4.4",
-        "kdbush": "^4.0.2",
+        "kdbush": "^4.1.0",
         "murmurhash-js": "^1.0.0",
-        "pbf": "^4.0.1",
+        "pbf": "^5.1.2",
         "potpack": "^2.1.0",
         "quickselect": "^3.0.0",
         "tinyqueue": "^3.0.0"
@@ -14592,6 +14573,31 @@
       },
       "funding": {
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
+    "node_modules/maplibre-gl/node_modules/@mapbox/vector-tile": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-3.0.0.tgz",
+      "integrity": "sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^5.0.0"
+      }
+    },
+    "node_modules/maplibre-gl/node_modules/pbf": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
       }
     },
     "node_modules/marked": {
@@ -20826,7 +20832,7 @@
         "eslint-plugin-vue": "^10.8.0",
         "eslint-plugin-vuetify": "^2.7.2",
         "http-link-header": "^1.1.3",
-        "maplibre-gl": "^5.11.0",
+        "maplibre-gl": "^6.8.0",
         "ofetch": "^1.4.1",
         "reconnecting-websocket": "^4.4.0",
         "sass-embedded": "^1.98.0",

--- a/tests/features/datasets/map-popup-content.unit.spec.ts
+++ b/tests/features/datasets/map-popup-content.unit.spec.ts
@@ -1,0 +1,70 @@
+import { test } from '@playwright/test'
+import assert from 'node:assert/strict'
+import { escapeHtml, buildPopupHtml } from '../../../ui/src/components/dataset/map/popup-content.ts'
+
+// Both the labels and the values interpolated into a map popup come from user-controlled
+// dataset content (column titles and cell values), and maplibre's Popup.setHTML does NOT
+// sanitize — its DOM.sanitize is only wired to the AttributionControl. So this module is
+// the only thing standing between a dataset cell and innerHTML.
+
+test.describe('escapeHtml', () => {
+  test('neutralizes the characters that can open a tag or close an attribute', () => {
+    assert.equal(escapeHtml('<img src=x>'), '&lt;img src=x&gt;')
+    assert.equal(escapeHtml('a & b'), 'a &amp; b')
+    assert.equal(escapeHtml('say "hi"'), 'say &quot;hi&quot;')
+    assert.equal(escapeHtml("it's"), 'it&#39;s')
+  })
+
+  test('escapes the ampersand first, so an escape is not double-decoded', () => {
+    // naive ordering would turn this into "&lt;" rendering as a literal "<"
+    assert.equal(escapeHtml('&lt;script&gt;'), '&amp;lt;script&amp;gt;')
+  })
+
+  test('leaves ordinary text untouched', () => {
+    assert.equal(escapeHtml('Nombre d’habitants : 1 234'), 'Nombre d’habitants : 1 234')
+  })
+
+  test('is total — non-string values are coerced, never thrown on', () => {
+    assert.equal(escapeHtml(1234), '1234')
+    assert.equal(escapeHtml(['a', '<b>']), 'a,&lt;b&gt;')
+    assert.equal(escapeHtml(null), 'null')
+  })
+})
+
+// the rendered value of a single-item popup: everything between our own static markup.
+// Asserting on it exactly proves no attacker character survived unescaped, rather than
+// hunting for substrings that are harmless once escaped.
+const valuePart = (html: string) => html.slice(html.indexOf('</strong> ') + '</strong> '.length, html.indexOf('</li>'))
+
+test.describe('buildPopupHtml', () => {
+  test('renders a list item per field', () => {
+    const html = buildPopupHtml([{ label: 'Ville', value: 'Lorient' }, { label: 'Code', value: '56121' }])
+    assert.ok(html.startsWith('<ul style="padding-left: 0;">'))
+    assert.ok(html.includes('<strong>Ville:</strong> Lorient'))
+    assert.ok(html.includes('<strong>Code:</strong> 56121'))
+  })
+
+  // the payload shape the maplibre sanitizer bypass (GHSA-jrc7-96c5-q579) relied on: two
+  // adjacent dangerous attributes. It never mattered here — setHTML does not sanitize at all —
+  // which is exactly why the escaping below has to hold on its own.
+  test('a hostile cell value cannot inject markup', () => {
+    const html = buildPopupHtml([{ label: 'Ville', value: '<img src=x onerror=alert(1) onload=alert(2)>' }])
+    assert.ok(html.includes('&lt;img src=x onerror=alert(1) onload=alert(2)&gt;'))
+    assert.equal(valuePart(html), '&lt;img src=x onerror=alert(1) onload=alert(2)&gt;')
+  })
+
+  test('a hostile column title cannot inject markup', () => {
+    const html = buildPopupHtml([{ label: '</strong><script>alert(1)</script>', value: 'x' }])
+    assert.ok(!html.includes('<script>'))
+    assert.ok(!html.includes('</strong><'))
+  })
+
+  test('a hostile value cannot break out of the inline style attribute', () => {
+    const html = buildPopupHtml([{ label: 'a', value: '" onmouseover="alert(1)' }])
+    assert.equal(valuePart(html), '&quot; onmouseover=&quot;alert(1)')
+  })
+
+  test('an empty field list still produces a well-formed list', () => {
+    assert.equal(buildPopupHtml([]), '<ul style="padding-left: 0;"></ul>')
+  })
+})

--- a/tests/features/embed/dataset-map-popup.e2e.spec.ts
+++ b/tests/features/embed/dataset-map-popup.e2e.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '../../fixtures/login.ts'
+import { axiosAuth, clean } from '../../support/axios.ts'
+import { sendDataset } from '../../support/workers.ts'
+
+// A single geo point whose "nom" cell, and whose column title, both carry markup.
+// maplibre's Popup.setHTML does not sanitize (its DOM.sanitize is only wired to the
+// AttributionControl), so the escaping in popup-content.ts is the only thing between a
+// dataset cell and innerHTML. Note the dev SPA is served by vite with no CSP header, so
+// an injected `onerror` really would run here — which is what makes this a real check.
+const geoBody = {
+  schema: [
+    { key: 'nom', type: 'string', title: '<img src=y onerror="window.__xssTitle = 1">' },
+    { key: 'lat', type: 'number', 'x-refersTo': 'http://schema.org/latitude' },
+    { key: 'lon', type: 'number', 'x-refersTo': 'http://schema.org/longitude' }
+  ]
+}
+
+test.describe('embed dataset map popup', () => {
+  test.beforeEach(async () => {
+    await clean()
+  })
+
+  test('escapes dataset content instead of injecting it as markup', async ({ page, goToWithAuth }) => {
+    const ax = await axiosAuth('test_user1@test.com')
+    const dataset = await sendDataset('datasets/geo-html-injection.csv', ax, undefined, geoBody)
+
+    // the dev stack has no tileserver, so the basemap style 404s and MapLibre never fires
+    // "load" — serve a minimal style (with the configured beforeLayer id) instead
+    await page.route('**/tileserver/styles/**', route => route.fulfill({
+      json: { version: 8, sources: {}, layers: [{ id: 'poi_label', type: 'background', paint: { 'background-color': '#eeeeee' } }] }
+    }))
+
+    const tileRequest = page.waitForRequest(req => req.url().includes('format=pbf'), { timeout: 15000 })
+    await goToWithAuth(`/data-fair/embed/dataset/${dataset.id}/map`, 'test_user1')
+    await tileRequest
+
+    // a single point is centered by fitBounds at maxZoom 15, where the circle radius is
+    // ~10px — so the canvas center is a reliable hit for queryRenderedFeatures. The tile
+    // request resolving does not mean the point is painted yet, so hover until the layer's
+    // mousemove handler turns the cursor into a pointer: that is the map telling us the
+    // feature is now hit-testable, and only then is a click meaningful.
+    const canvas = page.locator('.maplibregl-canvas')
+    await expect(canvas).toBeVisible({ timeout: 10000 })
+    const box = (await canvas.boundingBox())!
+    const [cx, cy] = [box.x + box.width / 2, box.y + box.height / 2]
+    let jitter = 0
+    await expect.poll(async () => {
+      // alternate by a pixel so every poll really dispatches a fresh mousemove
+      jitter = jitter ? 0 : 1
+      await page.mouse.move(cx + jitter, cy)
+      return page.evaluate(() => (document.querySelector('.maplibregl-canvas') as HTMLElement)?.style.cursor)
+    }, { timeout: 15000 }).toBe('pointer')
+    await page.mouse.click(cx, cy)
+
+    const popup = page.locator('.maplibregl-popup-content')
+    await expect(popup).toBeVisible({ timeout: 10000 })
+
+    // the payloads are rendered as visible text, not parsed into elements
+    await expect(popup).toContainText('<img src=x onerror="window.__xss = 1">')
+    await expect(popup).toContainText('<img src=y onerror="window.__xssTitle = 1">')
+    await expect(popup.locator('img')).toHaveCount(0)
+    assertNoHandlerRan(await page.evaluate(() => [(window as any).__xss, (window as any).__xssTitle]))
+  })
+})
+
+const assertNoHandlerRan = ([value, title]: unknown[]) => {
+  expect(value, 'an injected cell value executed').toBeUndefined()
+  expect(title, 'an injected column title executed').toBeUndefined()
+}

--- a/tests/features/ui/permissions.e2e.spec.ts
+++ b/tests/features/ui/permissions.e2e.spec.ts
@@ -176,14 +176,22 @@ test.describe('permissions editor', () => {
       // Enter email
       await page.locator('.v-dialog').getByLabel(/Email/).fill('external@test.com')
 
-      // When Lister is checked, Lecture is checked and disabled with its explanatory subtitle
+      // When Lister is checked, Lecture is checked and disabled with its explanatory subtitle.
+      // Match on the title element rather than the option's accessible name: "Lecture" and
+      // "Lecture informations avancées" are both options, and the name of the former also
+      // absorbs the subtitle when it is shown, so no name pattern picks it out on its own.
       const actionsSelect = page.locator('.v-dialog .v-select').filter({ hasText: /Classes d'actions/ })
       await actionsSelect.click()
-      await expect(page.getByRole('option', { name: /Lecture/ })).toBeDisabled()
-      await expect(page.getByRole('option', { name: /Lecture/ })).toContainText(/Toujours autorisé si la permission de lister est activée/)
+      const lectureOption = page.getByRole('option')
+        .filter({ has: page.locator('.v-list-item-title', { hasText: /^Lecture$/ }) })
+      // Vuetify greys the option out with a class and no aria-disabled, so toBeDisabled() —
+      // which needs the disabled attribute or aria-disabled — would read it as enabled and
+      // its negation would pass vacuously. Assert on the class that actually carries the state.
+      await expect(lectureOption).toHaveClass(/v-list-item--disabled/)
+      await expect(lectureOption).toContainText(/Toujours autorisé si la permission de lister est activée/)
       // Uncheck Lister so Lecture becomes enabled and remains the sole selected class
       await page.getByRole('option', { name: /^Lister$/ }).click()
-      await expect(page.getByRole('option', { name: /^Lecture$/ })).toBeEnabled()
+      await expect(lectureOption).not.toHaveClass(/v-list-item--disabled/)
       await page.keyboard.press('Escape')
 
       // Validate

--- a/tests/resources/datasets/geo-html-injection.csv
+++ b/tests/resources/datasets/geo-html-injection.csv
@@ -1,0 +1,2 @@
+nom,lat,lon
+"<img src=x onerror=""window.__xss = 1"">",48.454903,-2.057803

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-vue": "^10.8.0",
     "eslint-plugin-vuetify": "^2.7.2",
     "http-link-header": "^1.1.3",
-    "maplibre-gl": "^5.11.0",
+    "maplibre-gl": "^6.8.0",
     "ofetch": "^1.4.1",
     "reconnecting-websocket": "^4.4.0",
     "sass-embedded": "^1.98.0",

--- a/ui/src/components/dataset/map/dataset-map-bounds.vue
+++ b/ui/src/components/dataset/map/dataset-map-bounds.vue
@@ -19,14 +19,14 @@ en:
 <script setup lang="ts">
 import 'maplibre-gl/dist/maplibre-gl.css'
 import { type BBox } from 'geojson'
-import maplibregl, { LayerSpecification, LngLatBoundsLike } from 'maplibre-gl'
+// maplibre 6 has no default export
+import * as maplibregl from 'maplibre-gl'
+import { LayerSpecification, LngLatBoundsLike } from 'maplibre-gl'
 import { useTheme } from 'vuetify'
 import bbox from '@turf/bbox'
 import bboxPolygon from '@turf/bbox-polygon'
 import { useMapStyle } from './use-map-style'
-
-// @ts-ignore
-maplibregl.config.CSP_NONCE = $cspNonce
+import './maplibre-worker'
 
 const { height } = defineProps({
   height: { type: Number, required: true }
@@ -57,24 +57,35 @@ const dataLayers: LayerSpecification[] = [{
 }]
 const { style } = useMapStyle()
 
+const { t } = useI18n()
+const { sendUiNotif } = useUiNotif()
+
 watch(datasetBbox, (box) => {
   if (!box) return
-  const map = new maplibregl.Map({
-    container: 'map',
-    style,
-    transformRequest: (url) => {
-      if (url.startsWith($siteUrl)) {
-      // include cookies, for data-fair sessions
-        return { url, credentials: 'include' }
-      } else {
-        return { url }
-      }
-    },
-    // preserveDrawingBuffer: noInteraction, // for capture ? TODO: only apply this if in a capture context ?
-    attributionControl: false,
-  }).addControl(new maplibregl.AttributionControl({
-    compact: false
-  }))
+  // maplibre 6 dropped WebGL1 and THROWS GPUInitializationError from the constructor rather
+  // than emitting an "error" event, so a browser without a WebGL2 context is handled here
+  let map: maplibregl.Map
+  try {
+    map = new maplibregl.Map({
+      container: 'map',
+      style,
+      transformRequest: (url) => {
+        if (url.startsWith($siteUrl)) {
+        // include cookies, for data-fair sessions
+          return { url, credentials: 'include' }
+        } else {
+          return { url }
+        }
+      },
+      // preserveDrawingBuffer: noInteraction, // for capture ? TODO: only apply this if in a capture context ?
+      attributionControl: false,
+    }).addControl(new maplibregl.AttributionControl({
+      compact: false
+    }))
+  } catch (error) {
+    sendUiNotif({ type: 'error', error, msg: t('mapError') })
+    return
+  }
 
   map.fitBounds(box as LngLatBoundsLike, { padding: 30, duration: 0 })
 

--- a/ui/src/components/dataset/map/maplibre-worker.ts
+++ b/ui/src/components/dataset/map/maplibre-worker.ts
@@ -1,0 +1,14 @@
+// maplibre 6 no longer inlines its worker. It derives the worker URL from its own
+// `import.meta.url`, expecting to find `maplibre-gl-worker.mjs` as a sibling — but under a
+// bundler that resolves next to our own chunk, where the file does not exist, so the worker
+// must be pointed at explicitly. Importing this module is a prerequisite for constructing a
+// Map; it is a side effect, so import it for its side effect only, before any Map is created.
+//
+// `?worker&url` rather than a plain `?url` is load-bearing: maplibre's worker entry imports a
+// sibling `maplibre-gl-shared` chunk, and only the `worker` part makes Vite bundle the two
+// together. A plain `?url` emits the entry alone, which fails to resolve its import at runtime
+// — and it fails only in a production build, where the chunk layout differs from dev.
+import { setWorkerUrl } from 'maplibre-gl'
+import workerUrl from 'maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url'
+
+setWorkerUrl(workerUrl)

--- a/ui/src/components/dataset/map/popup-content.ts
+++ b/ui/src/components/dataset/map/popup-content.ts
@@ -1,0 +1,27 @@
+// Pure rendering of the feature popup shown when clicking a geometry on a dataset map.
+//
+// Extracted from use-map.ts so it can be unit tested, because it is a security boundary:
+// maplibre's `Popup.setHTML` does NOT sanitize its input. Its `DOM.sanitize()` helper has a
+// single caller, the AttributionControl — `setHTML` merely does `body.innerHTML = html` and
+// moves the resulting nodes into the live popup container. Labels (column titles) and values
+// (cell contents) are both authored by whoever owns the dataset, so escaping here is the only
+// thing preventing HTML injection into every viewer of a public dataset's map.
+
+/** Escape a value for interpolation into HTML text content or a double-quoted attribute. */
+export const escapeHtml = (value: unknown): string => ('' + value)
+  // the ampersand must be replaced first, otherwise it would re-escape the escapes below
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#39;')
+
+export type PopupItem = { label: string, value: unknown }
+
+/** Build the popup markup for a feature, one list item per displayed field. */
+export const buildPopupHtml = (items: PopupItem[]): string => {
+  const htmlList = items
+    .map(({ label, value }) => `<li style="list-style-type: none;"><strong>${escapeHtml(label)}:</strong> ${escapeHtml(value)}</li>`)
+    .join('\n')
+  return `<ul style="padding-left: 0;">${htmlList}</ul>`
+}

--- a/ui/src/components/dataset/map/use-map.ts
+++ b/ui/src/components/dataset/map/use-map.ts
@@ -1,11 +1,11 @@
-import maplibregl, { Map, ControlPosition, LegacyFilterSpecification, LngLatBoundsLike, type AddLayerObject, type ExpressionSpecification } from 'maplibre-gl'
+// maplibre 6 has no default export
+import * as maplibregl from 'maplibre-gl'
+import { Map, ControlPosition, LegacyFilterSpecification, LngLatBoundsLike, type AddLayerObject, type DataDrivenPropertyValueSpecification, type ExpressionSpecification } from 'maplibre-gl'
 import { useMapStyle } from './use-map-style'
 import debounce from 'debounce'
 import { formatValue } from '../../../composables/dataset/lines'
 import { buildPopupHtml } from './popup-content'
-
-// @ts-ignore
-maplibregl.config.CSP_NONCE = $cspNonce
+import './maplibre-worker'
 
 const fitBoundsOpts = { maxZoom: 15, padding: 40 }
 
@@ -28,25 +28,37 @@ export const useMap = (
 
   let _map: Map
   let styleLoaded = false
+  // maplibre 6 dropped WebGL1 and now THROWS GPUInitializationError from the constructor where
+  // maplibre 5 emitted an "error" event, so a browser that cannot give us a WebGL2 context has
+  // to be caught here instead — and remembered, or every watcher tick would raise the toast again
+  let mapUnavailable = false
   const getMap = () => {
     if (!tileUrl.value || !bbox.value || !mapEl.value) return
     if (_map) return _map
-    const map = _map = new maplibregl.Map({
-      container: mapEl.value,
-      style,
-      transformRequest: (url) => {
-        if (url.startsWith($siteUrl)) {
-        // include cookies, for data-fair sessions
-          return { url, credentials: 'include' }
-        } else {
-          return { url }
-        }
-      },
-      // preserveDrawingBuffer: noInteraction, // for capture ? TODO: only apply this if in a capture context ?
-      attributionControl: false,
-    }).addControl(new maplibregl.AttributionControl({
-      compact: false
-    }))
+    if (mapUnavailable) return
+    let map: Map
+    try {
+      map = _map = new maplibregl.Map({
+        container: mapEl.value,
+        style,
+        transformRequest: (url) => {
+          if (url.startsWith($siteUrl)) {
+          // include cookies, for data-fair sessions
+            return { url, credentials: 'include' }
+          } else {
+            return { url }
+          }
+        },
+        // preserveDrawingBuffer: noInteraction, // for capture ? TODO: only apply this if in a capture context ?
+        attributionControl: false,
+      }).addControl(new maplibregl.AttributionControl({
+        compact: false
+      }))
+    } catch (error) {
+      mapUnavailable = true
+      sendUiNotif({ type: 'error', error, msg: t('mapError') })
+      return
+    }
 
     if (!noInteraction) {
       map.addControl(new maplibregl.NavigationControl({ showCompass: false }), navigationPosition ?? 'top-right')
@@ -197,7 +209,10 @@ export const useMap = (
 
   // the category expression usually arrives after the layers were added
   // (values fetch resolving later than the tile url change) — apply it live
-  const categoryPaint: Array<[string, 'fill-color' | 'line-color' | 'circle-color']> = [
+  // all three are color properties, so a single value type covers them — which matters since
+  // maplibre 6 types setPaintProperty generically on the property name
+  type CategoryPaintProp = 'fill-color' | 'line-color' | 'circle-color'
+  const categoryPaint: Array<[string, CategoryPaintProp]> = [
     ['results_polygon', 'fill-color'],
     ['results_polygon_outline', 'line-color'],
     ['results_line', 'line-color'],
@@ -209,7 +224,7 @@ export const useMap = (
       if (!map || !styleLoaded) return
       for (const [layerId, prop] of categoryPaint) {
         if (map.getLayer(layerId)) {
-          const layer = dataLayers.value.find(l => l.id === layerId) as AddLayerObject & { paint: Record<string, unknown> }
+          const layer = dataLayers.value.find(l => l.id === layerId) as AddLayerObject & { paint: Record<CategoryPaintProp, DataDrivenPropertyValueSpecification<string>> }
           map.setPaintProperty(layerId, prop, layer.paint[prop])
         }
       }

--- a/ui/src/components/dataset/map/use-map.ts
+++ b/ui/src/components/dataset/map/use-map.ts
@@ -2,6 +2,7 @@ import maplibregl, { Map, ControlPosition, LegacyFilterSpecification, LngLatBoun
 import { useMapStyle } from './use-map-style'
 import debounce from 'debounce'
 import { formatValue } from '../../../composables/dataset/lines'
+import { buildPopupHtml } from './popup-content'
 
 // @ts-ignore
 maplibregl.config.CSP_NONCE = $cspNonce
@@ -123,15 +124,16 @@ export const useMap = (
         const item = (await $fetch(`datasets/${id}/lines`, { params })).results[0]
         if (!item) return
 
-        const htmlList = dataset.value.schema
+        // both the column titles and the cell values are user-authored, and setHTML does not
+        // sanitize — buildPopupHtml escapes them (see popup-content.ts)
+        const html = buildPopupHtml(dataset.value.schema
           .filter(field => !field['x-calculated'] && field['x-refersTo'] !== 'https://purl.org/geojson/vocab#geometry')
           .filter(field => !cols.length || cols.includes(field.key))
           .filter(field => item[field.key] !== undefined)
-          .map(field => {
-            return `<li style="list-style-type: none;"><strong>${field.title || field['x-originalName'] || field.key}:</strong> ${formatValue(item[field.key], field, null, localeDayjs)}</li>`
-          })
-          .join('\n')
-        const html = `<ul style="padding-left: 0;">${htmlList}</ul>`
+          .map(field => ({
+            label: field.title || field['x-originalName'] || field.key,
+            value: formatValue(item[field.key], field, null, localeDayjs)
+          })))
 
         // Populate the popup and set its coordinates
         // based on the feature found.

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -14,6 +14,10 @@ import { commonjsDeps } from '@koumoul/vjsf/utils/build.js'
 // https://vitejs.dev/config/
 export default defineConfig({
   base: '/data-fair',
+  // maplibre 6 ships its worker as an ES module and starts it with `new Worker(url, { type: 'module' })`.
+  // Vite's default worker format is iife, which in dev serves that module source as a classic script
+  // ("Cannot use import statement outside a module", and no vector tiles at all).
+  worker: { format: 'es' },
   optimizeDeps: {
     // prevent reloading when auto-discovering deps to optimize, everything must be solved before hand
     noDiscovery: true,


### PR DESCRIPTION
Upgrade `maplibre-gl` from 5.24.0 to 6.8.0, and fix an HTML-injection sink in dataset map popups that the upgrade work uncovered.

**Why:** a critical advisory (GHSA-jrc7-96c5-q579) prompted a look at maplibre 5. The advisory itself turned out not to apply to us — its range covers 6.0–6.4.0 as well, and the vulnerable `DOM.sanitize()` is only reachable from the AttributionControl, which we feed from the operator's own base style. But 5.24.0 is the last 5.x that will ever be published, so the upgrade was a matter of when; and tracing the advisory surfaced a real bug of our own.

**The popup fix:** the dataset map built its popup markup by interpolating cell values and column titles into a template string and handing it to `Popup.setHTML`, which does not sanitize — maplibre's `DOM.sanitize()` has a single caller, the AttributionControl. Anyone able to upload a row or name a column controlled HTML in the popup of every viewer of that dataset's map. Production CSP (`script-src-attr 'none'` plus a nonce-only `script-src`) blocked script execution, so the impact was HTML injection rather than script execution, but the dev SPA sends no CSP at all. Markup building moves to a pure `popup-content.ts` that escapes both label and value; no maplibre version fixes this.

**The migration:**
- v6 has no default export, and `config.CSP_NONCE` is gone with it — those lines were already dead, since maplibre only used the nonce for the inline worker blob it no longer creates.
- v6 no longer inlines its worker. `maplibre-worker.ts` points it at a Vite-emitted worker via `?worker&url`, and `worker: { format: 'es' }` is required in the Vite config — its default iife format serves maplibre's ESM worker as a classic script. Either mistake fails the same misleading way: canvas and base style render, no vector tile ever loads.
- v6 dropped WebGL1 and throws `GPUInitializationError` from the `Map` constructor where v5 emitted an `error` event, so both construction sites now catch it and raise the existing degradation toast.
- `setPaintProperty` is now generic over the property name, so the paint record is typed as colors. No net-new tsc errors.

Also fixes `permissions.e2e.spec.ts`, which has been failing since #555 and blocks the pre-push gate for everyone: its `/Lecture/` locator became ambiguous when that PR added a "Lecture informations avancées" option, and underneath that `toBeDisabled()` could never have passed, since Vuetify greys the option with a class and no `aria-disabled` — which also made the paired `toBeEnabled()` pass vacuously.

**Heads-up:**
- **WebGL1 support is dropped.** Viewers whose browser or hardware cannot provide a WebGL2 context lose dataset maps entirely and now get an error toast. This is the one user-visible regression.
- Any future code constructing a maplibre `Map` must `import './maplibre-worker'` or vector tiles will silently stop loading. Both current call sites do; the invariant is documented in `docs/architecture/map-tiles.md` but not enforced.
- `zoomLevelsToOverscale` now defaults to 4 instead of overscaling every level past a source's maxzoom, which upstream notes changes `queryRenderedFeatures` results. Left at the default: our vector source declares no maxzoom and serves tiles at every zoom, so it never overscales, and the map e2e tests hover and click features to hit-test them.
- Reviewing locally: the dev stack has no tileserver, so the base style 404s and the map is blank with "Erreur pendant le rendu de la carte : Not Found". That is pre-existing, not from this PR.
