### PR TITLE
chore(deps): upgrade vjsf to 4.6.0 and keep app datasets required

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3502,9 +3502,9 @@
       "license": "MIT"
     },
     "node_modules/@json-layout/core": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@json-layout/core/-/core-2.8.2.tgz",
-      "integrity": "sha512-se1UBOEo1u3qnpERhD0J7oEbphlD7PYQ5u+maRw7EkoyOChlStvnSJWS2av76CLsxXxW5nh2VaY2Lats1qHwYg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@json-layout/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-Z9ifOkYVKqyCUO65MEEIgU+LoixwkWY472czDhU1/F+4s8qTPmkg6vL3ot0+5loxreDOOYKnoccmbRubLfPp2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3519,13 +3519,13 @@
         "marked": "^15.0.7"
       },
       "peerDependencies": {
-        "@json-layout/vocabulary": "^2.13.1"
+        "@json-layout/vocabulary": "^2.13.2"
       }
     },
     "node_modules/@json-layout/vocabulary": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@json-layout/vocabulary/-/vocabulary-2.13.1.tgz",
-      "integrity": "sha512-DYEPXu4MmPJkok5wOnezKIGM3tLU2iuyQ+YaiLw6j6RFiY2iBJapOIBVV3+BTiAeH+dTbn95Glf/W12tv9OS0w==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@json-layout/vocabulary/-/vocabulary-2.13.2.tgz",
+      "integrity": "sha512-B2yncuPFWH1B5wJsfectN9oGxSik7VETwbv2I/nraYjvRJMW2KhBQD/fbnHmkgvgc73RfTxIYqiS4VdGsBN5Mg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3547,14 +3547,14 @@
       }
     },
     "node_modules/@koumoul/vjsf": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/@koumoul/vjsf/-/vjsf-4.5.4.tgz",
-      "integrity": "sha512-gj9VtPC6KBoXnaToENL1+8nCQe0RQOG52L1WiHQco/puuoIyDCEpHq2IyLVq8TA/sOHB6EhmOTADjPF6L8qyCQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@koumoul/vjsf/-/vjsf-4.6.0.tgz",
+      "integrity": "sha512-tQzTLBob3TalfkIqmFZkoGtR89qw/FXt/Qa18RDlRdC7RNJ7PSJ98/n7vc46cbKMVP7qZgcSMs1Ceef4/ewyTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@json-layout/core": "~2.8.1",
-        "@json-layout/vocabulary": "~2.13.1",
+        "@json-layout/core": "~2.9.0",
+        "@json-layout/vocabulary": "~2.13.2",
         "@vueuse/core": "^12.5.0",
         "debug": "^4.3.4"
       },
@@ -20807,7 +20807,7 @@
         "@data-fair/lib-vuetify": "^2.4.0",
         "@data-fair/lib-vuetify-agents": "^0.6.0",
         "@intlify/unplugin-vue-i18n": "^11.0.7",
-        "@koumoul/vjsf": "^4.5.3",
+        "@koumoul/vjsf": "^4.6.0",
         "@koumoul/vjsf-markdown": "^0.5.2",
         "@mdi/js": "^7.4.47",
         "@turf/bbox": "^7.2.0",

--- a/tests/features/ui/datasets-list.e2e.spec.ts
+++ b/tests/features/ui/datasets-list.e2e.spec.ts
@@ -361,10 +361,22 @@ test.describe('topics facet display', () => {
     const navRight = page.locator('#navigation-right-local')
     const topicsFacet = navRight.getByRole('combobox', { name: 'Thématiques' })
     await expect(topicsFacet).toBeVisible({ timeout: 5000 })
-    await topicsFacet.click()
-
-    // Select the first topic option
-    await page.getByRole('listbox', { name: 'Thématiques' }).getByRole('option').first().click()
+    // the menu can close on its own about 150ms after opening while the page is still settling
+    // (observed: listbox gone, options detached, combobox still mounted and focused). clicking
+    // straight into the freshly opened menu then races that transient and times out, so open and
+    // select as one retried unit rather than assuming the menu stays up.
+    // retry towards the selected state rather than towards a dispatched click: the facet is
+    // multiple, so a retry that re-clicked an option whose click had already landed would toggle
+    // the selection back off.
+    const topicsListbox = page.getByRole('listbox', { name: 'Thématiques' })
+    await expect(async () => {
+      if (await topicsListbox.count() === 0) await topicsFacet.click()
+      const firstOption = topicsListbox.getByRole('option').first()
+      if (await firstOption.getAttribute('aria-selected') !== 'true') {
+        await firstOption.click({ timeout: 2000 })
+      }
+      await expect(firstOption).toHaveAttribute('aria-selected', 'true', { timeout: 2000 })
+    }).toPass({ timeout: 15000 })
     await page.keyboard.press('Escape')
 
     // Should filter to 1 dataset

--- a/tests/support/axios.ts
+++ b/tests/support/axios.ts
@@ -41,14 +41,15 @@ export const axiosAuth = async (email: string, org?: string, adminMode = false, 
   })
 }
 
-export const waitForWorkerIdle = async (timeoutMs = 5000): Promise<void> => {
+export const waitForWorkerIdle = async (timeoutMs = 5000): Promise<boolean> => {
   const start = Date.now()
   while (Date.now() - start < timeoutMs) {
     const res = await anonymousAx.get(`${apiUrl}/api/v1/test-env/pending-tasks`)
     const allEmpty = Object.values(res.data).every((pending: any) => Object.keys(pending).length === 0)
-    if (allEmpty) return
+    if (allEmpty) return true
     await new Promise(resolve => setTimeout(resolve, 100))
   }
+  return false
 }
 
 export const clean = async () => {
@@ -64,15 +65,17 @@ export const config = {
   defaultRemoteKey: { in: 'header', name: 'x-apiKey', value: 'test_default_key' },
 }
 
-export const checkPendingTasks = async () => {
+export const checkPendingTasks = async (timeoutMs = 30000) => {
   // some test paths legitimately leave a finalize task in-flight (e.g. a successful REST line POST
-  // sets _partialRestStatus: 'indexed' which the shortProcessor picks up asynchronously). Give workers
-  // the same idle grace period clean() uses before asserting — anything still pending after 5s is a leak.
-  await waitForWorkerIdle()
+  // sets _partialRestStatus: 'indexed' which the shortProcessor picks up asynchronously). A task that
+  // is still running is not a leak, so keep polling for the whole window and only report what is
+  // still pending at the end: waiting a flat 5s and then asserting once reported a slow finalize as
+  // a leak, which is where this check was failing intermittently.
+  if (await waitForWorkerIdle(timeoutMs)) return
   const res = await anonymousAx.get(`${apiUrl}/api/v1/test-env/pending-tasks`)
   for (const [worker, pending] of Object.entries(res.data)) {
     if (Object.keys(pending as any).length > 0) {
-      throw new Error(`pending tasks remaining in worker "${worker}": ${JSON.stringify(pending)}`)
+      throw new Error(`pending tasks remaining in worker "${worker}" after ${timeoutMs}ms: ${JSON.stringify(pending)}`)
     }
   }
 }

--- a/tests/support/workers.ts
+++ b/tests/support/workers.ts
@@ -99,11 +99,26 @@ export const waitForDatasetError = async (
   // terminal 'validation-error' (carries hasDiagnosticFile). Non-terminal
   // validation-errors (e.g. breaking-changes detection on a draft) do NOT
   // make the dataset enter the error state, so we ignore them here.
-  await ws.waitFor(
-    `datasets/${datasetId}/journal`,
-    (e: any) => e.type === 'error' || (e.type === 'validation-error' && e.hasDiagnosticFile),
-    timeout
-  )
+  try {
+    await ws.waitFor(
+      `datasets/${datasetId}/journal`,
+      (e: any) => e.type === 'error' || (e.type === 'validation-error' && e.hasDiagnosticFile),
+      timeout
+    )
+  } catch (err: any) {
+    // a bare "Timeout of 15000ms exceeded" says nothing about which half failed: the worker never
+    // errored, or it errored before this wait had subscribed (waitFor only subscribes when called,
+    // and the journal is not replayed). report what the dataset actually did.
+    try {
+      const dataset = (await ax.get(`/api/v1/datasets/${datasetId}`, { params })).data
+      const journal = (await ax.get(`/api/v1/datasets/${datasetId}/journal`, { params })).data
+      const events = Array.isArray(journal) ? journal.slice(0, 5).map((e: any) => e.type) : journal
+      err.message += ` — dataset status "${dataset.status}", last journal events ${JSON.stringify(events)}`
+    } catch (diagErr: any) {
+      err.message += ` — could not read dataset state for diagnostic: ${diagErr.message}`
+    }
+    throw err
+  }
   // The journal event is emitted before the generic worker error handler flips
   // the dataset status to 'error' (especially for 'validation-error', where the
   // worker also sends a notification before throwing). Poll until the status is

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,7 +24,7 @@
     "@data-fair/lib-vuetify": "^2.4.0",
     "@data-fair/lib-vuetify-agents": "^0.6.0",
     "@intlify/unplugin-vue-i18n": "^11.0.7",
-    "@koumoul/vjsf": "^4.5.3",
+    "@koumoul/vjsf": "^4.6.0",
     "@koumoul/vjsf-markdown": "^0.5.2",
     "@mdi/js": "^7.4.47",
     "@turf/bbox": "^7.2.0",

--- a/ui/src/components/application/application-config.vue
+++ b/ui/src/components/application/application-config.vue
@@ -205,29 +205,36 @@ const draftSchema = ref<any>()
 
 const completeSchema = (schema: any) => {
   debug('complete schema for vjsf')
-  let datasetsProp
-  if (schema.definitions && schema.definitions.datasets) {
-    datasetsProp = schema.definitions.datasets
-  } else if (schema.properties && schema.properties.datasets) {
-    datasetsProp = schema.properties && schema.properties.datasets
-  } else if (schema.allOf) {
-    const datasetsAllOf = schema.allOf.find((a: any) => a.properties && a.properties.datasets)
-    if (datasetsAllOf) datasetsProp = datasetsAllOf.properties.datasets
+  // a base app can declare its datasets in a definition, directly in properties, or in an allOf branch,
+  // and a built schema often carries a resolved copy next to the original definition. patch every occurrence:
+  // stopping at the first one found silently misses the copy the form actually renders.
+  const datasetsProps: any[] = []
+  if (schema.definitions && schema.definitions.datasets) datasetsProps.push(schema.definitions.datasets)
+  if (schema.properties && schema.properties.datasets) datasetsProps.push(schema.properties.datasets)
+  if (schema.allOf) {
+    for (const allOfItem of schema.allOf) {
+      if (allOfItem.properties && allOfItem.properties.datasets) datasetsProps.push(allOfItem.properties.datasets)
+    }
   }
-  if (!datasetsProp) {
-    console.error('dit not find a "datasets" property in schema')
-  } else {
+  if (!datasetsProps.length) {
+    console.error('did not find a "datasets" property in schema')
+  }
+
+  const fixFromUrl = (fromUrl: string) => {
+    return fromUrl.replace('owner={context.owner.type}:{context.owner.id}', '{context.datasetFilter}')
+  }
+  for (const datasetsProp of datasetsProps) {
     if (roDataset) {
       datasetsProp.readOnly = true
     }
 
-    const fixFromUrl = (fromUrl: string) => {
-      return fromUrl.replace('owner={context.owner.type}:{context.owner.id}', '{context.datasetFilter}')
-    }
     // manage retro-compatibility of use of "context.owner" to "context.datasetsFilter"
     if (datasetsProp['x-fromUrl']) datasetsProp['x-fromUrl'] = fixFromUrl(datasetsProp['x-fromUrl'])
-    if (datasetsProp.items['x-fromUrl']) datasetsProp.items['x-fromUrl'] = fixFromUrl(datasetsProp.items['x-fromUrl'])
+    if (datasetsProp.items?.['x-fromUrl']) datasetsProp.items['x-fromUrl'] = fixFromUrl(datasetsProp.items['x-fromUrl'])
     if (Array.isArray(datasetsProp.items)) {
+      // json-layout only considers a tuple entry required up to minItems, and base app schemas rarely declare it.
+      // an application always needs its first dataset, so state it explicitly and let the validation enforce it.
+      datasetsProp.minItems = datasetsProp.minItems ?? 1
       for (const item of datasetsProp.items) {
         if (item['x-fromUrl']) item['x-fromUrl'] = fixFromUrl(item['x-fromUrl'])
       }


### PR DESCRIPTION
Upgrade the json-layout stack to vjsf 4.6.0 (`@json-layout/core` 2.9.0, `@json-layout/vocabulary` 2.13.2) and adapt the application config form to it.

core 2.9.0 stopped marking every tuple entry as required and now only does so up to `minItems`, which is what the schema actually says. No base app config schema declares `minItems` on its datasets tuple, so the dataset select lost its required status: it gained a clear button and stopped being announced as required to the WebMCP tools. `completeSchema` now sets `minItems: 1` on that tuple, the honest version of the old behaviour since the validation enforces it too.

`completeSchema` also patches every occurrence of `datasets` instead of stopping at the first one found. A built schema often carries a resolved copy of the datasets definition next to the original, as app-charts does, and the first match is then the orphan copy — the `readOnly` flag and the `context.owner` retro-compatibility rewrite have been silent no-ops there.

Also included, unrelated to the upgrade: two test-stability fixes. `checkPendingTasks` polls for the whole window instead of waiting a flat 5s and asserting once, so a slow-but-legitimate finalize is no longer reported as a leaked task; `waitForDatasetError` appends the dataset status and last journal events to its timeout message; and the topics facet e2e opens and selects as one retried unit, since the menu can close on its own while the page is still settling.

**Heads-up:** an application config with no dataset is now invalid and can no longer be saved. This applies to every base app whose `datasets` is a tuple, including existing saved configs with an empty first slot — worth a check against the base app catalogue for one that legitimately allows zero datasets. The `readOnly` and `context.owner` rewrites also start taking effect where they were previously no-ops, so the read-only dataset flow visibly changes.
