### PR TITLE
fix(ui): never offer a pending partner in the permissions dialog

### DIFF
--- a/tests/features/ui/permissions.e2e.spec.ts
+++ b/tests/features/ui/permissions.e2e.spec.ts
@@ -231,6 +231,39 @@ test.describe('permissions editor', () => {
       }, { timeout: 5000 }).toBeTruthy()
     })
 
+    // Regression guard: simple-directory only fills a partner's `id` once the
+    // partnership is accepted. A pending invitation used to be offered in the
+    // partner select and produced a permission with no id, which the API rejects
+    // with "Error in permissions format" (400). It must not be listed at all.
+    test('a pending partner is not offered in the partner select', async ({ page, goToWithAuth }) => {
+      await page.route('**/simple-directory/api/organizations/test_org1', async (route) => {
+        const response = await route.fetch()
+        const org = await response.json()
+        org.partners = [
+          { name: 'Partenaire En Attente', contactEmail: 'pending@test.com', partnerId: 'pending-partner', createdAt: '2026-01-01T00:00:00.000Z' },
+          ...(org.partners ?? [])
+        ]
+        await route.fulfill({ json: org })
+      })
+
+      await goToPermissions(page, goToWithAuth)
+      await page.getByLabel(/Édition détaillée/i).click()
+      await expect(page.getByRole('button', { name: /Ajouter des permissions/ })).toBeVisible({ timeout: 10000 })
+
+      await page.getByRole('button', { name: /Ajouter des permissions/ }).click()
+      await expect(page.locator('.v-dialog')).toBeVisible({ timeout: 5000 })
+
+      const orgTypeSelect = page.locator('.v-dialog .v-select').nth(1)
+      await orgTypeSelect.click()
+      await page.getByRole('option', { name: /partenaires/ }).click()
+
+      const partnerSelect = page.locator('.v-dialog .v-select').filter({ hasText: /Partenaire/ })
+      await partnerSelect.click()
+      // the accepted partners are listed, the pending one is not
+      await expect(page.getByRole('option', { name: /Test Org 2/ })).toBeVisible({ timeout: 5000 })
+      await expect(page.getByRole('option', { name: /Partenaire En Attente/ })).toHaveCount(0)
+    })
+
     // Regression guard for two bugs in the edit-permission dialog:
     // 1. The detailed-actions select grouped its entries with `{ header }`
     //    (Vuetify 2 syntax); on Vuetify 4 these rendered as "[object Object]".

--- a/ui/src/components/permissions/permission-dialog.vue
+++ b/ui/src/components/permissions/permission-dialog.vue
@@ -52,7 +52,7 @@
           <template v-if="orgSelectType === 'partner'">
             <v-select
               v-model="partners"
-              :items="owner.partners"
+              :items="partnerItems"
               item-title="name"
               item-value="id"
               return-object
@@ -229,7 +229,7 @@ const props = defineProps<{
   modelValue?: Permission
   permissionClasses: Record<string, { id: string, title: string }[]>
   resourceType: 'datasets' | 'applications'
-  owner: { type: string, id: string, name?: string, departments?: { id: string, name: string }[], roles?: string[], partners?: { id: string, name: string }[] }
+  owner: { type: string, id: string, name?: string, departments?: { id: string, name: string }[], roles?: string[], partners?: { id?: string, name: string }[] }
 }>()
 
 const emit = defineEmits<{
@@ -438,6 +438,13 @@ const orgSelectType = computed({
   }
 })
 
+// --- Computed: partner items ---
+// simple-directory only fills a partner's `id` once the partnership is accepted;
+// a pending invitation designates no organization yet, so there is nothing to
+// grant a permission to and it must not be offered.
+const partnerItems = computed(() => (props.owner.partners ?? [])
+  .filter((p): p is { id: string, name: string } => !!p.id))
+
 // --- Computed get/set: member ---
 const member = computed({
   get () {
@@ -468,7 +475,9 @@ const valid = computed(() => {
   if ((!p.operations || !p.operations.length) && (!p.classes || !p.classes.length)) return false
   if (p.type === 'organization') {
     if (orgSelectType.value === 'partner') {
-      if (!partners.value.length) return false
+      // every selected partner must designate an organization, the API rejects
+      // the whole permissions array otherwise
+      if (!partners.value.length || partners.value.some(org => !org.id)) return false
     } else if (!p.id) return false
   }
   if (p.type === 'user' && !(p.id || p.email)) return false


### PR DESCRIPTION
## The bug

Granting read + list to a partner organization returns `400 Error in permissions format`, and the permission is lost.

The payload carries a permission with no `id`:

```json
{"type":"organization","operations":[],"classes":["read","list"],"name":"Partenaire En Attente","roles":[]}
```

which `api/src/misc/utils/permissions.ts` rejects:

```js
if ((!permission.type && permission.id) || (permission.type && !(permission.id || permission.email))) valid = false
```

## Root cause

In simple-directory a partner entry only requires `name`, `contactEmail`, `partnerId` and `createdAt` — **`id` is optional and is filled only once the partnership is accepted**. The partner select listed `owner.partners` unfiltered, so a pending invitation appeared as a normal choice, and `submit()` built `id: org.id` → `undefined`.

There has never been a filter, neither on display nor before the PUT. What existed before #550 was the dialog's validity check `type === 'organization' && !p.id`, which caught the case as a side effect — the Validate button just stayed disabled, with no explanation. #550 (`a913f1bc1`, shipped in 6.18.0) rewrote it as:

```js
if (orgSelectType.value === 'partner') {
  if (!partners.value.length) return false   // only asserts the array is non-empty
} else if (!p.id) return false               // no longer covers the partner case
```

so Validate became clickable and the request started reaching the API.

This is not specific to applications: datasets and applications mount the same `permission-dialog.vue` and the same generic permissions router.

## The fix

1. **Filter on display** — the select only offers accepted partnerships:

```js
const partnerItems = computed(() => (props.owner.partners ?? [])
  .filter((p): p is { id: string, name: string } => !!p.id))
```

The `owner` prop type is corrected too: it declared `partners?: { id: string, ... }[]`, which did not match what simple-directory returns.

2. **Restore the guard** as a safety net — every selected partner must designate an organization.

## Verification

Done in the browser against the dev environment, on a **dataset** (confirming it is not application-specific), with a pending partner injected into the simple-directory response:

- before: pending partner listed, Validate enabled, `PUT /permissions` → **400** `Error in permissions format`
- after: simple-directory returns 3 partners, the select offers only the 2 accepted ones; granting read + list to `test_org2` still saves normally

`npm run lint` passes.

**Draft because the checks below have not run:**

- The e2e suite could not be exercised on this machine: every test in `permissions.e2e.spec.ts` › `detailed mode` times out at login/navigation, **including on a clean tree with these changes stashed** — a local environment problem, not a regression from this PR. The new regression test has therefore never been observed passing and needs a run on a healthy environment.
- `vue-tsc` is killed by the OOM killer here (~1.5 GB free), so the UI type check has not run. The root `tsc` reports only pre-existing errors in unrelated benchmark/test files, none in the files touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CQsapUzNTR4CK7BxRhXWB
